### PR TITLE
remove query params from the download links

### DIFF
--- a/views/country.erb
+++ b/views/country.erb
@@ -13,7 +13,7 @@
         <div class="country__legislature__header">
           <h3><%= house[:name] %></h3>
           <!-- download link as button? -->
-          <a class="button button--quarternary" href="download?house=<%= house[:slug].downcase %>">
+          <a class="button button--quarternary" href="download">
             <i class="fa fa-download"></i>
             Download <span class="large-screen-only">data</span>
           </a>

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -117,7 +117,7 @@
 
                 <div class="download-options">
                   <!-- download link as button? -->
-                  <a class="button button--quarternary" href="../../download?house=<%= @house[:slug].downcase %>&term=<%= @term[:slug].downcase %>">
+                  <a class="button button--quarternary" href="../../download">
                     <i class="fa fa-download"></i>
                     Download <span class="large-screen-only">data</span>
                   </a>


### PR DESCRIPTION
can reintroduce them when I've sorted out not having wget record them as part
of the page name
(highlighting won't work on select terms for now)
closes #11631
