### PR TITLE
WIP Adding tracking to term-table page interactive elements

### DIFF
--- a/public/javascript/main.js
+++ b/public/javascript/main.js
@@ -453,8 +453,6 @@ analytics = {
         // The deferred object is resolved when the GA call
         // completes or fails to respond within 2 seconds.
         var dfd = $.Deferred();
-        params.eventLabel = params.eventLabel || document.title;
-        params.hitType = params.hitType || 'event';
 
         if(!ga.loaded){
             // GA has not loaded (blocked by adblock?)
@@ -463,6 +461,7 @@ analytics = {
 
         var defaults = {
             hitType: 'event',
+            eventLabel: document.title,
             hitCallback: function(){
                 dfd.resolve();
             }

--- a/public/javascript/main.js
+++ b/public/javascript/main.js
@@ -283,7 +283,6 @@ $(function(){
     var that = this;
     event.preventDefault();
     analytics.trackEvent({
-        hitType: 'event',
         eventCategory: eventDescription,
         eventDescription: $(this).attr('data-ga-track-change'),
         eventAction: event.type
@@ -420,7 +419,6 @@ $('[data-ga-track-click]').on('click', function(event){
     var that = this;
     event.preventDefault();
     analytics.trackEvent({
-        hitType: 'event',
         eventCategory: eventDescription,
         eventDescription: $(this).attr('data-ga-track-click'),
         eventAction: event.type
@@ -458,6 +456,7 @@ analytics = {
         // completes or fails to respond within 2 seconds.
         var dfd = $.Deferred();
         params.eventLabel = params.eventLabel || document.title;
+        params.hitType = params.hitType || 'event';
 
         if(!ga.loaded){
             // GA has not loaded (blocked by adblock?)

--- a/public/javascript/main.js
+++ b/public/javascript/main.js
@@ -408,7 +408,14 @@ function doneTyping () {
   ga('send', 'event', $(this).attr('data-ga-track-change'), 'user input', document.title);
 }
 
-$('[data-ga-track-click]').on('click', deferredTracking)
+// Track clicks
+$('[data-ga-track-click]').on('click', function(event){
+  var that = this;
+  deferredTracking(event, function(){
+    var link = $(that).attr('href');
+    if (link) window.location.href = link;
+  })
+})
 
 function deferredTracking(event, callback){
     event.preventDefault();
@@ -424,8 +431,7 @@ function deferredTracking(event, callback){
     })
 
     deferred.done(function(){
-      if (href) window.location.href = href;
-      if (callback) callback();
+        callback();
     })
 }
 

--- a/public/javascript/main.js
+++ b/public/javascript/main.js
@@ -286,8 +286,7 @@ $(function(){
         hitType: 'event',
         eventCategory: eventDescription,
         eventDescription: $(this).attr('data-ga-track-change'),
-        eventAction: event.type,
-        eventLabel: document.title
+        eventAction: event.type
     })
     .done(function(){
         var link = $(that).val();
@@ -424,8 +423,7 @@ $('[data-ga-track-click]').on('click', function(event){
         hitType: 'event',
         eventCategory: eventDescription,
         eventDescription: $(this).attr('data-ga-track-click'),
-        eventAction: event.type,
-        eventLabel: document.title
+        eventAction: event.type
     })
     .done(function(){
         var link = $(that).attr('href');
@@ -459,6 +457,7 @@ analytics = {
         // The deferred object is resolved when the GA call
         // completes or fails to respond within 2 seconds.
         var dfd = $.Deferred();
+        params.eventLabel = params.eventLabel || document.title;
 
         if(!ga.loaded){
             // GA has not loaded (blocked by adblock?)

--- a/public/javascript/main.js
+++ b/public/javascript/main.js
@@ -454,9 +454,9 @@ analytics = {
         // completes or fails to respond within 2 seconds.
         var dfd = $.Deferred();
 
-        if(!ga.loaded){
-            // GA has not loaded (blocked by adblock?)
-            return dfd.resolve();
+        if(typeof ga === 'undefined' || !ga.loaded){
+          // GA has not loaded (blocked by adblock?)
+          return dfd.resolve();
         }
 
         var defaults = {
@@ -466,12 +466,14 @@ analytics = {
                 dfd.resolve();
             }
         }
+
         ga('send', $.extend(defaults, params));
 
         // Wait a maximum of 2 seconds for GA response.
         setTimeout(function(){
             dfd.resolve();
         }, 2000);
+
         return dfd.promise();
     }
 

--- a/public/javascript/main.js
+++ b/public/javascript/main.js
@@ -430,9 +430,7 @@ function deferredTracking(event, callback){
         eventLabel: document.title
     })
 
-    deferred.done(function(){
-        callback();
-    })
+    return deferred;
 }
 
 analytics = {

--- a/public/javascript/main.js
+++ b/public/javascript/main.js
@@ -281,10 +281,19 @@ $(function(){
 
   $('.js-navigation-menu').on('change', function(event){
     var that = this;
-    deferredTracking(event, function(){
-      window.location.href = $(that).val();
+    event.preventDefault();
+    analytics.trackEvent({
+        hitType: 'event',
+        eventCategory: eventDescription,
+        eventDescription: $(this).attr('data-ga-track-change'),
+        eventAction: event.type,
+        eventLabel: document.title
     })
-  });
+    .done(function(){
+        var link = $(that).val();
+        if (link) window.location.href = link;
+    })
+  })
 
   $('html').removeClass('no-js');
 
@@ -393,45 +402,36 @@ var doneTypingInterval = 2000;  //time in ms, 2 seconds
 var $input = $('[data-ga-track-change]');
 
 //on keyup, start the countdown
-$input.on('keyup', function () {
+$input.on('keyup', function() {
   clearTimeout(typingTimer);
   if (this.value.length > 0)
     typingTimer = setTimeout(doneTyping, doneTypingInterval);
 });
 
 //on keydown, clear the countdown
-$input.on('keydown', function () {
+$input.on('keydown', function() {
   clearTimeout(typingTimer);
 });
 
-function doneTyping () {
+function doneTyping() {
   ga('send', 'event', $(this).attr('data-ga-track-change'), 'user input', document.title);
 }
 
-// Track clicks
 $('[data-ga-track-click]').on('click', function(event){
-  var that = this;
-  deferredTracking(event, function(){
-    var link = $(that).attr('href');
-    if (link) window.location.href = link;
-  })
-})
-
-function deferredTracking(event, callback){
+    var that = this;
     event.preventDefault();
-    var href = $(this).attr('href') || false;
-
-    eventDescription = $(this).attr('data-ga-track-click') || 'Undescribed event';
-
-    var deferred = analytics.trackEvent({
+    analytics.trackEvent({
         hitType: 'event',
         eventCategory: eventDescription,
+        eventDescription: $(this).attr('data-ga-track-click'),
         eventAction: event.type,
         eventLabel: document.title
     })
-
-    return deferred;
-}
+    .done(function(){
+        var link = $(that).attr('href');
+        if (link) window.location.href = link;
+    });
+})
 
 analytics = {
 

--- a/public/javascript/main.js
+++ b/public/javascript/main.js
@@ -283,8 +283,7 @@ $(function(){
     var that = this;
     event.preventDefault();
     analytics.trackEvent({
-        eventCategory: eventDescription,
-        eventDescription: $(this).attr('data-ga-track-change'),
+        eventCategory: $(this).attr('data-ga-track-change'),
         eventAction: event.type
     })
     .done(function(){
@@ -419,8 +418,7 @@ $('[data-ga-track-click]').on('click', function(event){
     var that = this;
     event.preventDefault();
     analytics.trackEvent({
-        eventCategory: eventDescription,
-        eventDescription: $(this).attr('data-ga-track-click'),
+        eventCategory: $(this).attr('data-ga-track-click'),
         eventAction: event.type
     })
     .done(function(){

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -12,14 +12,14 @@
         <div class="container">
             <div class="term-navigation">
               <% if @prev_term %>
-                <a href="<%= term_table_url(@country, @house, @prev_term) %>" class="term-navigation__prev">
+                <a href="<%= term_table_url(@country, @house, @prev_term) %>" class="term-navigation__prev" data-ga-track-click="Show previous term">
                     <i class="fa fa-arrow-left"></i>
                     Earlier
                 </a>
               <% end %>
 
               <span class="term-navigation__jump">Jump to:
-                  <select class="js-navigation-menu">
+                  <select class="js-navigation-menu" data-ga-track-select="Jump to term by date">
                     <% @terms.each do |t| %>
                       <option value="<%= term_table_url(@country, @house, t) %>" <% if t[:name] == @term[:name] %>selected<% end %>>
                         <%= t[:name] %>
@@ -32,7 +32,7 @@
               </span>
 
               <% if @next_term %>
-                <a href="<%= term_table_url(@country, @house, @next_term) %>" class="term-navigation__next">
+                <a href="<%= term_table_url(@country, @house, @next_term) %>" class="term-navigation__next" data-ga-track-click="Show next term">
                     Later
                     <i class="fa fa-arrow-right"></i>
                 </a>
@@ -70,25 +70,25 @@
             <div class="container">
                 <div class="grid-list grid-list--vertically-center grid-list--narrow-columns">
                     <div class="data-completeness">
-                        <span class="section-toggle section-toggle--selected" data-section-toggle="bio">
+                        <span class="section-toggle section-toggle--selected" data-section-toggle="bio" data-ga-track-click="Section toggle: bio">
                             <span class="data-completeness__label">Biographical</span>
                             <span class="data-completeness__percentage"><%= @percentages[:bio] %>%</span>
                         </span>
                     </div>
                     <div class="data-completeness">
-                        <span class="section-toggle" data-section-toggle="social">
+                        <span class="section-toggle" data-section-toggle="social" data-ga-track-click="Section toggle: social">
                             <span class="data-completeness__label">Social links</span>
                             <span class="data-completeness__percentage"><%= @percentages[:social] %>%</span>
                         </span>
                     </div>
                     <div class="data-completeness">
-                        <span class="section-toggle" data-section-toggle="contacts">
+                        <span class="section-toggle" data-section-toggle="contacts" data-ga-track-click="Section toggle: contacts">
                             <span class="data-completeness__label">Contact details</span>
                             <span class="data-completeness__percentage"><%= @percentages[:contacts] %>%</span>
                         </span>
                     </div>
                     <div class="data-completeness">
-                        <span class="section-toggle" data-section-toggle="identifiers">
+                        <span class="section-toggle" data-section-toggle="identifiers" data-ga-track-click="Section toggle: identifiers">
                             <span class="data-completeness__label">Identifiers</span>
                             <span class="data-completeness__percentage"><%= @percentages[:identifiers] %>%</span>
                         </span>
@@ -112,12 +112,12 @@
 
                 <span class="person-card-filter">
                     <label for="filter-input" class="fa fa-search"></label>
-                    <input type="text" class="js-filter-input" id="filter-input" placeholder="Search by name, place, etc…">
+                    <input type="text" class="js-filter-input" id="filter-input" placeholder="Search by name, place, etc…" data-ga-track-change="Filter field">
                 </span>
 
                 <div class="download-options">
                   <!-- download link as button? -->
-                  <a class="button button--quarternary" href="../../download.html">
+                  <a class="button button--quarternary" href="../../download.html" data-ga-track-click="Download term data">
                     <i class="fa fa-download"></i>
                     Download <span class="large-screen-only">data</span>
                   </a>


### PR DESCRIPTION
Added tracking to interactive elements on term_table page: prev/next term links, term dropdown list, filter field, download button, section-toggles. 

Tracked elements are given the `data-ga-track-click` attribute.

Example: `<button data-ga-track-click='Download button'>…`

JS finds all elements with this attribute and attaches an event handler.

Closes #5420 