### PR TITLE
Round down the number on the homepage

### DIFF
--- a/lib/popolo_helper.rb
+++ b/lib/popolo_helper.rb
@@ -54,7 +54,8 @@ module Popolo
     end
 
     def number_to_millions(num)
-      (num.to_f / 100_000).floor.to_f / 10
+      result = (num.to_f / 100_000).floor.to_f / 10
+      result.modulo(1) < 0.1 ?  result.to_i : result
     end
   end
 end

--- a/lib/popolo_helper.rb
+++ b/lib/popolo_helper.rb
@@ -54,7 +54,7 @@ module Popolo
     end
 
     def number_to_millions(num)
-      (num.to_f / 1_000_000).round(1)
+      (num.to_f / 100_000).floor.to_f / 10
     end
   end
 end

--- a/t/web/popolo_helper.rb
+++ b/t/web/popolo_helper.rb
@@ -14,5 +14,9 @@ describe Popolo::Helper do
     it 'rounds down rather than up' do
       number_to_millions(2680000).must_equal(2.6)
     end
+
+    it 'removes the zero for whole numbers' do
+      number_to_millions(3000000).must_equal(3)
+    end
   end
 end

--- a/t/web/popolo_helper.rb
+++ b/t/web/popolo_helper.rb
@@ -8,15 +8,15 @@ describe Popolo::Helper do
 
   describe '#number_to_millions' do
     it 'formats numbers as millions to one decimal place' do
-      number_to_millions(2700000).must_equal(2.7)
+      number_to_millions(2700000).to_s.must_equal('2.7')
     end
 
     it 'rounds down rather than up' do
-      number_to_millions(2680000).must_equal(2.6)
+      number_to_millions(2680000).to_s.must_equal('2.6')
     end
 
     it 'removes the zero for whole numbers' do
-      number_to_millions(3000000).must_equal(3)
+      number_to_millions(3000000).to_s.must_equal('3')
     end
   end
 end

--- a/t/web/popolo_helper.rb
+++ b/t/web/popolo_helper.rb
@@ -1,0 +1,18 @@
+ENV['RACK_ENV'] = 'test'
+
+require_relative '../../app'
+require 'minitest/autorun'
+
+describe Popolo::Helper do
+  include Popolo::Helper
+
+  describe '#number_to_millions' do
+    it 'formats numbers as millions to one decimal place' do
+      number_to_millions(2700000).must_equal(2.7)
+    end
+
+    it 'rounds down rather than up' do
+      number_to_millions(2680000).must_equal(2.6)
+    end
+  end
+end


### PR DESCRIPTION
Rather than saying we've got 2.7m statements when we've only got 2.68m
we instead say we've got 2.6m. This means we won't claim we've got 2.7m
statements until we actually do.

![screen shot 2016-03-22 at 16 28 02](https://cloud.githubusercontent.com/assets/22996/13956976/15559e74-f04b-11e5-8ff6-944a85871faa.png)

Closes #5671 