### PR TITLE
Update politician-image-proxy when building viewer-static

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,12 +4,14 @@ set -eo pipefail
 
 [[ "$TRACE" ]] && set -x
 
-if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "master" ]]; then
+add_ssh_key() {
   openssl aes-256-cbc -K $encrypted_ab0690a1b9d7_key -iv $encrypted_ab0690a1b9d7_iv -in deploy_key.pem.enc -out deploy_key.pem -d
   chmod 600 deploy_key.pem
   eval "$(ssh-agent)"
   ssh-add deploy_key.pem
+}
 
+update_viewer_static() {
   bundle exec ruby app.rb &
   while ! nc -z localhost 4567; do sleep 1; done
   cd /tmp
@@ -21,4 +23,26 @@ if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "master" ]]; then
   git add .
   git -c "user.name=everypoliticianbot" -c "user.email=everypoliticianbot@users.noreply.github.com" commit -m "Automated commit" || true
   git push origin gh-pages
-fi
+}
+
+update_politician_image_proxy() {
+  cd /tmp
+  git clone "git@github.com:mysociety/politician-image-proxy.git"
+  cd politician-image-proxy
+  bundle install --gemfile=Gemfile
+  puts "Updating politician-image-proxy"
+  QUIET=1 ruby scraper.rb
+  git add .
+  git -c "user.name=everypoliticianbot" -c "user.email=everypoliticianbot@users.noreply.github.com" commit -m "Update images" || true
+  git push origin gh-pages
+}
+
+main() {
+  if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "master" ]]; then
+    add_ssh_key
+    update_viewer_static
+    update_politician_image_proxy
+  fi
+}
+
+main


### PR DESCRIPTION
When the `release.sh` script runs after merging to master clone and run the politician-image-proxy scraper to update the images.

Fixes https://github.com/everypolitician/app-manager/issues/21