### PR TITLE
Click a party name to show only people in that party

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -123,6 +123,7 @@ get '/:country/:house/term-table/:id.html' do |country, house, termid|
           end_date: mem.end_date
         }
         membership[:group] = org_lookup[mem.on_behalf_of_id].name if mem.on_behalf_of_id
+        membership[:group_id] = mem.on_behalf_of_id
         membership[:area] = area_lookup[mem.area_id].name if mem.area_id
         membership
       end,

--- a/public/javascript/ep-card-filter.js
+++ b/public/javascript/ep-card-filter.js
@@ -197,6 +197,10 @@ var CardFilter = function(){
 
 }
 
+var scrollToTheCards = function scrollToTheCards(){
+  var scrollTop = $('.js-filter-target').parents('.page-section').position().top;
+  $('html, body').animate({ scrollTop: scrollTop });
+}
 
 $(document).ready(function(){
 
@@ -217,6 +221,7 @@ $(document).ready(function(){
     $('[data-section-toggle]').on('click', function(){
       var section = $(this).attr('data-section-toggle');
       window.cards.setFacet(section);
+      scrollToTheCards();
     });
 
     $('[data-party-filter]').on('click', function(){
@@ -227,6 +232,7 @@ $(document).ready(function(){
         var partyID = $(this).attr('data-party-filter');
         window.cards.setParty(partyID);
       }
+      scrollToTheCards();
     });
 
   }

--- a/public/javascript/main.js
+++ b/public/javascript/main.js
@@ -333,6 +333,29 @@ $(function(){
     $('#country-selector').siblings('.ui-autocomplete-input').focus();
   });
 
+  $('[data-party-filter]').on('click', function(){
+    var alreadyActive = $(this).is('[data-party-filter-active]');
+    var $targets = $('.js-filter-target[data-parties]');
+    var partyID = $(this).attr('data-party-filter');
+
+    if(alreadyActive){
+      $(this).removeAttr('data-party-filter-active');
+      $targets.removeClass('js-filter-target--hidden');
+
+    } else {
+      $('[data-party-filter-active]').removeAttr('data-party-filter-active');
+      $(this).attr('data-party-filter-active', true);
+      $targets.each(function(){
+        var partyIDs = $(this).attr('data-parties').split(' ');
+        if( partyIDs.indexOf(partyID) < 0 ){
+          $(this).addClass('js-filter-target--hidden');
+        } else {
+          $(this).removeClass('js-filter-target--hidden');
+        }
+      });
+    }
+  });
+
   $('.data-completeness__percentage').each(function(){
       var percent = parseFloat( $(this).text() );
       var label = $(this).prev().text();

--- a/public/javascript/main.js
+++ b/public/javascript/main.js
@@ -333,29 +333,6 @@ $(function(){
     $('#country-selector').siblings('.ui-autocomplete-input').focus();
   });
 
-  $('[data-party-filter]').on('click', function(){
-    var alreadyActive = $(this).is('[data-party-filter-active]');
-    var $targets = $('.js-filter-target[data-parties]');
-    var partyID = $(this).attr('data-party-filter');
-
-    if(alreadyActive){
-      $(this).removeAttr('data-party-filter-active');
-      $targets.removeClass('js-filter-target--hidden');
-
-    } else {
-      $('[data-party-filter-active]').removeAttr('data-party-filter-active');
-      $(this).attr('data-party-filter-active', true);
-      $targets.each(function(){
-        var partyIDs = $(this).attr('data-parties').split(' ');
-        if( partyIDs.indexOf(partyID) < 0 ){
-          $(this).addClass('js-filter-target--hidden');
-        } else {
-          $(this).removeClass('js-filter-target--hidden');
-        }
-      });
-    }
-  });
-
   $('.data-completeness__percentage').each(function(){
       var percent = parseFloat( $(this).text() );
       var label = $(this).prev().text();

--- a/views/sass/_custom.scss
+++ b/views/sass/_custom.scss
@@ -177,6 +177,17 @@
     }
 }
 
+[data-party-filter] {
+  cursor: pointer;
+}
+
+[data-party-filter]:hover,
+[data-party-filter-active] {
+  .avatar-unit h3 {
+    text-decoration: underline;
+  }
+}
+
 .button--download {
     @extend .button--tertiary;
 }

--- a/views/sass/_custom.scss
+++ b/views/sass/_custom.scss
@@ -141,7 +141,7 @@
   }
 }
 
-.term-membership-table__title {
+.term-table__title {
     position: relative;
     padding: 1em 0;
 

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -134,7 +134,7 @@
             <div class="grid-list" data-active-section="bio">
 
               <% @people.each do |person| %>
-                <div class="js-filter-target">
+                <div class="js-filter-target" data-parties="<%= person[:memberships].map { |m| m[:group_id] }.uniq.reject { |s| s.empty? }.join(' ') %>">
                     <div class="person-card" id="mem-<%= person[:id] %>">
 
                         <div class="person-card__primary">

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -50,7 +50,7 @@
             </div>
             <ul class="grid-list grid-list--vertically-center">
               <% @group_data.each do |party| %>
-                <li id="party-<%= party[:group_id] %>"><div class="avatar-unit">
+                <li id="party-<%= party[:group_id] %>" data-party-filter="<%= party[:group_id] %>"><div class="avatar-unit">
                     <span class="avatar"><i class="fa fa-users"></i></span>
                     <h3><%= party[:name].to_s.empty? ? 'Independent' : party[:name] %></h3>
                     <p><span class="seatcount"><%= party[:member_count] %></span> seat<% if party[:member_count] > 1 %>s<% end %></p>

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -107,26 +107,49 @@
     <div class="page-section page-section--grey">
         <div class="container">
 
-            <div class="term-membership-table__title">
+            <div class="term-table__title">
                 <h2>Members</h2>
+            </div>
 
-                <span class="person-card-filter">
+            <div class="term-table__filters">
+                <div class="term-table__filters__search">
                     <label for="filter-input" class="fa fa-search"></label>
                     <input type="text" class="js-filter-input" id="filter-input" placeholder="Search by name, place, etc…">
-                </span>
+                    <span class="filter-input-clear js-filter-input-clear"><i class="fa fa-times-circle"></i></span>
+                </div>
 
-                <div class="download-options">
-                    <label class="houdini-label button button--tertiary" for="download-options">Download</label>
-                    <input class="houdini-input" type="checkbox" id="download-options">
-                    <div class="houdini-target download-options__dropdown">
-                        <a href="<%= @urls[:csv] %>">
-                            <h3>Download as CSV</h3>
-                            <p>Core data on these politicians, perfect for quick analysis</p>
-                        </a>
-                        <a href="<%= @urls[:json] %>">
-                            <h3>Download as JSON</h3>
-                            <p>All the data we hold on this legislature (including historic)</p>
-                        </a>
+                <div class="term-table__filters__party">
+                    <select>
+                      <option value="" selected="selected">All parties</option>
+                      <% @group_data.each do |party| %>
+                        <option value="<%= party[:group_id] %>"><%= party[:name].to_s.empty? ? 'Independent' : party[:name] %></option>
+                      <% end %>
+                    </select>
+                </div>
+
+                <div class="term-table__filters__facet">
+                    <select>
+                        <option>Biographical (<%= @percentages[:bio] %>%)</option>
+                        <option>Social links (<%= @percentages[:social] %>%)</option>
+                        <option>Contact details (<%= @percentages[:contacts] %>%)</option>
+                        <option>Identifiers (<%= @percentages[:identifiers] %>%)</option>
+                    </select>
+                </div>
+
+                <div class="term-table__filters__download">
+                    <div class="download-options">
+                        <label class="houdini-label button button--tertiary" for="download-options">Download</label>
+                        <input class="houdini-input" type="checkbox" id="download-options">
+                        <div class="houdini-target download-options__dropdown">
+                            <a href="<%= @urls[:csv] %>">
+                                <h3>Download as CSV</h3>
+                                <p>Core data on these politicians, perfect for quick analysis</p>
+                            </a>
+                            <a href="<%= @urls[:json] %>">
+                                <h3>Download as JSON</h3>
+                                <p>All the data we hold on this legislature (including historic)</p>
+                            </a>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Fixes everypolitician/everypolitician#340.

There is potential for a confusing situation when you filter by party and then start additionally filtering by text using the `js-filter-input`. (Your most recent action will take precedence, but the UI won't make that clear.)

@chrismytton: This appears to work fine for some countries (eg: the UK) but not others (eg: USA). I think maybe it's because I'm assuming the `mem.on_behalf_of_id` of a membership and the `mems.first[:group_id]` in the party list are the same, but they're not (eg: in the USA, the links up top have `data-party-filter="republican"` but the list items have `data-parties="party/republican"`) – why?

![screen shot 2016-03-16 at 15 43 20](https://cloud.githubusercontent.com/assets/739624/13818459/d762ed5e-eb8d-11e5-98e4-cb5d118ebb97.png)
