### PR TITLE
Show biography section on person cards by default

### DIFF
--- a/public/javascript/ep-card-filter.js
+++ b/public/javascript/ep-card-filter.js
@@ -29,7 +29,7 @@ var CardFilter = function(){
   // When the UI is in its default position,
   // this is what the state should look like.
   var defaultState = {
-    facet: "biography",
+    facet: "bio",
     search: undefined,
     party: undefined
   }


### PR DESCRIPTION
This wasn't working correctly due to a typo: `biography` instead of `bio` as the default section name.

![screen shot 2016-05-20 at 16 52 11](https://cloud.githubusercontent.com/assets/22996/15431679/3a923f42-1eab-11e6-8452-76442426cd90.png)


Fixes https://github.com/everypolitician/everypolitician/issues/400