### PR TITLE
Better disambiguate Congo-Kinshasa and Congo-Brazzaville

### DIFF
--- a/world.json
+++ b/world.json
@@ -4,11 +4,11 @@
     "allNames": "Bahamas バハマ Bahama’s"
   },
   "congo-kinshasa": {
-    "displayName": "Congo, The Democratic Republic Of The",
+    "displayName": "Congo-Kinshasa (Democratic Republic)",
     "allNames": "Congo (Dem. Rep.) Kinshasa Kongo (Dem. Rep.) Congo (Rep. Dem.) コンゴ民主共和国 Congo [DRC] Congo (The Democratic Republic Of The)"
   },
   "congo-brazzaville": {
-    "displayName": "Congo",
+    "displayName": "Congo-Brazzaville (Republic)",
     "allNames": "Congo Brazzaville Kongo コンゴ共和国 Congo [Republiek]"
   },
   "north-korea": {


### PR DESCRIPTION
Add better display names for both Congos on the homepage search box