### PR TITLE
Issues/437 redirect docs pages

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -22,16 +22,14 @@ end
 wjson = File.read('world.json')
 WORLD = JSON.parse(wjson, symbolize_names: true)
 
+DOCS_URL = 'http://docs.everypolitician.org'
+
 # Can't do server-side redirection on a GitHub Pages-hosted static site, so the 
 # kindest next-best-thing is to have a placeholder with meta HTTP-refresh.
-def redirect_page(page_title)
-  filename = request.path_info.sub("/", "")
-  if filename == 'about.html'
-    filename = "" # about.html maps to the root (/) on docs.
-  end
+def redirect_page(url, page_title)
   @head_tags = [
-    %(<meta http-equiv="refresh" content="0; url=http://docs.everypolitician.org/#{filename}">),
-    %(<link rel="canonical" href="http://docs.everypolitician.org/#{filename}"/>)
+    %(<meta http-equiv="refresh" content="0; url=#{url}">),
+    %(<link rel="canonical" href="#{url}"/>)
   ].join("\n\t")
   @page_title = page_title
   erb :redirect
@@ -228,39 +226,40 @@ end
 
 # Old doc pages are now at docs.everypolitician.org: redirect to them
 get '/about.html' do
-  redirect_page("About") # note: about.html -> docs subdomain root (/)
+  # note: about.html -> docs subdomain root (/)
+  redirect_page(DOCS_URL + "/", "About")
 end
 
 get '/contribute.html' do
-  redirect_page("How to contribute")
+  redirect_page(DOCS_URL + request.path_info, "How to contribute")
 end
 
 get '/data_structure.html' do
-  redirect_page("About EveryPolitician’s data")
+  redirect_page(DOCS_URL + request.path_info, "About EveryPolitician’s data")
 end
 
 get '/data_summary.html' do
-  redirect_page("What’s in EveryPolitician’s data?")
+  redirect_page(DOCS_URL + request.path_info, "What’s in EveryPolitician’s data?")
 end
 
 get '/repo_structure.html' do
-  redirect_page("Getting the most recent data")
+  redirect_page(DOCS_URL + request.path_info, "Getting the most recent data")
 end
 
 get '/scrapers.html' do
-  redirect_page("About writing scrapers")
+  redirect_page(DOCS_URL + request.path_info, "About writing scrapers")
 end
 
 get '/submitting.html' do
-  redirect_page("How we import data")
+  redirect_page(DOCS_URL + request.path_info, "How we import data")
 end
 
 get '/technical.html' do
-  redirect_page("Technical overview")
+  redirect_page(DOCS_URL + request.path_info, "Technical overview")
 end
 
 get '/use_the_data.html' do
-  redirect_page("Use EveryPolitician data")
+  redirect_page(DOCS_URL + request.path_info, "Use EveryPolitician data")
 end
 
 not_found do

--- a/app.rb
+++ b/app.rb
@@ -26,7 +26,11 @@ DOCS_URL = 'http://docs.everypolitician.org'
 
 # Can't do server-side redirection on a GitHub Pages-hosted static site, so the 
 # kindest next-best-thing is to have a placeholder with meta HTTP-refresh.
