### PR TITLE
Enable the display of either house

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -24,7 +24,6 @@ before '/:country/*' do |country, _|
   pass if country == '__sinatra__'
 
   @country = ALL_COUNTRIES.find { |c| c[:url] == country } || halt(404)
-  @popolo = Popolo::Data.new(@country)
 end
 
 set :erb, trim: '-'
@@ -45,7 +44,8 @@ get '/:country/' do
 end
 
 get '/:country/:house/term-table/:id.html' do |_, house, id|
-  last_modified Time.at(@popolo.lastmod.to_i)
+  popolo = Popolo::Data.new(@country)
+  last_modified Time.at(popolo.lastmod.to_i)
 
   @terms = @country[:legislative_periods]
   (@next_term, @term, @prev_term) = [nil, @terms, nil]
@@ -59,10 +59,10 @@ get '/:country/:house/term-table/:id.html' do |_, house, id|
 
   @page_title = @term[:name]
   @urls = {
-    csv: @popolo.csv_url(@term),
-    json: @popolo.popolo_url
+    csv: popolo.csv_url(@term),
+    json: popolo.popolo_url
   }
-  @data_source = @popolo.data_source
+  @data_source = popolo.data_source
 
   @csv = CSV.parse(EveryPolitician::GithubFile.new(@urls[:csv]).raw, headers: true, header_converters: :symbol, converters: :all)
   erb :term_table

--- a/app.rb
+++ b/app.rb
@@ -45,7 +45,7 @@ end
 
 get '/:country/:house/term-table/:id.html' do |_, house, id|
   popolo = Popolo::Data.new(@country)
-  last_modified Time.at(popolo.lastmod.to_i)
+  last_modified Time.at(@country[:lastmod].to_i)
 
   @terms = @country[:legislative_periods]
   (@next_term, @term, @prev_term) = [nil, @terms, nil]

--- a/app.rb
+++ b/app.rb
@@ -57,8 +57,6 @@ get '/:country/:house/term-table/:id.html' do |_, house, id|
   # the _correct_ one. Just that this country _has_ one called this
   _house = @country[:legislatures].find { |h| h[:slug].downcase == house } || halt(404)
 
