### PR TITLE
Fail build on failed deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: ruby
 cache: bundler
 
-script: bundle exec rake test
+script:
+  - bundle exec rake test
+  - scripts/release.sh
 rvm:
 - 2.0.0
 
 notifications:
   slack:
     secure: GVD9d+kwR5hzab5ZnWugbCkp9QSYyheSrABWkD+LmpMcWcx7jijajSn4LLvDi/zHYn1MdOBcPe08hSygmpm7ViUApp0EJcSzE4BLU/5oAs+ANV0Qq6jsssMlyo3v8eRAqHNiLxAiAsz+lc0EZWfQnSW8kHzzbO3NeYq1NRL5CgQ=
-
-after_success:
-- scripts/release.sh

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -13,7 +13,7 @@ if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "master" ]]; then
   bundle exec ruby app.rb &
   while ! nc -z localhost 4567; do sleep 1; done
   cd /tmp
-  wget -m localhost:4567
+  wget -m localhost:4567 || (echo "wget exited with non-zero exit code: $?" >&2 && exit 1)
   git clone "git@github.com:everypolitician/viewer-static.git"
   cd viewer-static
   git checkout gh-pages


### PR DESCRIPTION
We want to know if a release to viewer-static has failed, so we make it part of the build when we merge to master. This means the build will fail if the release script fails to push to viewer-static. I've also added an error message if wget exits with a non-zero code so it doesn't fail silently.