### PR TITLE
Link missing countries to the /needed page

### DIFF
--- a/views/countries.erb
+++ b/views/countries.erb
@@ -67,6 +67,8 @@
         if(ep_link = ep_countries[code]) {
           var url = '/' + ep_link + "/";
           window.location = url;
+        } else { 
+          window.location = "/needed.html";
         }
         return false;
       },


### PR DESCRIPTION
On the map, when someone clicks on a country in red, we now take them to
the /needed page

Closes https://github.com/everypolitician/viewer-sinatra/issues/772