-  # Ugh
-  @term['id'] = @term[:id]
   @page_title = @term[:name]
   @urls = {
     csv: @popolo.csv_url(@term),

--- a/lib/popolo_helper.rb
+++ b/lib/popolo_helper.rb
@@ -50,7 +50,7 @@ module Popolo
     end
 
     def csv_url(term)
-      found = @term_list.find { |t| t[:id].split('/').last == term['id'].split('/').last } or return
+      found = @term_list.find { |t| t[:id].split('/').last == term[:id].split('/').last } or return
       @github_url + found[:csv]
     end
 

--- a/lib/popolo_helper.rb
+++ b/lib/popolo_helper.rb
@@ -5,10 +5,17 @@ module EveryPolitician
 
   class GithubFile
 
-    def initialize(url, cache_dir = '_cached_data')
+    @@GH_PATH = "https://raw.githubusercontent.com/everypolitician/everypolitician-data/%s/%s"
+
+    def initialize(file, sha, cache_dir = '_cached_data')
+      @url = @@GH_PATH % [sha, file]
+
       FileUtils.mkpath cache_dir
-      @cache_file = File.join cache_dir, url.split('/everypolitician-data/').last.tr('/', '-')
-      @url = url
+      @cache_file = File.join cache_dir, sha + "-" + file.tr('/', '-')
+    end
+
+    def url
+      @url
     end
 
     def raw
@@ -24,35 +31,6 @@ module EveryPolitician
 end
 
 module Popolo
-  require 'yajl/json_gem'
-
-  class Data
-    def initialize(c, cache_dir = '_cached_data')
-      FileUtils.mkpath cache_dir
-
-      @github_url = "https://raw.githubusercontent.com/everypolitician/everypolitician-data/#{c[:sha]}/"
-      @popolo_url = @github_url + c[:popolo]
-      @term_list  = c[:legislative_periods]
-    end
-
-    def json
-      @_data ||= JSON.parse( EveryPolitician::GithubFile.new(@popolo_url).raw )
-    end
-
-    def popolo_url
-      @popolo_url
-    end
-
-    def csv_url(term)
-      found = @term_list.find { |t| t[:id].split('/').last == term[:id].split('/').last } or return
-      @github_url + found[:csv]
-    end
-
-    def data_source
-      json.key?('meta') && json['meta']['source']
-    end
-
-  end
 
   module Helper
     def term_table_url(t)

--- a/lib/popolo_helper.rb
+++ b/lib/popolo_helper.rb
@@ -30,8 +30,6 @@ module Popolo
     def initialize(c, cache_dir = '_cached_data')
       FileUtils.mkpath cache_dir
 
-      @lastmod = c[:lastmod]
-
       @github_url = "https://raw.githubusercontent.com/everypolitician/everypolitician-data/#{c[:sha]}/"
       @popolo_url = @github_url + c[:popolo]
       @term_list  = c[:legislative_periods]
@@ -39,10 +37,6 @@ module Popolo
 
     def json
       @_data ||= JSON.parse( EveryPolitician::GithubFile.new(@popolo_url).raw )
-    end
-
-    def lastmod
-      @lastmod 
     end
 
     def popolo_url

--- a/t/web/term_table/australia.rb
+++ b/t/web/term_table/australia.rb
@@ -11,24 +11,19 @@ def app
   Sinatra::Application
 end
 
-describe 'Per Country Tests' do
+describe 'Per Country Tests: Australia' do
   subject { Nokogiri::HTML(last_response.body) }
   let(:memtable) { subject.css('.term-membership-table') }
 
-  describe 'Australia' do
+  describe 'Representatives' do
     before { get '/australia/representatives/term-table/44.html' }
 
     it 'should include a Representative' do
-      subject.at_css('.term-membership-table tr#mem-EZ5 td:first')
-        .text.must_include 'Tony Abbott'
+      subject.css('.term-membership-table').text.must_include 'Tony Abbott'
     end
 
     it 'should not include any Senators' do
-      subject.css('#house-senate').count.must_equal 0
-    end
-
-    it 'should not have a button with the house name' do
-      subject.css('a.button').text.downcase.wont_include 'senate'
+      subject.css('.term-membership-table').text.wont_include 'Alan Eggleston'
     end
 
     it 'should have the correct page title' do
@@ -39,4 +34,25 @@ describe 'Per Country Tests' do
       subject.css('.source-credits').text.must_include 'openaustralia'
     end
   end
+
+  describe 'Senate' do
+    before { get '/australia/senate/term-table/44.html' }
+
+    it 'should include a Senator' do
+      subject.css('.term-membership-table').text.must_include 'Alan Eggleston'
+    end
+
+    it 'should not include any Representatives' do
+      subject.css('.term-membership-table').text.wont_include 'Tony Abbott'
+    end
+
+    it 'should have the correct page title' do
+      subject.css('title').text.must_equal '44th Parliament'
+    end
+
+    it 'should list the correct source' do
+      subject.css('.source-credits').text.must_include 'openaustralia'
+    end
+  end
+
 end

--- a/views/index.erb
+++ b/views/index.erb
@@ -4,7 +4,7 @@
     <p>We currently have information for:</p>
 
     <ul class="grid-list">
-      <% @country[:legislative_periods].each do |t| %>
+      <% @country[:legislatures].first[:legislative_periods].each do |t| %>
         <li>
           <a class="avatar-unit" href="<%= term_table_url(t) %>">
             <span class="avatar"><i class="fa fa-university"></i></span>


### PR DESCRIPTION
(part of #291)

As long as you know the URL, you can now view either house of a bicameral legislature. 

Actually displaying the correct links to these comes as part of a separate change.