### PR TITLE
Use Popolo JSON exclusively for the term table

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -199,9 +199,7 @@ get '/:country/:house/term-table/:id.html' do |country, house, termid|
     json: popolo_file.url,
   }
 
-  # TODO: Make this use EveryPolitician::Popolo once that supports the 'meta' field.
-  popolo_json = JSON.parse(popolo_file.raw)
-  @data_sources = (popolo_json['meta']['sources'] || [popolo_json['meta']['source']]).map { |s| CGI.unescape(s) }
+  @data_sources = popolo.popolo[:meta][:sources].map { |s| CGI.unescape(s) }
 
   erb :term_table
 end

--- a/app.rb
+++ b/app.rb
@@ -67,14 +67,14 @@ get '/:country/:house/wikidata' do |country, house|
   erb :wikidata_match
 end
 
-get '/:country/:house/term-table/:id.html' do |country, house, id|
+get '/:country/:house/term-table/:id.html' do |country, house, termid|
   @country = ALL_COUNTRIES.find { |c| c[:url] == country } || halt(404)
   @house = @country[:legislatures].find { |h| h[:slug].downcase == house } || halt(404)
 
   @terms = @house[:legislative_periods]
   (@next_term, @term, @prev_term) = [nil, @terms, nil]
     .flatten.each_cons(3)
-    .find { |_p, e, _n| e[:slug] == id }
+    .find { |_p, e, _n| e[:slug] == termid }
   @page_title = @term[:name]
 
   last_sha = @house[:sha]
@@ -83,7 +83,7 @@ get '/:country/:house/term-table/:id.html' do |country, house, id|
   popolo = EveryPolitician::Popolo.parse(popolo_file.raw)
 
   # We only want memberships that are in the requested term.
-  term_memberships = popolo.memberships.find_all { |m| m.legislative_period_id.split('/').last == id }
+  term_memberships = popolo.memberships.find_all { |m| m.legislative_period_id.split('/').last == termid }
 
   # Pull all the people who held a membership in this term out of the Popolo.
   person_ids = Set.new(term_memberships.map(&:person_id))

--- a/app.rb
+++ b/app.rb
@@ -82,23 +82,26 @@ get '/:country/:house/term-table/:id.html' do |country, house, id|
   popolo_file = EveryPolitician::GithubFile.new(@house[:popolo], last_sha)
   popolo = EveryPolitician::Popolo.parse(popolo_file.raw)
 
+  # We only want memberships that are in the requested term.
   memberships = popolo.memberships.find_all { |m| m.legislative_period_id.split('/').last == id }
 
+  # Pull all the people who held a membership in this term out of the Popolo.
   person_ids = Set.new(memberships.map(&:person_id))
   people = popolo.persons.find_all { |p| person_ids.include?(p.id) }.sort_by(&:sort_name)
 
+  # Create a few hashes so that looking up memberships and their related orgs and areas is faster.
   memberships_by_person = memberships.group_by(&:person_id)
   areas_by_id = Hash[popolo.areas.map { |a| [a.id, a] }]
   orgs_by_id = Hash[popolo.organizations.map { |o| [o.id, o] }]
 
-  current_memberships = memberships.find_all { |mem| mem.end_date.to_s.empty? || mem.end_date == @term[:end_date] }
-                                   .group_by(&:on_behalf_of_id)
-                                   .map { |group_id, mems| [orgs_by_id[group_id], mems] }
-                                   .sort_by { |group, mems| [-mems.count, group.name] }
-
-  @parties = current_memberships.map do |group, mems|
-    { group_id: group.id.split('/').last, name: group.name, member_count: mems.count }
-  end
+  # Pull all unique parties out of memberships. We don't want to count
+  # memberships that finished before the end of the term. We then sort them by
+  # size and remap them to the format that the template consumes.
+  @parties = memberships.find_all { |mem| mem.end_date.to_s.empty? || mem.end_date == @term[:end_date] }
+                        .group_by(&:on_behalf_of_id)
+                        .map { |group_id, mems| [orgs_by_id[group_id], mems] }
+                        .sort_by { |group, mems| [-mems.count, group.name] }
+                        .map { |group, mems| { group_id: group.id.split('/').last, name: group.name, member_count: mems.count } }
 
   # If we don't know the parties for anyone in a term then hide the parties section.
   if @parties.length == 1 && @parties.first[:name] == 'unknown'

