### PR TITLE
Remove the last_modified header

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -53,8 +53,6 @@ get '/:country/:house/term-table/:id.html' do |country, house, id|
   @country = ALL_COUNTRIES.find { |c| c[:url] == country } || halt(404)
   @house = @country[:legislatures].find { |h| h[:slug].downcase == house } || halt(404)
 
-  last_modified Time.at(@country[:lastmod].to_i)
-
   @terms = @house[:legislative_periods]
   (@next_term, @term, @prev_term) = [nil, @terms, nil]
     .flatten.each_cons(3)


### PR DESCRIPTION
We added this in the hope that it would speed up building the site, but
(a) it didn't, as wget doesn't DTRT with it, and (b) we sped the build
up substantially in other ways anyway. All this does now is make so
that we have to do hard-refreshes when we change the layout (rather
than the data), so remove it.