### PR TITLE
Add a "No Data Yet" page for a missing country

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -15,13 +15,6 @@ ALL_COUNTRIES = JSON.parse(open(cjson).read, symbolize_names: true ).each do |c|
   c[:url] = c[:slug].downcase
 end
 
-before '/:country/*' do |country, _|
-  # Allow inbuilt sinatra requests through
-  pass if country == '__sinatra__'
-
-  @country = ALL_COUNTRIES.find { |c| c[:url] == country } || halt(404)
-end
-
 set :erb, trim: '-'
 
 get '/' do
@@ -35,11 +28,17 @@ get '/new_index' do
   erb :new_index, :layout => :new_layout
 end
 
-get '/:country/' do
-  erb :index
+get '/:country/' do |country|
+  if @country = ALL_COUNTRIES.find { |c| c[:url] == country } 
+    erb :index
+  else
+    @missing = country
+    erb :country_missing
+  end
 end
 
-get '/:country/:house/term-table/:id.html' do |_, house, id|
+get '/:country/:house/term-table/:id.html' do |country, house, id|
+  @country = ALL_COUNTRIES.find { |c| c[:url] == country } || halt(404)
   @house = @country[:legislatures].find { |h| h[:slug].downcase == house } || halt(404)
 
   last_modified Time.at(@country[:lastmod].to_i)

--- a/t/web/basic.rb
+++ b/t/web/basic.rb
@@ -30,12 +30,30 @@ describe 'Viewer' do
     end
   end
 
-  describe 'unknown country' do
-    before { get '/revalia/' }
+  describe 'unknown house of known country' do
+    before { get '/finland/upper' }
 
-    it 'should have no match for Revalia' do
+    it 'should have no match for Upper House of Finland' do
       last_response.status.must_equal 404
     end
   end
+
+  describe 'unknown country' do
+    before { get '/revalia/' }
+
+    it 'should have go to no-match page for Revalia' do
+      last_response.status.must_equal 200
+      last_response.body.must_include 'Sorry'
+    end
+  end
+
+  describe 'unknown house of unknown country' do
+    before { get '/revalia/upper' }
+
+    it 'should have no match for Upper House of Revalia' do
+      last_response.status.must_equal 404
+    end
+  end
+
 
 end

--- a/views/country_missing.erb
+++ b/views/country_missing.erb
@@ -1,0 +1,6 @@
+<div class="container" id="country_missing">
+  <div class="page-section">
+    <h2>Sorry!</h2>
+    <p>We have no data yet for that country. If you can help us find some, please contact us at <a href="mailto:team@everypolitician.org">team@everypolitician.org</a>.
+  </div>
+</div>


### PR DESCRIPTION
When someone visits the page for a country that we don’t have data for yet, go to a page that explains that, rather than simply 404ing:
![screen shot 2015-07-07 at 10 18 50](https://cloud.githubusercontent.com/assets/57483/8542995/a250da18-2491-11e5-8f81-9fb5624a3c30.png)

This lets the auto-complete search box not need to care whether a country exists or not — it can just send everything through.

https://github.com/everypolitician/everypolitician/issues/107 deals with ensuring that these pages get spidered for the static site.

https://github.com/everypolitician/viewer-sinatra/issues/360 deals with getting better text on that page.