### PR TITLE
Link to the countries.json file on Github

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -31,6 +31,7 @@ set :erb, trim: '-'
 
 get '/' do
   @countries = ALL_COUNTRIES.to_a
+  @cjson = cjson
   erb :front_index
 end
 

--- a/views/front_index.erb
+++ b/views/front_index.erb
@@ -10,7 +10,7 @@
             </li>
           <% end %>
         </ul>
-        <a class="button button--download" style="float:right" href="/countries.json">
+        <a class="button button--download" style="float:right" href="<%= @cjson %>">
           <i class="fa fa-download"></i>
           <span class="large-screen-only">JSON</span>
         </a>


### PR DESCRIPTION
We no longer have our own countries.json file — it’s been replaced by the one stored in the everypolitican-data repo on Github. So link directly to that instead.

This should really be to rawgit.com instead, so people get the correct headers if they want to use it, but that'll happen in https://github.com/everypolitician/viewer-sinatra/issues/197