### PR TITLE
Add house name in the term table under country name

### DIFF
--- a/t/web/term_table/malaysia.rb
+++ b/t/web/term_table/malaysia.rb
@@ -25,5 +25,9 @@ describe 'Per Country Tests' do
     it 'should list the areas' do
       memtable.text.must_include 'Samarahan, Sarawak'
     end
+
+    it 'should show the house name in the title' do
+      subject.css('.site-header__logo h3').text.must_include 'Dewan Rakyat'
+    end
   end
 end

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -60,6 +60,7 @@
                         <a href="/"><span class="header-logo">EveryPolitician</span></a>
                       <% end %>
                     </h2>
+                    <% if @house %><h3><%= @house[:name] %></h3><% end %>
                 </div>
                 <div class="site-header__navigation site-header__navigation--primary">
                     <nav role="navigation">
@@ -98,4 +99,3 @@
     </div>
   </body>
 </html>
-

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -253,4 +253,3 @@
             here's <a href="http://docs.everypolitician.org/contribute.html">how to get that fixed</a>.</p>
         </div>
       </div>
-


### PR DESCRIPTION
If there is no country there will be no house name either, so I added a conditional under the title.
Wrapped it with an h3 tag.
It works for long names in country or house name.

Closes: #11915