### PR TITLE
Improve new homepage

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -69,6 +69,10 @@ get '/about.html' do
   erb :about
 end
 
+get '/contribute.html' do
+  erb :contribute
+end
+
 get '/*.css' do |filename|
   scss :"sass/#{filename}"
 end

--- a/views/about.erb
+++ b/views/about.erb
@@ -2,7 +2,7 @@
   <div class="page-section">
 
     <h1>About</h1>
-    <p>Help ua build a publicly available, distributed, open list of all the
+    <p>Help us build a publicly available, distributed, open list of all the
     world’s politicians, in a standardised format. </p>
 
     <h2 id="why">Why?</h2>
@@ -18,43 +18,13 @@
     <p>That standardised format is <a href="http://www.popoloproject.com/">Popolo</a>, the
     new data standard for politicians’ details.</p>
 
-    <h2 id="how-do-i-get-involved">How do I get involved?</h2>
+    <h2 id="how-do-i-get-involved">How can I add or correct information?</h2>
 
-    <p>If you‘ve already published Popolo format data for your country’s
-    politicians, let us know, and we’ll add it to the growing <a href="/">list</a>.</p>
-
-    <p>If you can create a CSV file (for example, by exporting it from a
-    spreadsheet) with that information, we have tools that will probably convert 
-    that quite easily — <a href="mailto:team@everypolitician.org"</a>contact us</a> 
-    and let’s see if it we can get it uploaded.</p>
-
-    <p>If you have the information in another format, and would like assistance
-    converting it to Popolo, talk to us, and we’ll see if we can help. </p>
-
-    <h2 id="which-politicians-do-you-care-about">Which politicians do you care about?</h2>
-
-    <p>Initially we’re only collecting information about 
-    <a href="http://en.wikipedia.org/wiki/List_of_legislatures_by_country">country-level Parliaments and Congresses</a>.
-    Eventually we hope that much more than this will be available, but we
-    think that getting every national legislature would be a great first
-    step.</p>
-
-    <h2 id="what-information-about-them-do-you-want">What information about them do you want?</h2>
-
-    <p>Popolo lets you express lots of complex information about your
-    politicians and their history. If you have the time and skills to put
-    lots of that together, then great! The UK data, for example, lists 
-    <a href="https://parliament.popit.mysociety.org/persons/">every Member of Parliament for the last 100 years</a>. </p>
-
-    <p>But for now we’re simply focussed on getting basic information about the
-    current legislators in every country. Even if you can only provide their
-    names, political parties, and areas they represent, that‘s plenty. Part
-    of the beauty of Popolo is that it’s easy to add more complex data at
-    any stage, and we’ll be encouraging people to do just that later.</p>
+    <p>See our handy guide to <a href="/contribute.html">contributing</a>.
 
     <h2 id="what-next">What next?</h2>
 
-    <p>Th data can also be used in bigger projects, such as making it
+    <p>The data can also be used in bigger projects, such as making it
     easy to <a href="http://sayit.poplus.org/">track what those politicians say</a>, or
     <a href="http://www.cargografias.org/">visualise their political careers</a>, or
     for citizens to <a href="http://writeit.poplus.org/">send public messages to them</a>. </p>

