### PR TITLE
Stop Safari redirecting to localhost on page blur.

### DIFF
--- a/public/javascript/main.js
+++ b/public/javascript/main.js
@@ -218,8 +218,11 @@ $(function(){
 
   // http://baymard.com/labs/country-selector
   $('.js-select-to-autocomplete').selectToAutocomplete().on('change', function(){
-    // Assumes the <option>'s `value` attribute is a URL slug for the country
-    window.location.href = '/' + $(this).val() + '/';
+    var v = $(this).val();
+    if (v) {
+        // Assumes the <option>'s `value` attribute is a URL slug for the country
+        window.location.href = '/' + v + '/';
+    }
   }).on('focus', function(){
     $(this).next().trigger("focus");
   });


### PR DESCRIPTION
An onchange is fired as the field had focus, so don't redirect if we
don't have a selected entry.