### PR TITLE
add .html suffix to download pages

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -178,7 +178,7 @@ get '/:country/:house/term-table/:id.html' do |country, house, termid|
   erb :term_table
 end
 
-get '/:country/download' do |country|
+get '/:country/download.html' do |country|
   @country = ALL_COUNTRIES.find { |c| c[:url] == country } || halt(404)
   @cjson = cjson
   erb :country_download

--- a/views/country.erb
+++ b/views/country.erb
@@ -13,7 +13,7 @@
         <div class="country__legislature__header">
           <h3><%= house[:name] %></h3>
           <!-- download link as button? -->
-          <a class="button button--quarternary" href="download">
+          <a class="button button--quarternary" href="download.html">
             <i class="fa fa-download"></i>
             Download <span class="large-screen-only">data</span>
           </a>

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -117,7 +117,7 @@
 
                 <div class="download-options">
                   <!-- download link as button? -->
-                  <a class="button button--quarternary" href="../../download">
+                  <a class="button button--quarternary" href="../../download.html">
                     <i class="fa fa-download"></i>
                     Download <span class="large-screen-only">data</span>
                   </a>


### PR DESCRIPTION
This ensures GitHub Pages serves the file up as with an HTML content type.

closes #11634 
