### PR TITLE
Make the "Load every country" test work again.

### DIFF
--- a/t/web/term_table/all_countries.rb
+++ b/t/web/term_table/all_countries.rb
@@ -14,10 +14,12 @@ end
 describe 'Basic loads' do
   it 'should be able to load every country' do
     # Get the list of countries on the homepage
-    get '/'
+    get '/countries.html'
     countries = Nokogiri::HTML(last_response.body)
                 .css('#home ul.grid-list li a/@href')
                 .map(&:text)
+
+    countries.wont_be :empty?
 
     # Then get the front page for each
     countries.each do |country|
@@ -28,8 +30,7 @@ describe 'Basic loads' do
       terms = noko.css('a[href*="/term-table/"]/@href').map(&:text)
       terms.size.wont_be :zero?
 
-      # Then get the first term for each
-      # puts "GET #{terms.first}"
+      # Then make sure each term for each loads
       get terms.first
       last_response.status.must_equal 200
       noko = Nokogiri::HTML(last_response.body)


### PR DESCRIPTION
When we put the new homepage live (#385), the test that loads every country linked from it stopped doing anything, as none are now linked! Make that test fail if it can’t find any countries, but also now load from the correct place.

closes #408