### PR TITLE
Pin to ruby 2.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby '2.0.0'
+
 gem 'dotenv'
 gem 'everypolitician-popolo', git: 'https://github.com/everypolitician/everypolitician-popolo', branch: 'master'
 gem 'iso_country_codes'


### PR DESCRIPTION
We've been seeing various problems with getting this running, so let's
revert to pinning at 2.0.0