### PR TITLE
Make Travis happier

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   Exclude: 
     - 'Vagrantfile'
+    - 'vendor/**/*'
 
 Style/AlignHash:
   EnforcedHashRocketStyle: table

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ script:
   - bundle exec rake test
   - bundle exec rake rubocop
   - scripts/release.sh
+sudo: false
 rvm:
   - 2.0.0
 notifications:


### PR DESCRIPTION
Travis is having problems as it runs rubocop against vendor/, with lots of
failures.

By default this is excluded, but because we're supplying our own Exclude
list, that clobbers the defaults, so we need to put it back explicitly.

Whilst we're here, also switch to container-based builds.