### PR TITLE
Add the house name to term-table URLs

### DIFF
--- a/lib/popolo_helper.rb
+++ b/lib/popolo_helper.rb
@@ -152,7 +152,8 @@ module Popolo
 
   module Helper
     def term_table_url(t)
-      "/%s/term-table/%s.html" % [ @country[:slug].downcase, t[:csv][/term-(.*?).csv/, 1] ]
+      # TODO include the _correct_ legislature when we handle >1
+      "/%s/%s/term-table/%s.html" % [ @country[:slug].downcase, @country[:legislatures].first[:slug].downcase, t[:csv][/term-(.*?).csv/, 1] ]
     end
   end
 end

--- a/t/web/term_table/australia.rb
+++ b/t/web/term_table/australia.rb
@@ -16,7 +16,7 @@ describe 'Per Country Tests' do
   let(:memtable) { subject.css('.term-membership-table') }
 
   describe 'Australia' do
-    before { get '/australia/term-table/44.html' }
+    before { get '/australia/representatives/term-table/44.html' }
 
     it 'should include a Representative' do
       subject.at_css('#house-representatives tr#mem-EZ5 td:first')

--- a/t/web/term_table/canada.rb
+++ b/t/web/term_table/canada.rb
@@ -16,7 +16,7 @@ describe 'Per Country Tests' do
   let(:memtable) { subject.css('.term-membership-table') }
 
   describe 'Canada' do
-    before { get '/canada/term-table/41.html' }
+    before { get '/canada/commons/term-table/41.html' }
 
     it 'should have three parties with 2 seats' do
       doubles = subject.xpath('//p[contains(.,"2 seats")]/../h3').map(&:text)

--- a/t/web/term_table/finland.rb
+++ b/t/web/term_table/finland.rb
@@ -16,7 +16,7 @@ describe 'Per Country Tests' do
   let(:memtable) { subject.css('.term-membership-table') }
 
   describe 'Finland' do
-    before { get '/finland/term-table/35.html' }
+    before { get '/finland/eduskunta/term-table/35.html' }
 
     it 'should have have its name' do
       subject.css('#term h1').text.must_include 'Eduskunta 35 (2007)'

--- a/t/web/term_table/malaysia.rb
+++ b/t/web/term_table/malaysia.rb
@@ -16,7 +16,7 @@ describe 'Per Country Tests' do
   let(:memtable) { subject.css('.term-membership-table') }
 
   describe 'Malaysia' do
-    before { get '/malaysia/term-table/13.html' }
+    before { get '/malaysia/dewan-rakyat/term-table/13.html' }
 
     it 'should have have its name' do
       subject.css('#term h1').text.must_include '13th Parliament of Malaysia'

--- a/t/web/term_table/nz.rb
+++ b/t/web/term_table/nz.rb
@@ -16,7 +16,7 @@ describe 'Per Country Tests' do
   let(:memtable) { subject.css('.term-membership-table') }
 
   describe 'New Zeland' do
-    before { get '/new-zealand/term-table/51.html' }
+    before { get '/new-zealand/house/term-table/51.html' }
 
     it 'should have minus, rather than underscore, in its url' do
       subject.css('#term h1').text.must_include '51st Parliament'


### PR DESCRIPTION
As part of the move to handling multiple legislatures per country (#291) add the house name into the URL.

For now we still don’t cope properly with more than one house per country, but this gets us closer to that.