### PR TITLE
Link to Wikipedia pages on Parliamentary Groups and Electoral Districts

### DIFF
--- a/views/data_structure.erb
+++ b/views/data_structure.erb
@@ -84,9 +84,9 @@
         about <em>people</em>. Those people must be members of a specific legislature
         (for example, your country’s current parliament).</p>
 
-        <p>Those people may be members of factions or parties, and represent
-        particular districts or constituencies, so we provide some information
-        about those too.</p>
+        <p>Those people may be members of <a href="https://en.wikipedia.org/wiki/Parliamentary_group">factions or parties</a>, 
+        and represent particular <a href="https://en.wikipedia.org/wiki/Electoral_district">districts or constituencies</a>, 
+        so we provide some information about those too.</p>
 
         <p>There are two distinct types of information provided:</p>
 

--- a/views/submitting.erb
+++ b/views/submitting.erb
@@ -25,9 +25,9 @@
         <ul>
           <li><tt>id</tt>: a unique identifier for the politician</li>
           <li><tt>name</tt>: their name</li>
-          <li><tt>area</tt>: they constituency/district they represent (if appropriate)</li>
-          <li><tt>group</tt>: the party or faction they’re part of (if appropriate)</li>
-          <li><tt>term</tt>: the legislative session this membership represents (e.g. ‘19’ for the Nineteenth Assembly)</li>
+          <li><tt>area</tt>: the <a href="https://en.wikipedia.org/wiki/Electoral_district">constituency/district</a> they represent (if appropriate)</li>
+          <li><tt>group</tt>: the <a href="https://en.wikipedia.org/wiki/Parliamentary_group">party or faction</a> they’re part of (if appropriate)</li>
+          <li><tt>term</tt>: the legislative period this membership represents (e.g. ‘19’ for the Nineteenth Assembly)</li>
           <li><tt>start_date</tt>: if the person joined later than the start of the term</li>
           <li><tt>end_date</tt>: if they left before the end of the term</li>
         </ul>


### PR DESCRIPTION
Add links to the relevant Wikipedia pages when talking about parties/factions, and areas/districts.