--- a/views/contribute.erb
+++ b/views/contribute.erb
@@ -1,0 +1,46 @@
+<div class="container" id="contribute">
+  <div class="page-section">
+
+    <h1>Help Us</h1>
+    <p>We need your help to build and maintain this data.</p>
+
+    <h2 id="error">If you see an error in the data</h2>
+
+    <p>If you see something that’s incorrect, out-of-date, or simply missing, in the data we’re currently displaying on the site, then please
+    let us know.  We’re working on building tools to let you edit the data directly, but in the meantime, simply email us at
+    <a href="mailto:team@everypolitician.org">team@everypolitician.org</a> and we’ll fix it.</p>
+
+    <h2 id="error">If your country is missing</h2>
+
+    <p>If you already have Popolo format data for your country’s
+    politicians, let us know, and we’ll add it to the growing <a href="/">list</a>.</p>
+
+    <p>Or, if you can create a CSV file (for example, by exporting it from a
+    spreadsheet) with that information, we have tools that will probably convert 
+    that quite easily —  and let’s see if it we can get it uploaded.</p>
+
+    <p>If you have the information in another format, and would like assistance
+    converting it to Popolo, talk to us, and we’ll see if we can help. </p>
+
+    <h2 id="which-politicians-do-you-care-about">Which politicians do you care about?</h2>
+
+    <p>Initially we’re only collecting information about 
+    <a href="http://en.wikipedia.org/wiki/List_of_legislatures_by_country">country-level Parliaments and Congresses</a>.
+    Eventually we hope that much more than this will be available, but we
+    think that getting every national legislature would be a great first
+    step.</p>
+
+    <h2 id="what-information-about-them-do-you-want">What information about them do you want?</h2>
+
+    <p>Popolo lets you express lots of complex information about your
+    politicians and their history. If you have the time and skills to put
+    lots of that together, then great! The UK data, for example, lists 
+    <a href="https://parliament.popit.mysociety.org/persons/">every Member of Parliament for the last 100 years</a>. </p>
+
+    <p>But for now we’re simply focussed on getting basic information about the
+    current legislators in every country. Even if you can only provide their
+    names, political parties, and areas they represent, that’s plenty. Part
+    of the beauty of Popolo is that it’s easy to add more complex data at
+    any stage, and we’ll be encouraging people to do just that later.</p>
+  </div>
+</div>

--- a/views/new_index.erb
+++ b/views/new_index.erb
@@ -11,13 +11,13 @@
     <div class="container row">
         <div class="column-two-thirds">
             <h3>What is EveryPolitician?</h3>
-            <p>Blah blah blah. Blah blah blach blah blah. Blah blah blah. Blah blah blah blah. Blah blah blah blah blah blah. Blah blah blah. Blah blah blah blah.</p>
-            <a href="#" class="button button--small">Blah blah blah</a>
+            <p>Data for every national legislature in the world, freely available for you to use.</p>
+            <a href="/about.html" class="button button--small">Read more…</a>
         </div>
         <div class="column-one-third">
-            <h3>Contribute your data</h3>
-            <p>Blah blah blah blah blah blah. Blah blah blah. Blah blah blah.</p>
-            <a href="#" class="button button--small button--secondary">Blah blah</a>
+            <h3>Contribute data</h3>
+            <p>We have a long way to go, and need your help.</p>
+            <a href="/contribute.html" class="button button--small button--secondary">Read more…</a>
         </div>
     </div>
 </div>

--- a/views/new_index.erb
+++ b/views/new_index.erb
@@ -1,6 +1,6 @@
 <div class="hero hero--jazzy text-center homepage-hero">
     <div class="container">
-        <h1>Data for <a href="/"><%= @countries.length %> countries</a><br />(so far)</h1>
+        <h1>Data from <a href="/"><%= @countries.length %> countries</a><br />(so far)</h1>
 
         <% if false %>
           <p><label for="country-selector">Find representatives from your country:</label></p>

--- a/views/new_index.erb
+++ b/views/new_index.erb
@@ -1,7 +1,7 @@
 <div class="hero hero--jazzy text-center homepage-hero">
     <div class="container">
-        <h1><%= @countries.length %> countries of data (so far)</h1>
-        <p><label for="country-selector">Find representatives in your country</label></p>
+        <h1>Data for <%= @countries.length %> countries (so far)</h1>
+        <p><label for="country-selector">Find representatives from your country:</label></p>
         <%= erb :country_selector %>
     </div>
     <div class="homepage-map"></div>

--- a/views/new_index.erb
+++ b/views/new_index.erb
@@ -1,8 +1,11 @@
 <div class="hero hero--jazzy text-center homepage-hero">
     <div class="container">
-        <h1>Data for <%= @countries.length %> countries (so far)</h1>
-        <p><label for="country-selector">Find representatives from your country:</label></p>
-        <%= erb :country_selector %>
+        <h1>Data for <a href="/"><%= @countries.length %> countries</a><br />(so far)</h1>
+
+        <% if false %>
+          <p><label for="country-selector">Find representatives from your country:</label></p>
+          <%= erb :country_selector %>
+        <% end %>
     </div>
     <div class="homepage-map"></div>
 </div>


### PR DESCRIPTION
Split a Contributing page out of the About page, link to both from the new homepage, and hide the new search box until it’s ready to go live.