### PR TITLE
Present CSV and JSON download options on term page

### DIFF
--- a/public/javascript/main.js
+++ b/public/javascript/main.js
@@ -19,6 +19,21 @@
       });
     }
 
+    var deduplicateIDs = function deduplicateIDs($cloneThead){
+      // Tweak the `id` attribute of any elements inside the cloned
+      // thead, to avoid naming clashes with the original elements.
+      // Also tweak any labels inside the thead to refer to the
+      // cloned copies of whatever they pointed to originally.
+      $cloneThead.find('[id]').each(function(){
+        var oldID = $(this).attr('id');
+        var newID = oldID + '__clone';
+        $(this).attr('id', newID);
+        $cloneThead.find('[for="' + oldID + '"]').each(function(){
+          $(this).attr('for', newID);
+        });
+      });
+    }
+
     var showOrHideClone = function showOrHideClone($table, $cloneThead){
       var bounds = $table[0].getBoundingClientRect();
 
@@ -55,6 +70,7 @@
       $cloneThead.hide();
 
       calculateCloneDimensions($originalThead, $cloneThead);
+      deduplicateIDs($cloneThead);
       showOrHideClone($table, $cloneThead);
 
       $(window).resize(function(){

--- a/views/sass/_components.scss
+++ b/views/sass/_components.scss
@@ -464,3 +464,48 @@ p.lead {
         vertical-align: 0.1em;
     }
 }
+
+.download-options {
+    position: relative;
+
+    .button {
+        cursor: pointer;
+
+        &:after {
+            @include css-triangle(0.4em, $colour_dark_grey, down);
+            margin-left: 0.5em;
+        }
+    }
+}
+
+.download-options__dropdown {
+    position: absolute;
+    z-index: 1;
+    right: 0;
+    margin-top: 0.2em;
+    padding: 0.5em 0;
+    background-color: #fff;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+    border: 1px solid $colour_light_grey;
+    text-align: left;
+
+    a {
+        display: block;
+        padding: 0.75em 1.25em;
+        color: $colour_black;
+
+        &:hover, &:focus {
+            background-color: $colour_off_white;
+        }
+    }
+
+    h3 {
+        font-size: 1em;
+        margin-bottom: 0.2em;
+    }
+
+    p {
+        font-size: 0.875em;
+        line-height: 1.4em;
+    }
+}

--- a/views/sass/_custom.scss
+++ b/views/sass/_custom.scss
@@ -119,10 +119,14 @@
         margin-bottom: 0;
     }
 
-    .button {
+    .download-options {
         position: absolute;
         right: 0;
         top: 0.5em;
+    }
+
+    .download-options__dropdown a {
+        width: 16em;
     }
 }
 

--- a/views/sass/_houdini.scss
+++ b/views/sass/_houdini.scss
@@ -1,0 +1,46 @@
+// Houdini is a custom-written CSS+HTML library for
+// showing and hiding elements on a page using just
+// checkboxes and radio buttons.
+
+// Relies on the "+" adjacent/next sibling selector and
+// the ":checked" pseudo-class, which means this doesn't
+// work in IE8 or below.
+
+// Example use:
+//
+// <label class="houdini-label" for="input1">Click me...</label>
+// <input class="houdini-input" type="checkbox" id="input1">
+// <div class="houdini-target">...To show and hide me</div>
+
+// Or an example where the input remains visible to the user,
+// and is placed before the label (eg: to be floated right, so it
+// appears to the right of the label, like a normal checkbox):
+//
+// <input class="houdini-input houdini-input--visible" type="checkbox" id="input2">
+// <label class="houdini-label" for="input2">Click me...</label>
+// <div class="houdini-target">...To show and hide me</div>
+
+// The three elements must be placed sequentially in the document,
+// either label+input+target or input+label+target.
+
+// Each label+input pair must have matching `id` and `for` attributes.
+// You cannot nest the input inside the label.
+
+.houdini-input {
+  position: absolute;
+  opacity: 0;
+}
+
+.houdini-input--visible {
+  position: static;
+  opacity: 1;
+}
+
+.houdini-target {
+  display: none;
+
+  .houdini-input:checked + &,
+  .houdini-input:checked + .houdini-label + & {
+    display: block;
+  }
+}

--- a/views/sass/_mixins.scss
+++ b/views/sass/_mixins.scss
@@ -66,6 +66,36 @@
   flex-wrap: $wrap;
 }
 
+// Based on http://foundation.zurb.com/sites/docs/v/5.5.3/components/global.html
+@mixin css-triangle($triangle-size, $triangle-color, $triangle-direction) {
+  content: "";
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border: inset $triangle-size;
+  margin-bottom: ($triangle-size / 2) * -1;
+
+  @if ($triangle-direction == down) {
+    border-color: $triangle-color transparent transparent transparent;
+    border-top-style: solid;
+  }
+
+  @if ($triangle-direction == up) {
+    border-color: transparent transparent $triangle-color transparent;
+    border-bottom-style: solid;
+  }
+
+  @if ($triangle-direction == left) {
+    border-color: transparent transparent transparent $triangle-color;
+    border-left-style: solid;
+  }
+
+  @if ($triangle-direction == right) {
+    border-color: transparent $triangle-color transparent transparent;
+    border-right-style: solid;
+  }
+}
+
 .image-replacement {
     overflow: hidden;
     text-indent: -1000%;

--- a/views/sass/main.scss
+++ b/views/sass/main.scss
@@ -28,6 +28,7 @@ body {
     }
 }
 
+@import 'houdini';
 @import 'typography';
 @import 'layouts';
 @import 'components';

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -67,11 +67,24 @@
                     <tr>
                         <td colspan="4">
                             <div class="term-membership-table__title">
-                              <a class="button button--download" href="<%= @urls[:csv] %>">
-                                <i class="fa fa-download"></i>
-                                <span class="large-screen-only">Download as</span> CSV
-                              </a>
+
+                                <div class="download-options">
+                                    <label class="houdini-label button button--tertiary" for="download-options">Download</label>
+                                    <input class="houdini-input" type="checkbox" id="download-options">
+                                    <div class="houdini-target download-options__dropdown">
+                                        <a href="<%= @urls[:csv] %>">
+                                            <h3>Download as CSV</h3>
+                                            <p>Core data on these politicians, perfect for quick analysis</p>
+                                        </a>
+                                        <a href="<%= @urls[:json] %>">
+                                            <h3>Download as JSON</h3>
+                                            <p>All the data we hold on this legislature (including historic)</p>
+                                        </a>
+                                    </div>
+                                </div>
+
                                 <h2>Members</h2>
+
                             </div>
                         </td>
                     </tr>


### PR DESCRIPTION
We use the Houdini CSS library from other mySociety projects to handle the dropdown behaviour without JavaScript. But because Houdini uses `id/for` attributes we also needed to tweak the `$.fixedThead()` module to deduplicate ids on cloned elements.

![dropdown](https://cloud.githubusercontent.com/assets/739624/13573090/cb4b1fe2-e475-11e5-88c5-4cecbc05a320.jpg)

Fixes everypolitician/everypolitician#324.