### PR TITLE
Add a link to the What's Needed page

### DIFF
--- a/views/all_countries.erb
+++ b/views/all_countries.erb
@@ -11,5 +11,6 @@
             </li>
           <% end %>
         </ul>
+        <p><a href="/needed.html">What's needed?</a></p>
     </div>
 </div>


### PR DESCRIPTION
The “what’s needed” page needs to be linked, so that the spidering
generates a static version of it.