### PR TITLE
Fix release.sh to cd into correct directory

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -15,7 +15,7 @@ if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "master" ]]; then
   cd /tmp
   wget -m localhost:4567
   git clone "git@github.com:everypolitician/viewer-static.git"
-  cd everypolitician-data
+  cd viewer-static
   git checkout gh-pages
   cp -R ../localhost:4567/* .
   git add .


### PR DESCRIPTION
We're cloning the viewer-static repository, so we need to cd into that repository as well.