### PR TITLE
Only show relevant parts of membership dates

### DIFF
--- a/t/web/term_table/ni.rb
+++ b/t/web/term_table/ni.rb
@@ -1,0 +1,36 @@
+ENV['RACK_ENV'] = 'test'
+
+require_relative '../../../app'
+require 'minitest/autorun'
+require 'rack/test'
+require 'nokogiri'
+
+include Rack::Test::Methods
+
+def app
+  Sinatra::Application
+end
+
+describe 'Northern Ireland' do
+  subject { Nokogiri::HTML(last_response.body) }
+  let(:memtable) { subject.css('.term-membership-table') }
+
+  describe 'membership dates' do
+    before { get '/northern-ireland/assembly/term-table/3.html' }
+
+    it 'should have no dates for Adrian McQuillan' do
+      subject.css('tr#mem-13912 td').last.text.must_be :empty?
+    end
+
+    it 'should have a start date for Alastair Ross' do
+      subject.css('tr#mem-13927 td').last.text.must_include '2007-05-14'
+      subject.css('tr#mem-13927 td').last.text.wont_include '2011-03-24'
+    end
+
+    it 'should have an end date for David Simpson' do
+      subject.css('tr#mem-11892 td').last.text.wont_include '2007-03-09'
+      subject.css('tr#mem-11892 td').last.text.must_include '2010-07-01'
+    end
+
+  end
+end

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -98,7 +98,9 @@
                         <td><%= m[:group].to_s.empty? ? 'Independent' : m[:group] %></td>
                         <td><%= m[:area] %></td>
                       <% if show_dates %>
-                        <td><% unless m[:start_date].to_s.empty? and m[:end_date].to_s.empty? %><%= m[:start_date] %>–<%= m[:end_date] %><% end %></td>
+                        <% start_date = (m[:start_date].to_s.empty? or m[:start_date].to_s == @term[:start_date].to_s) ? '' : m[:start_date] %>
+                        <% end_date   = (m[:end_date].to_s.empty? or m[:end_date].to_s == @term[:end_date].to_s) ? '' : m[:end_date] %>
+                        <td><%= start_date %><% unless start_date.empty? and end_date.empty? %>-<% end %><%= end_date %></td>
                       <% end %>
                     </tr>
                   <% end %>


### PR DESCRIPTION
In the term table, don’t show the start date if if’s the same as that of the term, or the end date if it’s the same as the end.

Closes #400