### PR TITLE
Switch to using GitHub raw urls directly

### DIFF
--- a/DATASOURCE
+++ b/DATASOURCE
@@ -1,1 +1,1 @@
-https://cdn.rawgit.com/everypolitician/everypolitician-data/143c93761393e25d974009a08d756c06538fc1da/countries.json
+https://github.com/everypolitician/everypolitician-data/raw/143c93761393e25d974009a08d756c06538fc1da/countries.json

--- a/lib/popolo_helper.rb
+++ b/lib/popolo_helper.rb
@@ -5,7 +5,7 @@ module EveryPolitician
 
   class GithubFile
 
-    @@GH_PATH = "https://cdn.rawgit.com/everypolitician/everypolitician-data/%s/%s"
+    @@GH_PATH = "https://github.com/everypolitician/everypolitician-data/raw/%s/%s"
 
     def initialize(file, sha, cache_dir = '_cached_data')
       @url = @@GH_PATH % [sha, file]

--- a/views/country.erb
+++ b/views/country.erb
@@ -12,7 +12,7 @@
       <div class="country__legislature">
         <div class="country__legislature__header">
           <h3><%= house[:name] %></h3>
-          <a class="button button--small button--download" href="https://cdn.rawgit.com/everypolitician/everypolitician-data/<%= house[:sha] %>/<%= house[:popolo] %>">
+          <a class="button button--small button--download" href="<%= house[:popolo_url] %>">
             <i class="fa fa-download"></i>
             <span class="large-screen-only">Download as</span> JSON
           </a>


### PR DESCRIPTION
RawGit has been down a couple of times lately, so instead of pointing to
that this changes things to point directly to GitHub. This does mean
that all JSON and CSV urls will have the content type text/plain (as
that's what GitHub serves them up with) but we can document that and
tell people to use RawGit if they need the correct content type.