### PR TITLE
Development Mode test

### DIFF
--- a/t/web/development.rb
+++ b/t/web/development.rb
@@ -1,0 +1,29 @@
+ENV['RACK_ENV'] = 'development'
+
+require_relative '../../app'
+require 'minitest/autorun'
+require 'rack/test'
+require 'nokogiri'
+
+include Rack::Test::Methods
+
+def app
+  Sinatra::Application
+end
+
+describe "Viewer" do
+
+  subject { Nokogiri::HTML(last_response.body) }
+
+  describe "magic sinatra routes" do
+
+    before { get '/__sinatra__/500.png' }
+
+    it "should pass __sinatra__ requests through" do
+      last_response.status.must_equal 200
+    end
+  end
+  
+
+end
+


### PR DESCRIPTION
In #55 I made it so that we don’t clobber the magic /__sinatra__/ routes, but couldn't work out how to add a test for that.

After talking about it with @chrismytton, it seems that the best way is to just have a separate development mode test, as the routes are getting created long before the test runs.

Closes #56


<!---
@huboard:{"order":39.5,"milestone_order":63,"custom_state":""}
-->