-def redirect_page(url, page_title)
+# This works for humans (i.e., browsers parse and follow the redirect) but,
+# because wget simply fetches the HTML document, this lets us continue to 
+# spider the site to generate the contents of everypolitician/viewer-static.
+# See scripts/release.sh (update_viewer_static).
+def soft_redirect(url, page_title)
   @head_tags = [
     %(<meta http-equiv="refresh" content="0; url=#{url}">),
     %(<link rel="canonical" href="#{url}"/>)
@@ -227,39 +231,39 @@ end
 # Old doc pages are now at docs.everypolitician.org: redirect to them
 get '/about.html' do
   # note: about.html -> docs subdomain root (/)
-  redirect_page(DOCS_URL + "/", "About")
+  soft_redirect(DOCS_URL + "/", "About")
 end
 
 get '/contribute.html' do
-  redirect_page(DOCS_URL + request.path_info, "How to contribute")
+  soft_redirect(DOCS_URL + request.path_info, "How to contribute")
 end
 
 get '/data_structure.html' do
-  redirect_page(DOCS_URL + request.path_info, "About EveryPolitician’s data")
+  soft_redirect(DOCS_URL + request.path_info, "About EveryPolitician’s data")
 end
 
 get '/data_summary.html' do
-  redirect_page(DOCS_URL + request.path_info, "What’s in EveryPolitician’s data?")
+  soft_redirect(DOCS_URL + request.path_info, "What’s in EveryPolitician’s data?")
 end
 
 get '/repo_structure.html' do
-  redirect_page(DOCS_URL + request.path_info, "Getting the most recent data")
+  soft_redirect(DOCS_URL + request.path_info, "Getting the most recent data")
 end
 
 get '/scrapers.html' do
-  redirect_page(DOCS_URL + request.path_info, "About writing scrapers")
+  soft_redirect(DOCS_URL + request.path_info, "About writing scrapers")
 end
 
 get '/submitting.html' do
-  redirect_page(DOCS_URL + request.path_info, "How we import data")
+  soft_redirect(DOCS_URL + request.path_info, "How we import data")
 end
 
 get '/technical.html' do
-  redirect_page(DOCS_URL + request.path_info, "Technical overview")
+  soft_redirect(DOCS_URL + request.path_info, "Technical overview")
 end
 
 get '/use_the_data.html' do
-  redirect_page(DOCS_URL + request.path_info, "Use EveryPolitician data")
+  soft_redirect(DOCS_URL + request.path_info, "Use EveryPolitician data")
 end
 
 not_found do

--- a/app.rb
+++ b/app.rb
@@ -22,6 +22,21 @@ end
 wjson = File.read('world.json')
 WORLD = JSON.parse(wjson, symbolize_names: true)
 
+# Can't do server-side redirection on a GitHub Pages-hosted static site, so the 
+# kindest next-best-thing is to have a placeholder with meta HTTP-refresh.
+def redirect_page(page_title)
+  filename = request.path_info.sub("/", "")
+  if filename == 'about.html'
+    filename = "" # about.html maps to the root (/) on docs.
+  end
+  @head_tags = [
+    %(<meta http-equiv="refresh" content="0; url=http://docs.everypolitician.org/#{filename}">),
+    %(<link rel="canonical" href="http://docs.everypolitician.org/#{filename}"/>)
+  ].join("\n\t")
+  @page_title = page_title
+  erb :redirect
+end
+
 set :erb, trim: '-'
 
 get '/' do
@@ -209,6 +224,43 @@ end
 
 get '/404.html' do
   erb :fourohfour
+end
+
+# Old doc pages are now at docs.everypolitician.org: redirect to them
+get '/about.html' do
+  redirect_page("About") # note: about.html -> docs subdomain root (/)
+end
+
+get '/contribute.html' do
+  redirect_page("How to contribute")
+end
+
+get '/data_structure.html' do
+  redirect_page("About EveryPolitician’s data")
+end
+
+get '/data_summary.html' do
+  redirect_page("What’s in EveryPolitician’s data?")
+end
+
+get '/repo_structure.html' do
+  redirect_page("Getting the most recent data")
+end
+
+get '/scrapers.html' do
+  redirect_page("About writing scrapers")
+end
+
+get '/submitting.html' do
+  redirect_page("How we import data")
+end
+
+get '/technical.html' do
+  redirect_page("Technical overview")
+end
+
+get '/use_the_data.html' do
+  redirect_page("Use EveryPolitician data")
 end
 
 not_found do

--- a/views/all_countries.erb
+++ b/views/all_countries.erb
@@ -12,5 +12,17 @@
         </ul>
         <p><a href="/needed.html">What's needed?</a></p>
         <p><a href="/404.html">404</a></p>
+        <p>
+          Redirections:
+          <a href="/about.html">about</a>,
+          <a href="/contribute.html">contribute</a>,
+          <a href="/data_structure.html">data_structure</a>,
+          <a href="/data_summary.html">data_summary</a>,
+          <a href="/repo_structure.html">repo_structure</a>,
+          <a href="/scrapers.html">scrapers</a>,
+          <a href="/submitting.html">submitting</a>,
+          <a href="/technical.html">technical</a>,
+          <a href="/use_the_data.html">use_the_data</a>
+        </p>
     </div>
 </div>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -2,6 +2,7 @@
 <html class="no-js">
 <head>
     <meta charset="utf-8">
+    <%= @head_tags %>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
     <link rel="stylesheet" type="text/css" href="/javascript/jquery-ui-1.11.4.custom/jquery-ui.css">

--- a/views/redirect.erb
+++ b/views/redirect.erb
@@ -1,0 +1,16 @@
+<div class="hero hero--jazzy">
+    <div class="container">
+        <h1><%= @page_title %></h1>
+    </div>
+</div>
+
+<div class="page-section">
+    <div class="container centered">
+        <p class="lead">Redirecting to <a href="http://docs.everypolitician.org/<%= @filename %>">docs.everypolitician.org</a></p>
+        <p class="fourohfour-suggestions">
+            <a href="/" class="button button--primary">Go home</a>
+            <span class="fourohfour-suggestions__or">or</span>
+            <a href="http://docs.everypolitician.org/<%= @filename %>" class="button button--secondary">Load page</a>
+        </p>
+    </div>
+</div>


### PR DESCRIPTION
This replaces the existing (bad, old) docs pages within http://everypolitician.org with redirections to the corresponding pages in their new home on http://docs.everypolitician.org.

This is everypolitician/viewer-static#7  (wrongly attempted on the static files) re-done on this repo (viewer-sinatra), which is effectively the generator.

`wget` seems to play nicely here, in that (as expected) it does not parse/obey the `meta refresh` redirection, so the pages stick.

Closes everypolitician/everypolitician#437

Sanity check: there are nine doc pages being redirected.