### PR TITLE
Correctly limit width of homepage autocomplete dropdown

### DIFF
--- a/public/javascript/main.js
+++ b/public/javascript/main.js
@@ -227,6 +227,13 @@ $(function(){
     $(this).next().trigger("focus");
   });
 
+  // Fix the incorrect default autocomplete width, which meant that
+  // autocomplete menu was longer than the search input it's linked to.
+  // http://stackoverflow.com/a/11845718/3096375
+  jQuery.ui.autocomplete.prototype._resizeMenu = function(){
+    this.menu.element.outerWidth( this.element.outerWidth() );
+  }
+
   // Once the autocomplete widget has been created, we add our own
   // little hack to display the number of politicians in each country.
   var optionTitles = {};
@@ -235,7 +242,7 @@ $(function(){
       optionTitles[ $(this).text() ] = $(this).attr('title');
     }
   });
-  $('.ui-autocomplete-input').autocomplete('instance')._renderItem = function(ul, item) {
+  jQuery.ui.autocomplete.prototype._renderItem = function(ul, item) {
     var $li = $('<li>');
     $('<span>').text(item.label).appendTo($li);
     $('<span>').addClass('autocomplete-country__people').text(optionTitles[item.label]).appendTo($li);

--- a/views/sass/_custom.scss
+++ b/views/sass/_custom.scss
@@ -62,7 +62,7 @@
 
 .ui-menu .ui-menu-item {
     position: relative;
-    line-height: 1em;
+    line-height: 1.2em;
     padding: 0.7em 6em 0.7em 2.66em; // 2.66 = 0.66 input padding + 2em search icon offset
     border: none;
     border-bottom: 1px solid $colour_off_white;
@@ -89,6 +89,7 @@
     margin-top: -0.5em;
     color: #999;
     font-size: 0.8em;
+    line-height: 1.2em;
 }
 
 .homepage-map {


### PR DESCRIPTION
Fixes a styling bug related to #769, where wide country names made the dropdown overflow the width of the search box above it.

![fixed](https://cloud.githubusercontent.com/assets/739624/10425740/f20fa7dc-70d1-11e5-8a75-621ae1be1b26.gif)

Also, since menu items are more likely to wrap onto multiple lines now, we increase the line-height slightly to make them look better when they do wrap.

And for consistency, we use the same prototype-extending paradigm for the other autocomplete hack we added in 338648794956f315b7adca356caa8b6b99e7d792.