### PR TITLE
Make meta:image links absolute

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -21,7 +21,7 @@
     <script src="/javascript/main.js"></script>
     <meta property="og:title" content="<%= @page_title ||= "EveryPolitician" %>" />
     <meta property="og:type" content="article" />
-    <meta property="og:image" content="<%= @request.base_url %>/images/avatar.png" />
+    <meta property="og:image" content="http://everypolitician.org/images/avatar.png" />
     <meta property="og:image:height" content="300" />
     <meta property="og:image:width" content="300" />
     <meta property="og:site_name" content="EveryPolitician" />
@@ -29,7 +29,7 @@
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@mysocietyIntl" />
     <meta name="twitter:title" content="<%= @page_title ||= "EveryPolitician" %>" />
-    <meta property="twitter:image" content="<%= @request.base_url %>/images/avatar.png" />
+    <meta property="twitter:image" content="http://everypolitician.org/images/avatar.png" />
     <meta property="twitter:image:height" content="400" />
     <meta property="twitter:image:width" content="400" />
     <meta name="twitter:description" content="Data about every national legislature in the world, freely available for you to use."  />


### PR DESCRIPTION
Setting images (or indeed anything) with `@request.base_url` doesn’t work, as at the time the
static site is generated, the base_url will `localhost`.

I manually pushed the image in https://github.com/everypolitician/viewer-static/commit/5f401e14476389586ad3d2905930e170581c1382

Fixes #669 