### PR TITLE
Make sort_name the default sort

### DIFF
--- a/public/javascript/main.js
+++ b/public/javascript/main.js
@@ -131,10 +131,16 @@
       $table.data('unrowspanned', true);
     }
 
+    var getSortValue = function($element){
+      // Table cells can specify a custom value by which
+      // they will be sorted (useful for names and dates).
+      return $element.attr('data-sortable-sortvalue') || $element.text();
+    }
+
     var sortRows = function sortRows($tbody, $trs, columnIndex, sortOrder){
       $trs.detach().sort(function(rowA, rowB){
-        var valueA = $(rowA).children('td').eq(columnIndex).text();
-        var valueB = $(rowB).children('td').eq(columnIndex).text();
+        var valueA = getSortValue( $(rowA).children('td').eq(columnIndex) );
+        var valueB = getSortValue( $(rowB).children('td').eq(columnIndex) );
 
         var moveUp = 1;
         var moveDown = -1;

--- a/public/javascript/main.js
+++ b/public/javascript/main.js
@@ -77,6 +77,20 @@
 
     // Call this on a <table> and it'll make all the columns sortable.
 
+    // Columns will be sorted based on the .text() content of each cell.
+    // If you give a cell a data-sortable-sortvalue attribute, that will be
+    // used in place of the .text() content.
+
+    // Rowspans will be un-spanned on the first sorting operation, and will
+    // *not* be re-spanned, even if the original sort order is restored.
+
+    // If the table is already pre-sorted on a particular column, give that
+    // column's <th> element an attribute of data-sortable-presorted with a
+    // value of either "a-z" or "z-a". This will stop $.sortable from
+    // attempting to unsort the column on the third header click.
+
+    // Tables can only be sorted on one column at a time.
+
     var sortTable = function sortTable($table, columnIndex){
       // Find the rows to sort, and their parent
       var $tbody = $table.children('tbody');
@@ -90,16 +104,31 @@
       // Sort the right way, based on the state stored in $table.data
       var currentSortOrder = $table.data('sortOrder');
       if(columnIndex == $table.data('sortedOnColumnIndex')){
+        // Already sorting on this column, so either reverse the direction,
+        // or unsort the column, depending on the current state.
+
         if(currentSortOrder == 'a-z'){
           sortRows($tbody, $trs, columnIndex, 'z-a');
           showSortOrder($table, columnIndex, 'z-a');
           $table.data('sortOrder', 'z-a');
+
         } else if(currentSortOrder == 'z-a'){
-          restoreOriginalSortOrder($tbody, $trs);
-          showSortOrder($table);
-          $table.removeData('sortOrder');
-          $table.removeData('sortedOnColumnIndex');
+          // If this was a presorted column, we flip back to a-z sorting.
+          // If it was a normal column, we can simply unsort it instead.
+
+          if(columnIndex == $table.data('presortedOnColumnIndex')){
+            sortRows($tbody, $trs, columnIndex, 'a-z');
+            showSortOrder($table, columnIndex, 'a-z');
+            $table.data('sortOrder', 'a-z');
+
+          } else {
+            restoreOriginalSortOrder($tbody, $trs);
+            showSortOrder($table);
+            $table.removeData('sortOrder');
+            $table.removeData('sortedOnColumnIndex');
+          }
         }
+
       } else {
         sortRows($tbody, $trs, columnIndex, 'a-z');
         showSortOrder($table, columnIndex, 'a-z');
@@ -161,8 +190,8 @@
 
     var restoreOriginalSortOrder = function restoreOriginalSortOrder($tbody, $trs){
       $trs.detach().sort(function(rowA, rowB){
-        var valueA = $(rowA).data('originalSortOrder');
-        var valueB = $(rowB).data('originalSortOrder');
+        var valueA = $(rowA).data('originalSortIndex');
+        var valueB = $(rowB).data('originalSortIndex');
 
         if(valueA > valueB) {
           return 1;
@@ -192,14 +221,32 @@
 
     var saveOriginalSortOrder = function saveOriginalSortOrder($table){
       $table.find('tr').each(function(i){
-        $(this).data('originalSortOrder', i);
+        $(this).data('originalSortIndex', i);
       });
+    }
+
+    var detectPresortedTable = function detectPresortedTable($table){
+      var $presortedHeader = $table.find('th[data-sortable-presorted]');
+      var presortOrder = $presortedHeader.attr('data-sortable-presorted');
+      var columnIndex = $presortedHeader.prevAll().length;
+      $table.data('sortedOnColumnIndex', columnIndex);
+      $table.data('presortedOnColumnIndex', columnIndex);
+      if(presortOrder == 'a-z'){
+        $presortedHeader.addClass('sortedDown');
+        $table.data('sortOrder', 'a-z');
+        $table.data('presortOrder', 'a-z');
+      } else if(presortOrder == 'z-a'){
+        $presortedHeader.addClass('sortedUp');
+        $table.data('sortOrder', 'z-a');
+        $table.data('presortOrder', 'z-a');
+      }
     }
 
     return this.each(function() {
       var $table = $(this);
 
       saveOriginalSortOrder($table);
+      detectPresortedTable($table);
 
       $table.on('click', 'thead th', function(){
         var eq = $(this).prevAll().length;

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -77,7 +77,7 @@
                     </tr>
 
                     <tr>
-                        <th>Name</th>
+                        <th data-sortable-presorted="a-z">Name</th>
                         <th>Group</th>
                         <th>Area</th>
                         <% show_dates = @csv.any? { |m| !m[:start_date].to_s.empty? || !m[:end_date].to_s.empty? } %>

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -85,7 +85,7 @@
                     </tr>
                 </thead>
 
-              <% @csv.group_by { |m| m[:id] }.sort_by { |id, mems| mems.first[:name] }.each do |id, mems| %>
+              <% @csv.group_by { |m| m[:id] }.sort_by { |id, mems| mems.first[:sort_name] }.each do |id, mems| %>
                   <%# Each person can have multiple party affiliations in a single term, so we
                       loop through them and set the first cell (their name) to span all the rows %>
                   <% mems.each_with_index do |m, i| %>

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -91,7 +91,7 @@
                   <% mems.each_with_index do |m, i| %>
                     <tr id="mem-<%= id.to_s.split('/').last %>">
                       <% if i == 0 %>
-                        <td rowspan="<%= mems.count %>"><%= m[:name] %></td>
+                        <td rowspan="<%= mems.count %>" data-sortable-sortvalue="<%= m[:sort_name] or m[:name] %>"><%= m[:name] %></td>
                       <% end %>
                         <td><%= m[:group].to_s.empty? ? 'Independent' : m[:group] %></td>
                         <td><%= m[:area] %></td>
@@ -112,7 +112,7 @@
           <% if @data_sources %>
             <p>Main Source<% if @data_sources.size > 1 %>s<% end %>: <%= @data_sources.map { |url| %Q(<a href="#{url}">#{url}</a>) }.join(", ") %></p>
           <% end %>
-          <p><b>Anything wrong?</b> If you've spotted an error, or the data is incomplete, 
+          <p><b>Anything wrong?</b> If you've spotted an error, or the data is incomplete,
             here's <a href="/contribute.html">how to get that fixed</a>.</p>
         </div>
       </div>


### PR DESCRIPTION
By default we should order the names according the sort_name (where available — where it's not, it'll fall back on the `name` field).

<s>This has a slightly odd side-effect of meaning that once someone uses the clicky-arrows to re-sort, there's no way of returning to this order.  There may be a way of doing something with `restoreOriginalSortOrder` in the Javascript here, but it's not immediately obvious what that should be.</s>

This means that the behviour is:
* default: sort by sort-name (usually last name first)
* click on 'sort' in name field: sort alphabetically by display name (usually given name first)
* click on 'sort' in name field again: sort reverse alphabetically by display name
* click on 'sort' in name field again: return to sorted by sort-name

(With no way to reverse sort by sort-name)

@zarino any thoughts or comments on what you'd expect to happen here (and if that's different from what currently happens, what might be involved in making that work)? Is what we have now enough of an improvement for cases where we _have_ sort_order (try Slovakia for an example), or is it likely to be too confusing?