### PR TITLE
Improve vertical spacing on short but wide screens

### DIFF
--- a/views/sass/_components.scss
+++ b/views/sass/_components.scss
@@ -179,8 +179,13 @@ p.lead {
 
 .page-section {
     padding: 2em 0;
-    @media ( min-width: $medium_screen) {
-        padding: 4em 0;
+
+    @media (min-width: $medium_screen) and (min-height: 600px) {
+        padding: 2.5em 0;
+    }
+
+    @media (min-width: $medium_screen) and (min-height: 700px) {
+        padding: 3em 0;
     }
 
     & > .container {

--- a/views/sass/_custom.scss
+++ b/views/sass/_custom.scss
@@ -142,8 +142,13 @@
 
 .country__legislature {
     border-bottom: 1px solid $colour_lighter_grey;
-    padding-bottom: 1.5em;
-    margin-bottom: 2em;
+    padding-bottom: 0.5em;
+    margin-bottom: 1em;
+
+    @media (min-height: 600px) {
+        padding-bottom: 1.5em;
+        margin-bottom: 2em 0;
+    }
 
     & > :last-child {
         margin-bottom: 0;
@@ -154,13 +159,14 @@
 // Add some extra margin above the promo section because the screencast
 // sticks out and it feels a bit tight against the previous section.
 .page-section--gender-balance-promo {
-    @media ( min-width: $medium_screen) {
+    @media (min-width: $medium_screen) {
         margin-top: 2em;
+        padding: 3em 0;
     }
 }
 
 .gender-balance-promo {
-    @media ( min-width: $medium_screen) {
+    @media (min-width: $medium_screen) {
         position: relative; // positioning context for the demo gif
         padding-left: 340px; // make space for the demo gif
         max-width: 44em; // avoid silly long lines
@@ -181,10 +187,10 @@
     position: relative;
     bottom: -2em; // counteract padding-bottom on .page-section
 
-    @media ( min-width: $medium_screen) {
+    @media (min-width: $medium_screen) {
         position: absolute;
-        bottom: -4em; // padding-bottom on .page-section is taller now!
         left: 0;
+        bottom: -3em;
     }
 }
 

--- a/views/sass/_site-header.scss
+++ b/views/sass/_site-header.scss
@@ -6,7 +6,15 @@
     text-align: center;
 
     @media (min-width: $large_screen) {
-        padding: 2em 0 1em;
+        padding: 1em 0 0.5em 0;
+    }
+
+    @media (min-width: $large_screen) and (min-height: 600px) {
+        padding: 1.5em 0 0.75em 0;
+    }
+
+    @media (min-width: $large_screen) and (min-height: 700px) {
+        padding: 2em 0 1em 0;
     }
 
     .container {


### PR DESCRIPTION
Here's a before and after shot, of how a country page looks on a short (800px) but wide screen:

![animation](https://cloud.githubusercontent.com/assets/739624/9113185/12931496-3c4b-11e5-8610-3088d9ac9c0b.gif)

It compresses down even further for even shorter screens (below 600px high).