### PR TITLE
Improve term page layout on narrow screens

### DIFF
--- a/views/sass/_custom.scss
+++ b/views/sass/_custom.scss
@@ -144,19 +144,33 @@
 .term-membership-table__title {
     position: relative;
     padding: 1em 0;
+    text-align: center;
+
+    .download-options,
+    .person-card-filter {
+        margin-top: 1em;
+    }
 
     @media (min-width: $medium_screen) {
-        text-align: center;
+        .download-options,
+        .person-card-filter {
+            position: absolute;
+            margin-top: 0;
+        }
+
+        .download-options {
+            right: 0;
+            top: 0.5em;
+        }
+
+        .person-card-filter {
+            left: 0;
+            top: 1em;
+        }
     }
 
     h2 {
         margin-bottom: 0;
-    }
-
-    .download-options {
-        position: absolute;
-        right: 0;
-        top: 0.5em;
     }
 
     .download-options__dropdown a {
@@ -198,14 +212,21 @@
 
 .country__legislature__header {
     @include clearfix();
+    text-align: center;
+    margin-bottom: 1em;
 
-    h3 {
-        float: left;
-    }
+    @media (min-width: $medium_screen) {
+        text-align: left;
+        margin-bottom: 0;
 
-    .button {
-        float: right;
-        margin-top: -0.3em; // visually align with heading
+        h3 {
+            float: left;
+        }
+
+        .button {
+            float: right;
+            margin-top: -0.3em; // visually align with heading
+        }
     }
 }
 

--- a/views/sass/_person-cards.scss
+++ b/views/sass/_person-cards.scss
@@ -111,9 +111,7 @@ $person_card_sections: (
 }
 
 .person-card-filter {
-  position: absolute;
-  top: 1em;
-  left: 0;
+  display: block;
 
   .no-js & {
     display: none;


### PR DESCRIPTION
Fixes #10131.

The "headers" at the top of the term list section and the term members section now stack vertically on narrow screens.

![screen shot 2016-07-29 at 14 08 38](https://cloud.githubusercontent.com/assets/739624/17249147/734ffe60-5596-11e6-8314-e0d4702f933e.png)

![screen shot 2016-07-29 at 14 08 57](https://cloud.githubusercontent.com/assets/739624/17249148/75268cfe-5596-11e6-86db-d06ab27b78d2.png)
