### PR TITLE
Simpler wording for earlier/later links on term page

### DIFF
--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -14,7 +14,7 @@
               <% if @prev_term %>
                 <a href="<%= term_table_url(@country, @house, @prev_term) %>" class="term-navigation__prev">
                     <i class="fa fa-arrow-left"></i>
-                    <%= @prev_term[:name] %>
+                    Earlier
                 </a>
               <% end %>
 
@@ -33,7 +33,7 @@
 
               <% if @next_term %>
                 <a href="<%= term_table_url(@country, @house, @next_term) %>" class="term-navigation__next">
-                    <%= @next_term[:name] %>
+                    Later
                     <i class="fa fa-arrow-right"></i>
                 </a>
               <% end %>


### PR DESCRIPTION
Fixes everypolitician/everypolitician#293.

![screen shot 2016-03-15 at 09 54 56](https://cloud.githubusercontent.com/assets/739624/13773984/495c8c26-ea94-11e5-9c47-64338a149da5.png)
