### PR TITLE
Move JSON download button to avoid confusion over scope

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -41,6 +41,7 @@ end
 
 get '/:country/' do |country|
   if @country = ALL_COUNTRIES.find { |c| c[:url] == country }
+    @example_json_url = 'http://example.com/refactor-me.json'
     erb :country
   elsif @missing = WORLD[country.to_sym]
     erb :country_missing

--- a/app.rb
+++ b/app.rb
@@ -41,7 +41,6 @@ end
 
 get '/:country/' do |country|
   if @country = ALL_COUNTRIES.find { |c| c[:url] == country }
-    @example_json_url = 'http://example.com/refactor-me.json'
     erb :country
   elsif @missing = WORLD[country.to_sym]
     erb :country_missing

--- a/views/countries.erb
+++ b/views/countries.erb
@@ -15,7 +15,7 @@
         </ul>
         <a class="button button--download" style="float:right" href="<%= @cjson %>">
           <i class="fa fa-download"></i>
-          <span class="large-screen-only">JSON</span>
+          <span class="large-screen-only">Download as</span> JSON
         </a>
         
     </div>

--- a/views/country.erb
+++ b/views/country.erb
@@ -10,7 +10,13 @@
 
     <% @country[:legislatures].each do |house| %>
       <div class="country__legislature">
-        <h4><%= house[:name] %></h4>
+        <div class="country__legislature__header">
+          <h3><%= house[:name] %></h3>
+          <a class="button button--small button--download" href="<%= @example_json_url %>">
+            <i class="fa fa-download"></i>
+            <span class="large-screen-only">Download as</span> JSON
+          </a>
+        </div>
         <ul class="grid-list" id="terms-<%= house[:slug].downcase %>">
           <% house[:legislative_periods].each do |t| %>
             <li>

--- a/views/country.erb
+++ b/views/country.erb
@@ -12,7 +12,7 @@
       <div class="country__legislature">
         <div class="country__legislature__header">
           <h3><%= house[:name] %></h3>
-          <a class="button button--small button--download" href="<%= @example_json_url %>">
+          <a class="button button--small button--download" href="https://cdn.rawgit.com/everypolitician/everypolitician-data/<%= house[:sha] %>/<%= house[:popolo] %>">
             <i class="fa fa-download"></i>
             <span class="large-screen-only">Download as</span> JSON
           </a>

--- a/views/sass/_custom.scss
+++ b/views/sass/_custom.scss
@@ -96,19 +96,6 @@
     }
 }
 
-.term-membership-table {
-    .button-group {
-        margin-bottom: 1em;
-    }
-
-    // Make the selected tab look unclickable
-    .button--primary {
-        cursor: default;
-        background-color: $colour_green;
-        border-color: $colour_green;
-    }
-}
-
 .term-membership-table__title {
     position: relative;
     padding: 1em 0;

--- a/views/sass/_custom.scss
+++ b/views/sass/_custom.scss
@@ -109,30 +109,35 @@
     }
 }
 
