### PR TITLE
Remove duplicated paragraph

### DIFF
--- a/views/data_structure.erb
+++ b/views/data_structure.erb
@@ -58,11 +58,6 @@
         your tool needs to work across multiple countries — we can provide the
         initial data so you can concentrate on adding value on top of that.</p>
 
-        <p>Rather than having to start by finding data and turning that into a
-        usable format — a process that can be deceptively tricky, especially if
-        your tool needs to work across multiple countries — we can provide the
-        starting data so you can concentrate on adding value on top of that.</p>
-
         <p>In many cases the data EveryPolitician provides won’t be enough for
         what you need — you’ll need to combine it with other information
         locally. </p>


### PR DESCRIPTION
Remove a paragraph that was accidentally duplicated. Fixes #189 (thanks @Gemmamysoc !)