### PR TITLE
Make Northern Cyprus clickable on the map

### DIFF
--- a/views/countries.erb
+++ b/views/countries.erb
@@ -47,6 +47,7 @@
     ep_countries['<%= country[:code].upcase %>'] = '<%= country[:slug].downcase %>';
   <% end -%>
     ep_countries['_0'] = 'kosovo';
+    ep_countries['-99'] = 'northern-cyprus';
 
   var draw_map = function() {
     var colors = {}


### PR DESCRIPTION
Rather than being red, and taking you to the "Missing" page, make it
green and clickable through to the legislature.

Closes https://github.com/everypolitician/everypolitician/issues/430