-.table-action-buttons {
+.term-membership-table__title {
     position: relative;
-    display: none;
+    padding: 1em 0;
 
-    @media (min-width: $medium-screen) {
-        display: block;
+    @media (min-width: $medium_screen) {
+        text-align: center;
     }
 
-    & > * {
+    h2 {
+        margin-bottom: 0;
+    }
+
+    .button {
         position: absolute;
-        top: 0;
-        left: 0;
-    }
-
-    & > :last-child {
-        left: auto;
         right: 0;
+        top: 0.5em;
+    }
+}
+
+.party-groupings__title {
+    font-size: 0.875em;
+    margin-bottom: 1.5em;
+
+    @media (min-width: $medium_screen) {
+        text-align: center;
     }
 
-    // If this is the only child, give it a height,
-    // otherwise the parent cell will collapse to zero
-    // and the buttons will overlap the row beneath.
-    &:first-child:last-child {
-        height: 4em; // same as outerheight() of a .button
+    h2 {
+        margin-bottom: 0;
     }
 }
 
@@ -147,11 +152,24 @@
 
     @media (min-height: 600px) {
         padding-bottom: 1.5em;
-        margin-bottom: 2em 0;
+        margin-bottom: 2em;
     }
 
     & > :last-child {
         margin-bottom: 0;
+    }
+}
+
+.country__legislature__header {
+    @include clearfix();
+
+    h3 {
+        float: left;
+    }
+
+    .button {
+        float: right;
+        margin-top: -0.3em; // visually align with heading
     }
 }
 

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -1,9 +1,19 @@
 <div class="page-section" id="term">
-    <div class="container">
-        <h1 class="text-center"><span class="avatar"><i class="fa fa-university"></i></span> <%= @term[:name] %></h1>
+    <div class="container text-center">
+        <h1><span class="avatar"><i class="fa fa-university"></i></span> <%= @term[:name] %></h1>
+
       <% unless @term[:start_date].to_s.empty? and @term[:end_date].to_s.empty? %>
-        <p class="text-center"><%= @term[:start_date] %> – <%= @term[:end_date] or 'current' %></p>
+        <p><%= @term[:start_date] %> – <%= @term[:end_date] or 'current' %></p>
       <% end %>
+
+        <a href="<%= @urls[:csv] %>" class="term-download">
+          <i class="fa fa-download"></i>
+          <% if @terms.length > 1 %>
+            Download all <%= @terms.length %> terms as JSON
+          <% else %>
+            Download as JSON
+      <% end %>
+        </a>
     </div>
 </div>
 
@@ -44,7 +54,9 @@
 
     <div class="page-section page-section--grey" id="seat-count">
         <div class="container">
-            <h2 class="text-center">Party Groupings</h2>
+            <div class="party-groupings__title">
+                <h2>Party Groupings</h2>
+            </div>
             <ul class="grid-list">
               <% @csv.find_all { |r| r[:end_date].to_s.empty? || r[:end_date] == @term[:end_date] }.group_by { |r| r[:group] }.sort_by { |p, ms| [-ms.count, p] }.each do |party, mems| %>
                 <li id="party-<%= mems.first[:group_id] %>"><div class="avatar-unit">
@@ -59,21 +71,16 @@
 
     <div class="page-section page-section">
         <div class="container">
-            <h2 class="text-center">Members</h2>
 
             <table class="term-membership-table js-sortable">
                 <thead class="js-fixed-thead">
                     <tr>
-                        <td colspan="4" class="text-center">
-                            <div class="table-action-buttons">
+                        <td colspan="4">
+                            <div class="term-membership-table__title">
                               <a class="button button--download" href="<%= @urls[:csv] %>">
-                                <i class="fa fa-download"></i>
-                                <span class="large-screen-only">CSV</span>
+                                    <i class="fa fa-download"></i> CSV
                               </a>
-                              <a class="button button--download" href="<%= @urls[:json] %>">
-                                <i class="fa fa-download"></i>
-                                <span class="large-screen-only">JSON</span>
-                              </a>
+                                <h2>Members</h2>
                             </div>
                         </td>
                     </tr>

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -1,19 +1,9 @@
 <div class="page-section" id="term">
     <div class="container text-center">
         <h1><span class="avatar"><i class="fa fa-university"></i></span> <%= @term[:name] %></h1>
-
       <% unless @term[:start_date].to_s.empty? and @term[:end_date].to_s.empty? %>
         <p><%= @term[:start_date] %> – <%= @term[:end_date] or 'current' %></p>
       <% end %>
-
-        <a href="<%= @urls[:csv] %>" class="term-download">
-          <i class="fa fa-download"></i>
-          <% if @terms.length > 1 %>
-            Download all <%= @terms.length %> terms as JSON
-          <% else %>
-            Download as JSON
-      <% end %>
-        </a>
     </div>
 </div>
 

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -68,7 +68,8 @@
                         <td colspan="4">
                             <div class="term-membership-table__title">
                               <a class="button button--download" href="<%= @urls[:csv] %>">
-                                    <i class="fa fa-download"></i> CSV
+                                <i class="fa fa-download"></i>
+                                <span class="large-screen-only">Download as</span> CSV
                               </a>
                                 <h2>Members</h2>
                             </div>


### PR DESCRIPTION
Previously JSON download was presented alongside CSV download for a legislature’s membership table, despite the two files containing very different data.

This moves the JSON download link to the top of the term page (and names it clearly with the number of terms it contains) and also adds JSON download links to the country page.

@tmtmtmtm Before this can be merged, you need to pass the correct JSON file URL for each legislature into `country.erb` (in place of `@example_json_url`).

Fixes #370.

![screen shot 2015-10-09 at 12 59 07](https://cloud.githubusercontent.com/assets/739624/10393182/8fdacef0-6e85-11e5-9d0d-93432adc5cfb.png)

![screen shot 2015-10-09 at 12 59 35](https://cloud.githubusercontent.com/assets/739624/10393188/9a82af62-6e85-11e5-8943-885ce183da55.png)
