### PR TITLE
Update politician-image-proxy every travis build

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -38,11 +38,11 @@ update_politician_image_proxy() {
 }
 
 main() {
+  add_ssh_key
   if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "master" ]]; then
-    add_ssh_key
     update_viewer_static
-    update_politician_image_proxy
   fi
+  update_politician_image_proxy
 }
 
 main


### PR DESCRIPTION
Sometimes images temporarily error when scraping them only to work again
later. To try and improve this we scrape images every time there is a
viewer-sinatra build rather than just when a pull request is merged.

Fixes #519 