### PR TITLE
Decode Facebook usernames before displaying on term page

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -136,7 +136,7 @@ get '/:country/:house/term-table/:id.html' do |country, house, termid|
       p[:social] << { type: 'Twitter', value: "@#{person.twitter}", link: "https://twitter.com/#{person.twitter}" }
     end
     if person.facebook
-      fb_username = person.facebook.split('/').last
+      fb_username = URI.decode_www_form_component(person.facebook.split('/').last)
       p[:social] << { type: 'Facebook', value: fb_username, link: "https://facebook.com/#{fb_username}" }
     end
     p[:bio] << { type: 'Gender', value: person.gender } if person.gender


### PR DESCRIPTION
![screen shot 2016-03-22 at 16 46 50](https://cloud.githubusercontent.com/assets/22996/13957787/08979aae-f04e-11e5-94e5-80cbfb57af29.png)


Because we're getting the username out of the url some usernames contain
UTF-8 characters that need to be decoded before they are displayed.

Fixes https://github.com/everypolitician/everypolitician/issues/358