### PR TITLE
Tabs to switch between term pages for legislatures/houses in a single country

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,8 +70,5 @@ DEPENDENCIES
   sinatra!
   yajl-ruby
 
-RUBY VERSION
-   ruby 2.0.0p648
-
 BUNDLED WITH
    1.12.5

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -61,7 +61,6 @@
                         <a href="/"><span class="header-logo">EveryPolitician</span></a>
                       <% end %>
                     </h2>
-                    <% if @house %><h3><%= @house[:name] %></h3><% end %>
                 </div>
                 <div class="site-header__navigation site-header__navigation--primary">
                     <nav role="navigation">

--- a/views/sass/_components.scss
+++ b/views/sass/_components.scss
@@ -513,6 +513,17 @@ p.lead {
     @extend .inline-list;
     padding-top: 1em;
 
+    // Make the tabs scroll horizontally on small screens.
+    // TODO: Make this not suck when the currently selected tab is
+    // hidden off to the far right of the line.
+    @media (max-width: $small_screen_max) {
+        text-align: left;
+        white-space: nowrap;
+        overflow: auto;
+        margin: 0 -1em;
+        padding: 1em 0.5em 0 0.5em;
+    }
+
     @media (min-width: $medium_screen) and (min-height: 600px) {
         padding-top: 1.5em;
     }
@@ -537,4 +548,8 @@ p.lead {
 .house-tab--active:hover,
 .house-tab--active:focus {
     background: #fff;
+}
+
+.source-credits a {
+    @extend .break-word;
 }

--- a/views/sass/_components.scss
+++ b/views/sass/_components.scss
@@ -498,12 +498,43 @@ p.lead {
 
 // Little round social icons for membership tables
 .person-link {
-  display: inline-block;
-  width: 24px;
-  padding-top: 24px;
-  height: 0;
-  overflow: hidden;
-  vertical-align: middle;
-  border-radius: 100%;
-  margin-right: 0.3em;
+    display: inline-block;
+    width: 24px;
+    padding-top: 24px;
+    height: 0;
+    overflow: hidden;
+    vertical-align: middle;
+    border-radius: 100%;
+    margin-right: 0.3em;
+}
+
+.house-tabs {
+    @extend .unstyled-list;
+    @extend .inline-list;
+    padding-top: 1em;
+
+    @media (min-width: $medium_screen) and (min-height: 600px) {
+        padding-top: 1.5em;
+    }
+}
+
+.house-tab {
+    display: inline-block;
+    padding: 0.5em 1em;
+    border-radius: 5px 5px 0 0;
+    background-color: mix($colour_green, #fff, 25%);
+    background: linear-gradient(180deg, mix($colour_green, #fff, 20%), 50%, mix($colour_green, #fff, 30%));
+    color: darken($colour_green, 10%) !important;
+
+    &:hover,
+    &:focus {
+        background-color: mix($colour_green, #fff, 15%);
+        background: linear-gradient(180deg, mix($colour_green, #fff, 10%), 50%, mix($colour_green, #fff, 20%));
+    }
+}
+
+.house-tab--active,
+.house-tab--active:hover,
+.house-tab--active:focus {
+    background: #fff;
 }

--- a/views/sass/_mixins.scss
+++ b/views/sass/_mixins.scss
@@ -121,3 +121,18 @@
         }
     }
 }
+
+.break-word {
+    // https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+
+    -ms-word-break: break-all;
+    word-break: break-all;
+    word-break: break-word;
+
+    -ms-hyphens: auto;
+    -moz-hyphens: auto;
+    -webkit-hyphens: auto;
+    hyphens: auto;
+}

--- a/views/sass/_typography.scss
+++ b/views/sass/_typography.scss
@@ -171,6 +171,10 @@ textarea {
     -webkit-appearance: none;
 }
 
+select {
+    max-width: 100%;
+}
+
 fieldset {
     padding: 0;
     border: 0;

--- a/views/sass/_variables.scss
+++ b/views/sass/_variables.scss
@@ -34,6 +34,7 @@ $high_dpi_screen: '-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi
 
 $large_screen_max: $giant_screen - (1em * (1px / $size_font-base));
 $medium_screen_max: $large_screen - (1em * (1px / $size_font-base));
+$small_screen_max: $medium_screen - (1em * (1px / $size_font-base));
 
 $animation-short: 0.2s ease-out;
 

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -1,3 +1,18 @@
+<div class="page-section page-section--green page-section--no-padding">
+    <div class="container text-center">
+        <ul class="house-tabs">
+          <% @country[:legislatures].each do |house| %>
+            <li>
+                <% latest_term = house[:legislative_periods].sort_by{ |term| term[:start_date] }.last %>
+                <a class="house-tab <% if @house == house %>house-tab--active<% end %>" href="<%= term_table_url(@country, house, latest_term) %>">
+                    <%= house[:name] %>
+                </a>
+            </li>
+          <% end %>
+        </ul>
+    </div>
+</div>
+
 <div class="page-section" id="term">
     <div class="container text-center">
         <h1><span class="avatar"><i class="fa fa-university"></i></span> <%= @term[:name] %></h1>

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -3,8 +3,7 @@
         <ul class="house-tabs">
           <% @country[:legislatures].each do |house| %>
             <li>
-                <% latest_term = house[:legislative_periods].sort_by{ |term| term[:start_date] }.last %>
-                <a class="house-tab <% if @house == house %>house-tab--active<% end %>" href="<%= term_table_url(@country, house, latest_term) %>">
+                <a class="house-tab <% if @house == house %>house-tab--active<% end %>" href="<%= term_table_url(@country, house, house[:legislative_periods].first) %>">
                     <%= house[:name] %>
                 </a>
             </li>


### PR DESCRIPTION
Adds tabs to the top of the term_table pages, serving the dual purpose of making it clear which legislature/house is currently selected, and also making it easier to switch between legislatures/houses without having to go back "up" to the country-level page.

**Country with more than one legislature:**

![screen shot 2016-07-25 at 14 15 11](https://cloud.githubusercontent.com/assets/739624/17102580/35573708-5272-11e6-906e-4ba6b93cb55f.png)

![screen shot 2016-07-25 at 15 09 39](https://cloud.githubusercontent.com/assets/739624/17104220/d6b33c4e-5279-11e6-84b6-091e446264d6.png)

**Country with only one legislature:**

![screen shot 2016-07-25 at 15 08 09](https://cloud.githubusercontent.com/assets/739624/17104192/b59a1f14-5279-11e6-8b9f-48e3c37475c5.png)

![screen shot 2016-07-25 at 15 09 14](https://cloud.githubusercontent.com/assets/739624/17104209/c8c6c57e-5279-11e6-8546-8371ec4578cd.png)

Part of #13297, but actually quite beneficial to deploy on its own, since it improves the current experience.
