### PR TITLE
Show politician counts in country autocomplete

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -27,8 +27,6 @@ set :erb, trim: '-'
 get '/' do
   @countries = ALL_COUNTRIES.to_a
   @person_count = @countries.map { |c| c[:legislatures].map { |l| l[:person_count].to_i  } }.flatten.inject(:+)
-    .to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1,').reverse
-    # http://stackoverflow.com/questions/1078347/is-there-a-rails-trick-to-adding-commas-to-large-numbers
   @world = WORLD.to_a
 
   @world.each { |slug, country|

--- a/app.rb
+++ b/app.rb
@@ -30,6 +30,10 @@ get '/' do
     .to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1,').reverse
     # http://stackoverflow.com/questions/1078347/is-there-a-rails-trick-to-adding-commas-to-large-numbers
   @world = WORLD.to_a
+
+  # :TODO: Tony, replace this with something that uses real person_count.
+  @world.each { |slug, country| country[:totalPeople] = [0, 1, 20, 98765].sample }
+
   erb :homepage
 end
 

--- a/app.rb
+++ b/app.rb
@@ -31,8 +31,10 @@ get '/' do
     # http://stackoverflow.com/questions/1078347/is-there-a-rails-trick-to-adding-commas-to-large-numbers
   @world = WORLD.to_a
 
-  # :TODO: Tony, replace this with something that uses real person_count.
-  @world.each { |slug, country| country[:totalPeople] = [0, 1, 20, 98765].sample }
+  @world.each { |slug, country|
+    cjdata = @countries.find(->{{}}) { |c| c[:url] == slug.to_s }
+    country[:totalPeople] = (cjdata[:legislatures] || []).map { |l| l[:person_count].to_i }.inject(0, :+)
+  }
 
   erb :homepage
 end

--- a/lib/popolo_helper.rb
+++ b/lib/popolo_helper.rb
@@ -36,5 +36,10 @@ module Popolo
     def term_table_url(c, h, t)
       "/%s/%s/term-table/%s.html" % [ c[:slug].downcase, h[:slug].downcase, t[:csv][/term-(.*?).csv/, 1] ]
     end
+
+    # http://stackoverflow.com/questions/1078347/is-there-a-rails-trick-to-adding-commas-to-large-numbers
+    def commify(number)
+      number.to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1,').reverse
+    end
   end
 end

--- a/public/javascript/main.js
+++ b/public/javascript/main.js
@@ -227,6 +227,21 @@ $(function(){
     $(this).next().trigger("focus");
   });
 
+  // Once the autocomplete widget has been created, we add our own
+  // little hack to display the number of politicians in each country.
+  var optionTitles = {};
+  $('select.js-select-to-autocomplete option').each(function(){
+    if($(this).val() != ''){
+      optionTitles[ $(this).text() ] = $(this).attr('title');
+    }
+  });
+  $('.ui-autocomplete-input').autocomplete('instance')._renderItem = function(ul, item) {
+    var $li = $('<li>');
+    $('<span>').text(item.label).appendTo($li);
+    $('<span>').addClass('autocomplete-country__people').text(optionTitles[item.label]).appendTo($li);
+    return $li.appendTo(ul);
+  }
+
   $('label[for="country-selector"]').on('click', function(e){
     e.preventDefault();
     $('#country-selector').siblings('.ui-autocomplete-input').focus();

--- a/views/country_selector.erb
+++ b/views/country_selector.erb
@@ -1,6 +1,6 @@
 <select class="field js-select-to-autocomplete" placeholder="Search by country name" name="Country" id="country-selector" autofocus="autofocus" autocorrect="off" autocomplete="off">
     <option value="" selected="selected">Select Country</option>
   <% @world.sort_by { |_, country| country[:displayName] }.each do |slug, country| %>
-    <option value="<%= slug %>" data-alternative-spellings="<%= country[:allNames] %>"><%= country[:displayName] %></option>
+    <option value="<%= slug %>" data-alternative-spellings="<%= country[:allNames] %>" title="<%= country[:totalPeople] %> <% if country[:totalPeople] == 1 %>person<% else %>people<% end %>"><%= country[:displayName] %></option>
   <% end %>
 </select>

--- a/views/country_selector.erb
+++ b/views/country_selector.erb
@@ -1,6 +1,6 @@
 <select class="field js-select-to-autocomplete" placeholder="Search by country name" name="Country" id="country-selector" autofocus="autofocus" autocorrect="off" autocomplete="off">
     <option value="" selected="selected">Select Country</option>
   <% @world.sort_by { |_, country| country[:displayName] }.each do |slug, country| %>
-    <option value="<%= slug %>" data-alternative-spellings="<%= country[:allNames] %>" title="<%= country[:totalPeople] %> <% if country[:totalPeople] == 1 %>person<% else %>people<% end %>"><%= country[:displayName] %></option>
+    <option value="<%= slug %>" data-alternative-spellings="<%= country[:allNames] %>" title="<%= commify(country[:totalPeople]) %> <% if country[:totalPeople] == 1 %>person<% else %>people<% end %>"><%= country[:displayName] %></option>
   <% end %>
 </select>

--- a/views/homepage.erb
+++ b/views/homepage.erb
@@ -1,6 +1,6 @@
 <div class="hero hero--jazzy text-center homepage-hero">
     <div class="container">
-        <h1><%= @person_count %> politicians from <a href="/countries.html"><%= @countries.length %> countries</a> (so far)</h1>
+        <h1><%= commify(@person_count) %> politicians from <a href="/countries.html"><%= @countries.length %> countries</a> (so far)</h1>
         <p><label for="country-selector">Find representatives from your country:</label></p>
         <%= erb :country_selector %>
     </div>

--- a/views/sass/_custom.scss
+++ b/views/sass/_custom.scss
@@ -61,8 +61,9 @@
 }
 
 .ui-menu .ui-menu-item {
+    position: relative;
     line-height: 1em;
-    padding: 0.5em 1em 0.5em 2.66em; // 2.66 = 0.66 input padding + 2em search icon offset
+    padding: 0.7em 6em 0.7em 2.66em; // 2.66 = 0.66 input padding + 2em search icon offset
     border: none;
     border-bottom: 1px solid $colour_off_white;
 
@@ -79,6 +80,15 @@
         margin: 0;
         background: $colour_lighter_grey;
     }
+}
+
+.autocomplete-country__people {
+    position: absolute;
+    right: 1em;
+    top: 50%;
+    margin-top: -0.5em;
+    color: #999;
+    font-size: 0.8em;
 }
 
 .homepage-map {


### PR DESCRIPTION
Rather than hacking directly into the select-to-autocomplete module, we tweak the jQuery autocomplete settings *after* it has been instantiated on the page, supplying our own custom `_renderItem` method, which uses a list of people counts pulled in from the `title` attributes of the original select options.

Fixes #386 by showing people which countries have data and which don’t.

![screen shot 2015-10-09 at 16 42 59](https://cloud.githubusercontent.com/assets/739624/10398430/e18faa62-6ea4-11e5-8cee-946f3d58f57f.png)
