### PR TITLE
Sort country names in dropdown list 

### DIFF
--- a/views/country_selector.erb
+++ b/views/country_selector.erb
@@ -1,6 +1,6 @@
 <select class="field js-select-to-autocomplete" placeholder="Search by country name" name="Country" id="country-selector" autofocus="autofocus" autocorrect="off" autocomplete="off">
     <option value="" selected="selected">Select Country</option>
-  <% @world.each do |slug, country| %>
+  <% @world.sort_by { |_, country| country[:displayName] }.each do |slug, country| %>
     <option value="<%= slug %>" data-alternative-spellings="<%= country[:allNames] %>"><%= country[:displayName] %></option>
   <% end %>
 </select>

--- a/world.json
+++ b/world.json
@@ -841,7 +841,7 @@
   },
   "us-virgin-islands": {
     "displayName": "U.S. Virgin Islands",
-    "allNames": "Virgin Islands of the United States Amerikanische Jungferninseln Îles Vierges américaines Islas Vírgenes de los Estados Unidos アメリカ領ヴァージン諸島 Amerikaanse Maagdeneilanden Virgin Islands (U.S.)"
+    "allNames": "US Virgin Islands of the United States Amerikanische Jungferninseln Îles Vierges américaines Islas Vírgenes de los Estados Unidos アメリカ領ヴァージン諸島 Amerikaanse Maagdeneilanden Virgin Islands (U.S.)"
   },
   "uganda": {
     "displayName": "Uganda",
@@ -857,11 +857,11 @@
   },
   "uk": {
     "displayName": "United Kingdom",
-    "allNames": "United Kingdom Vereinigtes Königreich Royaume-Uni Reino Unido イギリス Verenigd Koninkrijk Great Britain (UK)"
+    "allNames": "United Kingdom Vereinigtes Königreich Royaume-Uni Reino Unido イギリス Verenigd Koninkrijk Great Britain (UK) England U.K."
   },
   "united-states-of-america": {
     "displayName": "United States of America",
-    "allNames": "United States of America Vereinigte Staaten von Amerika États-Unis Estados Unidos アメリカ合衆国 Verenigde Staten"
+    "allNames": "USA U.S.A. United States of America Vereinigte Staaten von Amerika États-Unis Estados Unidos アメリカ合衆国 Verenigde Staten"
   },
   "uruguay": {
     "displayName": "Uruguay",


### PR DESCRIPTION
Sort the elements in the homepage dropdown list, to be friendlier in a non-JS environment (closes #587)

(And fix up a few more country aliases as a drive-by)