--- a/app.rb
+++ b/app.rb
@@ -97,7 +97,7 @@ get '/:country/:house/term-table/:id.html' do |country, house, id|
                                    .sort_by { |group, mems| [-mems.count, group.name] }
 
   @parties = current_memberships.map do |group, mems|
-    { group_id: group.id, name: group.name, member_count: mems.count }
+    { group_id: group.id.split('/').last, name: group.name, member_count: mems.count }
   end
 
   # If we don't know the parties for anyone in a term then hide the parties section.

--- a/app.rb
+++ b/app.rb
@@ -84,7 +84,7 @@ get '/:country/:house/term-table/:id.html' do |country, house, id|
 
   memberships = popolo.memberships.find_all { |m| m.legislative_period_id.split('/').last == id }
 
-  person_ids = memberships.map(&:person_id)
+  person_ids = Set.new(memberships.map(&:person_id))
   people = popolo.persons.find_all { |p| person_ids.include?(p.id) }.sort_by(&:sort_name)
 
   memberships_by_person = memberships.group_by(&:person_id)

--- a/app.rb
+++ b/app.rb
@@ -87,7 +87,7 @@ get '/:country/:house/term-table/:id.html' do |country, house, termid|
 
   # Pull all the people who held a membership in this term out of the Popolo.
   person_ids = Set.new(term_memberships.map(&:person_id))
-  people = popolo.persons.find_all { |p| person_ids.include?(p.id) }.sort_by(&:sort_name)
+  people = popolo.persons.find_all { |p| person_ids.include?(p.id) }
 
   # Create a few hashes so that looking up memberships and their related orgs and areas is faster.
   memberships_by_person = term_memberships.group_by(&:person_id)
@@ -115,7 +115,7 @@ get '/:country/:house/term-table/:id.html' do |country, house, termid|
                                .map { |s, ids| s }
                                .take(3)
 
-  @people = people.map do |person|
+  @people = people.sort_by(&:sort_name).map do |person|
     p = {
       id: person.id,
       name: person.name,

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -42,14 +42,14 @@
     </div>
 <% end %>
 
-<% if @parties.any? %>
+<% if @group_data.any? %>
     <div class="page-section page-section--grey" id="seat-count">
         <div class="container">
             <div class="party-groupings__title">
                 <h2>Party Groupings</h2>
             </div>
             <ul class="grid-list grid-list--vertically-center">
-              <% @parties.each do |party| %>
+              <% @group_data.each do |party| %>
                 <li id="party-<%= party[:group_id] %>"><div class="avatar-unit">
                     <span class="avatar"><i class="fa fa-users"></i></span>
                     <h3><%= party[:name].to_s.empty? ? 'Independent' : party[:name] %></h3>

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -42,18 +42,18 @@
     </div>
 <% end %>
 
-<% unless @parties.length == 1 && @parties[0][0] == 'unknown' %>
+<% if @parties.any? %>
     <div class="page-section page-section--grey" id="seat-count">
         <div class="container">
             <div class="party-groupings__title">
                 <h2>Party Groupings</h2>
             </div>
             <ul class="grid-list grid-list--vertically-center">
-              <% @parties.each do |party, mems| %>
-                <li id="party-<%= mems.first[:group_id] %>"><div class="avatar-unit">
+              <% @parties.each do |party| %>
+                <li id="party-<%= party[:group_id] %>"><div class="avatar-unit">
                     <span class="avatar"><i class="fa fa-users"></i></span>
-                    <h3><%= party.to_s.empty? ? 'Independent' : party %></h3>
-                    <p><span class="seatcount"><%= mems.count %></span> seat<% if mems.count > 1 %>s<% end %></p>
+                    <h3><%= party[:name].to_s.empty? ? 'Independent' : party[:name] %></h3>
+                    <p><span class="seatcount"><%= party[:member_count] %></span> seat<% if party[:member_count] > 1 %>s<% end %></p>
                 </div></li>
               <% end %>
             </ul>


### PR DESCRIPTION
Previously we were getting the person ids from the CSV and then mapping
those to the JSON. This changes that to instead get everything directly
from the popolo to avoid confusion where there are subtle differences
between the CSV and the JSON.

I tried to cherry-pick the appropriate commits but too much had changed to make it simple, so I just reimplemented on top of `master`.

Extracted from #5349