### PR TITLE
Hide 'Party Groupings' section if only one group

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -96,13 +96,13 @@ get '/:country/:house/term-table/:id.html' do |country, house, termid|
 
   # Groups, ordered by size, with name and count of how many members
   # they had at the end of the term. Don't include this section if
-  # all groups are unknown.
+  # there is only a single group.
   @group_data = term_memberships.find_all { |mem| mem.end_date.to_s.empty? || mem.end_date == @term[:end_date] }
                 .group_by(&:on_behalf_of_id)
                 .map { |group_id, mems| [org_lookup[group_id], mems] }
                 .sort_by { |group, mems| [-mems.count, group.name] }
                 .map { |group, mems| { group_id: group.id.split('/').last, name: group.name, member_count: mems.count } }
-  @group_data = [] if @group_data.length == 1 && @group_data.first[:name] == 'unknown'
+  @group_data = [] if @group_data.length == 1 
 
   identifiers = people.map { |p| p.identifiers if p.respond_to?(:identifiers) }.compact.flatten
   top_identifiers = identifiers.reject { |i| i[:scheme] == 'everypolitician_legacy' }

--- a/t/web/term_table/party_groupings.rb
+++ b/t/web/term_table/party_groupings.rb
@@ -1,0 +1,38 @@
+ENV['RACK_ENV'] = 'test'
+
+require_relative '../../../app'
+require 'minitest/autorun'
+require 'rack/test'
+require 'nokogiri'
+
+include Rack::Test::Methods
+
+def app
+  Sinatra::Application
+end
+
+describe 'Party Groupings section' do
+  subject { Nokogiri::HTML(last_response.body) }
+  let(:heading) { subject.css('.party-groupings__title h2').text }
+
+  describe 'only Independent' do
+    before { get '/alderney/states/term-table/2014.html' }
+    it 'should have no party groupings (all Independent)' do
+      heading.must_be_empty
+    end
+  end
+
+  describe 'only Unknown' do
+    before { get '/transnistria/supreme-council/term-table/6.html' }
+    it 'should have no party groupings (all Unknown)' do
+      heading.must_be_empty
+    end
+  end
+
+  describe 'regular section' do
+    before { get '/estonia/riigikogu/term-table/13.html' }
+    it 'should have party groupings' do
+      heading.must_equal 'Party Groupings'
+    end
+  end
+end


### PR DESCRIPTION
Don't show the list of Groups if there's only one entry (e.g. if
everyone is an Independent).

Closes https://github.com/everypolitician/viewer-sinatra/issues/5629