### PR TITLE
Serve JSON and CSV from rawgit instead of githubusercontent

### DIFF
--- a/lib/popolo_helper.rb
+++ b/lib/popolo_helper.rb
@@ -5,7 +5,7 @@ module EveryPolitician
 
   class GithubFile
 
-    @@GH_PATH = "https://raw.githubusercontent.com/everypolitician/everypolitician-data/%s/%s"
+    @@GH_PATH = "https://cdn.rawgit.com/everypolitician/everypolitician-data/%s/%s"
 
     def initialize(file, sha, cache_dir = '_cached_data')
       @url = @@GH_PATH % [sha, file]


### PR DESCRIPTION
This gives them the correct content headers, etc. Fixes #197. Fixes #474