### PR TITLE
Better "missing country" pages

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -35,9 +35,10 @@ end
 get '/:country/' do |country|
   if @country = ALL_COUNTRIES.find { |c| c[:url] == country }
     erb :index
-  else
-    @missing = country
+  elsif @missing = WORLD[country.to_sym]
     erb :country_missing
+  else 
+    halt(404)
   end
 end
 

--- a/t/web/basic.rb
+++ b/t/web/basic.rb
@@ -38,19 +38,27 @@ describe 'Viewer' do
     end
   end
 
-  describe 'unknown country' do
-    before { get '/revalia/' }
+  describe 'country with no data' do
+    before { get '/marshall-islands/' }
 
-    it 'should have go to no-match page for Revalia' do
+    it 'should have go to no-match page for the Marshall Islands' do
       last_response.status.must_equal 200
       last_response.body.must_include 'Sorry'
     end
   end
 
   describe 'unknown house of unknown country' do
-    before { get '/revalia/upper' }
+    before { get '/marshall-islands/upper' }
 
-    it 'should have no match for Upper House of Revalia' do
+    it 'should have no match for Upper House of the Marshall Islands' do
+      last_response.status.must_equal 404
+    end
+  end
+
+  describe 'completely unknown country' do
+    before { get '/revalia/' }
+
+    it 'should have go to no-match page for Revalia' do
       last_response.status.must_equal 404
     end
   end

--- a/t/web/basic.rb
+++ b/t/web/basic.rb
@@ -44,6 +44,7 @@ describe 'Viewer' do
     it 'should have go to no-match page for the Marshall Islands' do
       last_response.status.must_equal 200
       last_response.body.must_include 'Sorry'
+      last_response.body.must_include 'Marshall Islands'
     end
   end
 

--- a/views/country_missing.erb
+++ b/views/country_missing.erb
@@ -1,6 +1,6 @@
 <div class="container" id="country_missing">
   <div class="page-section">
     <h2>Sorry!</h2>
-    <p>We have no data yet for that country. If you can help us find some, please contact us at <a href="mailto:team@everypolitician.org">team@everypolitician.org</a>.
+    <p>We have no data yet for <%= @missing[:displayName] %>. If you can help us find some, please contact us at <a href="mailto:team@everypolitician.org">team@everypolitician.org</a>.
   </div>
 </div>


### PR DESCRIPTION
Only go to the “no data for that country” page if it’s a country that’s actually in `world.json`.

And, because it’s in that list, we can now also show a name for it on the page.