### PR TITLE
Add better `title` for pages

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -50,6 +50,7 @@ end
 
 get '/:country/' do |country|
   if @country = ALL_COUNTRIES.find { |c| c[:url] == country }
+    @page_title = "EveryPolitician: #{@country[:name]}"
     erb :country
   elsif @missing = WORLD[country.to_sym]
     erb :country_missing
@@ -64,6 +65,7 @@ get '/:country/:house/wikidata' do |country, house|
   last_sha = @house[:sha]
   popolo_file = EveryPolitician::GithubFile.new(@house[:popolo], last_sha)
   @popolo = JSON.parse(popolo_file.raw, symbolize_names: true)
+  @page_title = "EveryPolitician: #{@country[:name]} — #{@house}"
   erb :wikidata_match
 end
 
@@ -75,7 +77,7 @@ get '/:country/:house/term-table/:id.html' do |country, house, termid|
   (@next_term, @term, @prev_term) = [nil, @terms, nil]
     .flatten.each_cons(3)
     .find { |_p, e, _n| e[:slug] == termid }
-  @page_title = @term[:name]
+  @page_title = "EveryPolitician: #{@country[:name]} — #{@house[:name]} - #{@term[:name]}"
 
   last_sha = @house[:sha]
 

--- a/t/web/basic.rb
+++ b/t/web/basic.rb
@@ -28,6 +28,10 @@ describe 'Viewer' do
     it 'should have know its country' do
       last_response.body.must_include 'Finland'
     end
+
+    it 'should have the country in the title' do
+      subject.css('title').text.must_equal 'EveryPolitician: Finland'
+    end
   end
 
   describe 'unknown house of known country' do

--- a/t/web/term_table/australia.rb
+++ b/t/web/term_table/australia.rb
@@ -38,7 +38,7 @@ describe 'Per Country Tests: Australia' do
     end
 
     it 'should have the correct page title' do
-      subject.css('title').text.must_equal '44th Parliament'
+      subject.css('title').text.must_equal 'EveryPolitician: Australia — House of Representatives - 44th Parliament'
     end
 
     it 'should list the correct source' do
@@ -58,7 +58,7 @@ describe 'Per Country Tests: Australia' do
     end
 
     it 'should have the correct page title' do
-      subject.css('title').text.must_equal '44th Parliament'
+      subject.css('title').text.must_equal 'EveryPolitician: Australia — Senate - 44th Parliament'
     end
 
     it 'should list the correct source' do

--- a/t/web/term_table/finland.rb
+++ b/t/web/term_table/finland.rb
@@ -23,7 +23,7 @@ describe 'Per Country Tests' do
     end
 
     it 'should have the correct page title' do
-      subject.css('title').text.must_equal 'Eduskunta 35'
+      subject.css('title').text.must_equal 'EveryPolitician: Finland — Eduskunta - Eduskunta 35'
     end
 
     it 'should list the parties' do


### PR DESCRIPTION
By default the title is just "EveryPolitican", so extend that for the
country and term pages to more accurately represent where we are.

Closes https://github.com/everypolitician/viewer-sinatra/issues/10130