### PR TITLE
Use https for everything

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -6,11 +6,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
     <link rel="stylesheet" type="text/css" href="/main.css">
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
-    <link href="http://fonts.googleapis.com/css?family=Roboto:400,900,700,500,300,400italic" rel="stylesheet" type="text/css">
+    <link href="https://fonts.googleapis.com/css?family=Roboto:400,900,700,500,300,400italic" rel="stylesheet" type="text/css">
     <!--[if lt IE 9]>
     <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
-    <script src="http://code.jquery.com/jquery-latest.js"></script>
+    <script src="https://code.jquery.com/jquery-latest.js"></script>
     <script src="/javascript/main.js"></script>
     <title><%= @page_title ||= "EveryPolitician" %></title>
 </head>


### PR DESCRIPTION
Getting jQuery and Google Fonts over http means that they don't work if
we're viewing the site over https (e.g. on heroku). Switch to always
using the https: versions.