### PR TITLE
Make the Country name in the header a link

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -22,7 +22,7 @@
                 <div class="site-header__logo">
                     <h2>
                       <% if @country %>
-                        <%= @country[:name] %>
+                        <a href="/<%= @country[:url] %>/"><%= @country[:name] %></a>
                       <% else %>
                         EveryPolitician
                       <% end %>

--- a/views/sass/_site-header.scss
+++ b/views/sass/_site-header.scss
@@ -24,7 +24,7 @@
 
     a {
         color: $colour_black;
-        letter-spacing: -4px;
+        letter-spacing: -1px;
 
         &:hover,
         &:active,


### PR DESCRIPTION
Now that we have Country pages, clicking on the country name in the
header of Term pages should go to them. Closes #231 