### PR TITLE
Fix failing terms

### DIFF
--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -98,8 +98,8 @@
                         <td><%= m[:group].to_s.empty? ? 'Independent' : m[:group] %></td>
                         <td><%= m[:area] %></td>
                       <% if show_dates %>
-                        <% start_date = (m[:start_date].to_s.empty? or m[:start_date].to_s == @term[:start_date].to_s) ? '' : m[:start_date] %>
-                        <% end_date   = (m[:end_date].to_s.empty? or m[:end_date].to_s == @term[:end_date].to_s) ? '' : m[:end_date] %>
+                        <% start_date = (m[:start_date].to_s.empty? or m[:start_date].to_s == @term[:start_date].to_s) ? '' : m[:start_date].to_s %>
+                        <% end_date   = (m[:end_date].to_s.empty? or m[:end_date].to_s == @term[:end_date].to_s) ? '' : m[:end_date].to_s %>
                         <td><%= start_date %><% unless start_date.empty? and end_date.empty? %>-<% end %><%= end_date %></td>
                       <% end %>
                     </tr>


### PR DESCRIPTION
Some term pages were blowing up because we were checking if the end_date was `empty?`, without making sure it was a string first. 

This is because the CSV library ‘smartly’ converts short dates like ‘2004’ to integers, leaving long dates like ‘2004-01-01’ as strings. We should probably change that behaviour, but for now it’s simplest (and generally safer) to simply cast everything to a string before performing tests.

Closes #405