### PR TITLE
Only show current or final memberships in the Seat Count

### DIFF
--- a/t/web/term_table/seat_count.rb
+++ b/t/web/term_table/seat_count.rb
@@ -31,4 +31,13 @@ describe 'Seat Count' do
       seatcount.css('span.seatcount').map(&:text).map(&:to_i).reduce(&:+).must_equal 101
     end
   end
+
+  describe 'Historic Finland' do
+    before { get '/finland/eduskunta/term-table/35.html' }
+
+    it 'should have 200 seats' do
+      seatcount.css('span.seatcount').map(&:text).map(&:to_i).reduce(&:+).must_equal 200
+    end
+  end
+
 end

--- a/t/web/term_table/seat_count.rb
+++ b/t/web/term_table/seat_count.rb
@@ -1,0 +1,34 @@
+ENV['RACK_ENV'] = 'test'
+
+require_relative '../../../app'
+require 'minitest/autorun'
+require 'rack/test'
+require 'nokogiri'
+
+include Rack::Test::Methods
+
+def app
+  Sinatra::Application
+end
+
+describe 'Seat Count' do
+  subject { Nokogiri::HTML(last_response.body) }
+  let(:seatcount) { subject.css('#seat-count') }
+
+  describe 'Estonia' do
+    before { get '/estonia/riigikogu/term-table/13.html' }
+
+    it 'should have have a seat count table' do
+      seatcount.text.must_include 'Party Groupings'
+    end
+
+    it 'should have some seats for IRL' do
+      irl = seatcount.css('li#party-IRL')
+      irl.text.must_include 'Isamaa ja Res Publica Liidu'
+    end
+
+    it 'should have 101 seats' do
+      seatcount.css('span.seatcount').map(&:text).map(&:to_i).reduce(&:+).must_equal 101
+    end
+  end
+end

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -46,7 +46,7 @@
         <div class="container">
             <h2 class="text-center">Party Groupings</h2>
             <ul class="grid-list">
-              <% @csv.group_by { |r| r[:group] }.sort_by { |p, ms| [-ms.count, p] }.each do |party, mems| %>
+              <% @csv.find_all { |r| r[:end_date].to_s.empty? || r[:end_date] == @term[:end_date] }.group_by { |r| r[:group] }.sort_by { |p, ms| [-ms.count, p] }.each do |party, mems| %>
                 <li><div class="avatar-unit">
                     <span class="avatar"><i class="fa fa-users"></i></span>
                     <h3><%= party.to_s.empty? ? 'Independent' : party %></h3>

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -47,10 +47,10 @@
             <h2 class="text-center">Party Groupings</h2>
             <ul class="grid-list">
               <% @csv.find_all { |r| r[:end_date].to_s.empty? || r[:end_date] == @term[:end_date] }.group_by { |r| r[:group] }.sort_by { |p, ms| [-ms.count, p] }.each do |party, mems| %>
-                <li><div class="avatar-unit">
+                <li id="party-<%= mems.first[:group_id] %>"><div class="avatar-unit">
                     <span class="avatar"><i class="fa fa-users"></i></span>
                     <h3><%= party.to_s.empty? ? 'Independent' : party %></h3>
-                    <p><%= mems.count %> seat<% if mems.count > 1 %>s<% end %></p>
+                    <p><span class="seatcount"><%= mems.count %></span> seat<% if mems.count > 1 %>s<% end %></p>
                 </div></li>
               <% end %>
             </ul>

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -42,7 +42,7 @@
     </div>
 <% end %>
 
-    <div class="page-section page-section--grey">
+    <div class="page-section page-section--grey" id="seat-count">
         <div class="container">
             <h2 class="text-center">Party Groupings</h2>
             <ul class="grid-list">


### PR DESCRIPTION
The seat count table currently sums all Memberships held by that Party over the term, which is very misleading if people change parties a lot, of where Members get replaced (e.g. if they join the government)

![seat count old](https://cloud.githubusercontent.com/assets/57483/8654523/b12b2fac-2982-11e5-994e-b39519c6bc89.png)

Instead, only sum memberships which are/were unfinished.

![seat count new](https://cloud.githubusercontent.com/assets/57483/8654522/af30fb6e-2982-11e5-82f0-af831eb3ff8c.png)

Closes #393 