### PR TITLE
More obvious card filtering UI on term table pages

### DIFF
--- a/public/javascript/ep-card-filter.js
+++ b/public/javascript/ep-card-filter.js
@@ -99,10 +99,16 @@ var CardFilter = function(){
     $('[data-active-section]').attr('data-active-section', state.facet);
     $('.js-show-facet').val(state.facet);
 
-    if( typeof state.search === 'undefined' ){
+    if( state.facet === defaultState.facet ){
+      $('.js-show-facet').removeClass('js-filter-trigger--changed');
+    } else {
+      $('.js-show-facet').addClass('js-filter-trigger--changed');
+    }
+
+    if( state.search === defaultState.search ){
       $('.js-filter-target--hidden').removeClass('js-filter-target--hidden');
       $('.js-person-card__section--visible').removeClass('js-person-card__section--visible');
-      $('.js-filter-input').val('');
+      $('.js-filter-input').val('').removeClass('js-filter-trigger--changed');
 
     } else {
       $('.js-filter-target').each(function(){
@@ -126,7 +132,7 @@ var CardFilter = function(){
         });
       });
 
-      $('.js-filter-input').val(state.search);
+      $('.js-filter-input').val(state.search).addClass('js-filter-trigger--changed');
     }
 
     // Other scripts might want to do something special once they know

--- a/public/javascript/ep-card-filter.js
+++ b/public/javascript/ep-card-filter.js
@@ -97,8 +97,7 @@ var CardFilter = function(){
   this._updateUI = function(){
 
     $('[data-active-section]').attr('data-active-section', state.facet);
-    $('[data-section-toggle]').removeClass('section-toggle--selected');
-    $('[data-section-toggle="' + state.facet + '"]').addClass('section-toggle--selected');
+    $('.js-show-facet').val(state.facet);
 
     if( typeof state.search === 'undefined' ){
       $('.js-filter-target--hidden').removeClass('js-filter-target--hidden');
@@ -194,8 +193,8 @@ $(document).ready(function(){
       window.cards.saveState();
     });
 
-    $('[data-section-toggle]').on('click', function(){
-      var section = $(this).attr('data-section-toggle');
+    $('.js-show-facet').on('change', function(){
+      var section = $(this).val();
       window.cards.setFacet(section);
     });
   }

--- a/public/javascript/ep-card-filter.js
+++ b/public/javascript/ep-card-filter.js
@@ -230,6 +230,14 @@ $(document).ready(function(){
         $referenceCard.offset().top - referenceCardPixelsIntoViewport
       );
 
+      // Some mobile browsers (eg: iOS Safari) make it really difficult to
+      // unfocus a `select` element. This is a pain for us, because it means
+      // our "temporary" absolute positioning fix (.js-fixed-child--absolute)
+      // could remain in place much longer than required. Manually blurring
+      // the input once a selection has been made avoids this problem, and
+      // most users won't even noticed it's happened.
+      $(this).trigger('blur');
+
     });
   }
 

--- a/public/javascript/ep-card-filter.js
+++ b/public/javascript/ep-card-filter.js
@@ -200,8 +200,36 @@ $(document).ready(function(){
     });
 
     $('.js-show-facet').on('change', function(){
+      // Changing the facet has the potential to resize every card on the
+      // page. If cards above the current viewport are resized, you can easily
+      // lose your place in the list. So we're going to do some devious maths
+      // to pick a "reference card" (usually the top left visible card) and
+      // make sure that the viewport scrolls to maintain that reference card's
+      // position on screen, even if all the preceding cards change size.
+      var pixelsAboveViewport = $(window).scrollTop();
+      var referenceCardPixelsIntoViewport;
+      var $referenceCard;
+
+      // Find the reference card.
+      $('.person-card').each(function(){
+        var thisCardOffset = $(this).offset().top;
+        if ( thisCardOffset > pixelsAboveViewport ) {
+          $referenceCard = $(this);
+          referenceCardPixelsIntoViewport = thisCardOffset - pixelsAboveViewport;
+          return false; // break out of .each loop
+        }
+      });
+
+      // Actually set the visible facet on all the cards.
       var section = $(this).val();
       window.cards.setFacet(section);
+
+      // Now the facet has changed, adjust the window's scroll position so the
+      // reference card is back in the same visual location it was before.
+      $(window).scrollTop(
+        $referenceCard.offset().top - referenceCardPixelsIntoViewport
+      );
+
     });
   }
 

--- a/public/javascript/ep-card-filter.js
+++ b/public/javascript/ep-card-filter.js
@@ -188,7 +188,16 @@ $(document).ready(function(){
   if( $('.person-card').length ){
     window.cards = new CardFilter();
 
-    $('.js-filter-input').show().on('keyup', function(e) {
+    // Ideally, we only want to update the search state when the search input
+    // text has been changed, ignoring other keystrokes like Ctrl-A / Ctrl-C.
+    // Modern browsers and IE9+ support the `input` event. But some old
+    // browsers like IE8 don't. So we provide `keyup` as a fallback.
+    var filterInputEvent = 'input';
+    if(jQuery.support && jQuery.support.input === false){
+      filterInputEvent = 'keyup';
+    }
+
+    $('.js-filter-input').show().on(filterInputEvent, function(e) {
       // We pass `false` into setSearch to update the UI and internal state
       // without saving the state to the URL hash (since we don't want a new
       // history state for each letter the user types).

--- a/public/javascript/ep-card-filter.js
+++ b/public/javascript/ep-card-filter.js
@@ -202,6 +202,19 @@ $(document).ready(function(){
       // without saving the state to the URL hash (since we don't want a new
       // history state for each letter the user types).
       window.cards.setSearch( $(this).val(), false );
+
+      // If you are searching while the card-filters are attached to the top
+      // of the window, then it feels most natural for your position to be
+      // 'reset' back to the top of the grid of cards when you start searching.
+      // Otherwise, you could be scrolled partway down the page, begin a
+      // search, and before you know it, almost all the cards have disappeared,
+      // and you're stranded at the bottom of the page, with no cards visible.
+      $(window).scrollTop(
+        Math.min(
+          $(window).scrollTop(),
+          $(this).parents('.js-fixed-parent').offset().top
+        )
+      );
     }).on('blur', function(){
       // Now they have finished typing, we manually tell the cardFilter to
       // save its state to the URL hash, creating a new history entry.

--- a/public/javascript/main.js
+++ b/public/javascript/main.js
@@ -325,7 +325,7 @@
       }
     }
 
-    updateChildPositionAbsolute = function updateChildPositionAbsolute($parent, $child, $spacer){
+    var updateChildPositionAbsolute = function updateChildPositionAbsolute($parent, $child, $spacer){
       // Even though $child is positioned absolutely (relative to $parent)
       // we still need to detect whether the top of the $parent is above
       // the viewport.

--- a/public/javascript/main.js
+++ b/public/javascript/main.js
@@ -85,10 +85,6 @@
 
   };
 
-}(jQuery));
-
-(function ($) {
-
   $.fn.sortable = function() {
 
     // Call this on a <table> and it'll make all the columns sortable.
@@ -272,12 +268,82 @@
 
   };
 
+  $.fn.fixedChild = function() {
+
+    // Call this on an element and it'll stay attached
+    // to the top of the window when you scroll down.
+
+    var calculateSpacerDimensions = function calculateSpacerDimensions($el, $spacer){
+      $spacer.css({
+        width: '100%',
+        height: $el.outerHeight(true)
+      });
+    }
+
+    var updateChildPosition = function updateChildPosition($parent, $child, $spacer){
+      var bounds = $parent[0].getBoundingClientRect();
+
+      // First we detect whether *any* of the parent is visible,
+      // then, if it is, we position the child element so that it
+      // never extends outside of the parent bounds even when the
+      // visible portion of the parent is shorter than the child.
+
+      if(bounds.top <= 0 && bounds.bottom >= 0){
+        $spacer.show();
+        $child.addClass('js-fixed-child--fixed').css({
+          width: $spacer.outerWidth()
+        });
+
+        var childHeight = $child.outerHeight(true);
+        if(bounds.bottom < childHeight){
+          $child.css({
+            top: (childHeight - bounds.bottom) * -1
+          });
+        } else {
+          $child.css({
+            top: 0
+          });
+        }
+
+      } else {
+        $spacer.hide();
+        $child.removeClass('js-fixed-child--fixed').css({
+          width: ''
+        });
+      }
+    }
+
+    return this.each(function() {
+      var $el = $(this);
+      var $parent = $el.parent('.js-fixed-parent');
+      var $spacer = $('<div>').addClass('js-fixed-spacer');
+
+      $spacer.insertAfter($el);
+      $spacer.hide();
+
+      calculateSpacerDimensions($el, $spacer);
+      updateChildPosition($parent, $el, $spacer);
+
+      $(window).resize(function(){
+        calculateSpacerDimensions($el, $spacer);
+        updateChildPosition($parent, $el, $spacer);
+      });
+
+      $(window).scroll(function(){
+        updateChildPosition($parent, $el, $spacer);
+      });
+    });
+
+  };
+
 }(jQuery));
 
 $(function(){
   $('.js-fixed-thead').fixedThead();
 
   $('.js-sortable').sortable();
+
+  $('.js-fixed-child').fixedChild();
 
   $('.js-navigation-menu').on('change', function(event){
     var that = this;

--- a/views/sass/_components.scss
+++ b/views/sass/_components.scss
@@ -433,6 +433,14 @@ input[type].form-control {
   top: 0;
 }
 
+.js-fixed-child--absolute {
+  position: absolute;
+}
+
+.js-fixed-parent {
+  position: relative;
+}
+
 .js-sortable {
   th {
     cursor: pointer;

--- a/views/sass/_components.scss
+++ b/views/sass/_components.scss
@@ -513,6 +513,7 @@ input[type].form-control {
     select {
         margin-left: 0.3em;
         vertical-align: 0.1em;
+        max-width: 100%;
     }
 }
 

--- a/views/sass/_components.scss
+++ b/views/sass/_components.scss
@@ -189,10 +189,10 @@ p.lead {
 input[type].form-control {
     display: block;
     width: 100%;
-    height: (22px + 8px + 8px);
+    height: (22px + 6px + 6px);
     font-size: 16px;
     line-height: 22px;
-    padding: 8px 10px;
+    padding: 6px 10px;
     background-color: #fff;
     background-image: none;
     border: none;

--- a/views/sass/_components.scss
+++ b/views/sass/_components.scss
@@ -428,6 +428,11 @@ input[type].form-control {
   background-color: #fff;
 }
 
+.js-fixed-child--fixed {
+  position: fixed;
+  top: 0;
+}
+
 .js-sortable {
   th {
     cursor: pointer;

--- a/views/sass/_components.scss
+++ b/views/sass/_components.scss
@@ -185,6 +185,21 @@ p.lead {
     }
 }
 
+.form-control,
+input[type].form-control {
+    display: block;
+    width: 100%;
+    height: (22px + 8px + 8px);
+    font-size: 16px;
+    line-height: 22px;
+    padding: 8px 10px;
+    background-color: #fff;
+    background-image: none;
+    border: none;
+    border-radius: 3px;
+    box-shadow: 0 1px 0 rgba(0,0,0,0.2);
+}
+
 .page-section {
     padding: 2em 0;
 

--- a/views/sass/_custom.scss
+++ b/views/sass/_custom.scss
@@ -115,69 +115,6 @@
   }
 }
 
-.homepage-data-example__toggles {
-  margin-top: 1em;
-
-  .section-toggle {
-    color: $colour_links;
-    margin: 0 1em;
-    cursor: pointer;
-    padding-bottom: 0.2em;
-
-    &:hover,
-    &:active,
-    &:focus {
-      color:darken($colour_links, 10%);
-    }
-  }
-
-  .section-toggle:hover {
-    border-bottom: 2px solid transparentize($colour_links, 0.5);
-  }
-
-  .section-toggle--selected {
-    border-bottom: 2px solid transparentize($colour_links, 0.5);
-    cursor: default;
-  }
-}
-
-.term-membership-table__title {
-    position: relative;
-    padding: 1em 0;
-    text-align: center;
-
-    .download-options,
-    .person-card-filter {
-        margin-top: 1em;
-    }
-
-    @media (min-width: $medium_screen) {
-        .download-options,
-        .person-card-filter {
-            position: absolute;
-            margin-top: 0;
-        }
-
-        .download-options {
-            right: 0;
-            top: 0.5em;
-        }
-
-        .person-card-filter {
-            left: 0;
-            top: 1em;
-        }
-    }
-
-    h2 {
-        margin-bottom: 0;
-    }
-
-    .download-options__dropdown a {
-        width: 16em;
-    }
-}
-
 .party-groupings__title {
     font-size: 0.875em;
     margin-bottom: 1.5em;
@@ -430,25 +367,3 @@ table.definition {
   font-weight: bold;
   margin-right: 0.2em;
 }
-
-// Technically this should probably live in _person-cards.scss,
-// but right now the section-toggles are only displayed inside
-// the data-completeness component, so that’s why it’s here.
-.section-toggle {
-  cursor: pointer;
-  padding-bottom: 0.2em;
-}
-
-// Ideally we’d use inheritance to signal the active toggle(s)
-// but we can’t be sure that the person-cards and all their
-// associated toggles will be within the same `data-active-state`
-// element, so we just add a --selected class to toggles instead.
-.section-toggle:hover {
-  border-bottom: 2px solid rgba(255, 255, 255, 0.5);
-}
-
-.section-toggle--selected {
-  border-bottom: 2px solid rgba(255, 255, 255, 0.5);
-  cursor: default;
-}
-

--- a/views/sass/_custom.scss
+++ b/views/sass/_custom.scss
@@ -367,3 +367,9 @@ table.definition {
   font-weight: bold;
   margin-right: 0.2em;
 }
+
+// A link that appears inside an h2 on the term page
+.download-members {
+    font-size: 0.5em;
+    margin-left: 1em;
+}

--- a/views/sass/_custom.scss
+++ b/views/sass/_custom.scss
@@ -372,4 +372,9 @@ table.definition {
 .download-members {
     font-size: 0.5em;
     margin-left: 1em;
+
+    @media (max-width: 28em) {
+        display: block;
+        margin-left: 0;
+    }
 }

--- a/views/sass/_custom.scss
+++ b/views/sass/_custom.scss
@@ -378,3 +378,11 @@ table.definition {
         margin-left: 0;
     }
 }
+
+.source-credits a {
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    -ms-word-break: break-all;
+    word-break: break-all;
+    word-break: break-word;
+}

--- a/views/sass/_mixins.scss
+++ b/views/sass/_mixins.scss
@@ -62,7 +62,7 @@
   -moz-box-wrap: $wrap;
   -webkit-box-wrap: $wrap;
   -webkit-flex-wrap: $wrap;
-  -ms-flexbox-wrap: $wrap;
+  -ms-flex-wrap: $wrap;
   flex-wrap: $wrap;
 }
 

--- a/views/sass/_person-cards.scss
+++ b/views/sass/_person-cards.scss
@@ -110,25 +110,6 @@ $person_card_sections: (
   display: block !important;
 }
 
-.person-card-filter {
-  display: block;
-
-  .no-js & {
-    display: none;
-  }
-
-  label {
-    color: $colour_mid_grey;
-    margin-right: 0.5em;
-  }
-
-  @media (min-width: $large_screen) {
-    input {
-      width: 16em;
-    }
-  }
-}
-
 .js-filter-target--hidden {
   display: none;
 }

--- a/views/sass/_person-cards.scss
+++ b/views/sass/_person-cards.scss
@@ -113,3 +113,59 @@ $person_card_sections: (
 .js-filter-target--hidden {
   display: none;
 }
+
+.card-filters {
+    border-top: 1px solid $colour_light_grey;
+    border-bottom: 1px solid $colour_light_grey;
+
+    @media (min-width: $medium_screen) {
+        padding: 1em 0;
+        text-align: center;
+    }
+}
+
+.card-filters__filter {
+    margin: 1em 0;
+
+    // Optional flexbox layout to wrap label and input onto same line
+    @include flexbox();
+    @include flex-align(baseline);
+
+    label {
+        display: block;
+        font-size: 0.8em;
+        margin-bottom: 0.3em;
+
+        // These styles should still look ok, even without flexbox support
+        // so no need for body.flexwrap check.
+        padding-right: 1em;
+        white-space: nowrap;
+    }
+
+    @media (min-width: $medium_screen) {
+        // Flexbox begone. Arrange the filters on single, centred line.
+        display: inline;
+        display: inline-block;
+        margin: 0;
+
+        & + & {
+            margin-left: 1.5em;
+        }
+
+        label, .form-control, input[type].form-control {
+            display: inline;
+            display: inline-block;
+            width: auto;
+        }
+
+        .form-control, input[type].form-control {
+            min-width: 11em; // Enough space for some text, but not too wide
+        }
+
+        label {
+            font-size: 0.9em;
+            margin-bottom: 0;
+            padding-right: 0.5em;
+        }
+    }
+}

--- a/views/sass/_person-cards.scss
+++ b/views/sass/_person-cards.scss
@@ -142,6 +142,12 @@ $person_card_sections: (
         white-space: nowrap;
     }
 
+    .js-filter-trigger--changed,
+    input[type].js-filter-trigger--changed {
+        background-color: $colour_pale_yellow;
+        border: 2px solid $colour_green;
+    }
+
     @media (min-width: $medium_screen) {
         // Flexbox begone. Arrange the filters on single, centred line.
         display: inline;

--- a/views/sass/_person-cards.scss
+++ b/views/sass/_person-cards.scss
@@ -122,6 +122,15 @@ $person_card_sections: (
         padding: 1em 0;
         text-align: center;
     }
+
+    .js-fixed-child--fixed & {
+        background-color: transparentize($colour_off_white, 0.1);
+        border-top-color: transparentize($colour_off_white, 0.1);;
+        margin: 0 -1em;
+        padding-left: 1em;
+        padding-right: 1em;
+        box-shadow: 0 1em 1em -1em rgba(0,0,0,0.2);
+    }
 }
 
 .card-filters__filter {
@@ -136,10 +145,18 @@ $person_card_sections: (
         font-size: 0.8em;
         margin-bottom: 0.3em;
 
+        // Don't grow, don't shrink
+        @include flex(0 0 auto);
+
         // These styles should still look ok, even without flexbox support
         // so no need for body.flexwrap check.
         padding-right: 1em;
         white-space: nowrap;
+    }
+
+    label + * {
+        // Grow but don't shrink
+        @include flex(1 0 auto);
     }
 
     .js-filter-trigger--changed,
@@ -158,13 +175,21 @@ $person_card_sections: (
             margin-left: 1.5em;
         }
 
-        label, .form-control, input[type].form-control {
+        label,
+        label + * {
+            @include flex(none);
+        }
+
+        label,
+        .form-control,
+        input[type].form-control {
             display: inline;
             display: inline-block;
             width: auto;
         }
 
-        .form-control, input[type].form-control {
+        .form-control,
+        input[type].form-control {
             min-width: 11em; // Enough space for some text, but not too wide
         }
 

--- a/views/sass/_typography.scss
+++ b/views/sass/_typography.scss
@@ -152,8 +152,7 @@ input[type=search],
 input[type=time],
 input[type=datalist],
 input[type=date],
-textarea,
-.standard-input {
+textarea {
     @include vendor-prefix(border-radius, $border_radius);
     border: 1px solid $colour_borders;
     max-width: 100%;

--- a/views/sass/_variables.scss
+++ b/views/sass/_variables.scss
@@ -18,6 +18,7 @@ $colour_grey: #CCCCCC;
 $colour_mid_grey: #999999;
 $colour_dark_grey: #666666;
 $colour_black: #333333;
+$colour_pale_yellow: #fffadd;
 
 $colour_background: $colour_white;
 $colour_links: $colour_red;

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -64,7 +64,7 @@
     <div class="page-section page-section--green">
         <div class="container text-center">
             <h2>What’s in this dataset?</h2>
-            <p>As much as we know. Click one of the categories to get a taste of the information we have so far.</p>
+            <p>As much as we know. Here’s a taste of the information we have so far.</p>
         </div>
         <div class="data-completeness-wrapper">
             <div class="container">

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -70,28 +70,20 @@
             <div class="container">
                 <div class="grid-list grid-list--vertically-center grid-list--narrow-columns">
                     <div class="data-completeness">
-                        <span class="section-toggle section-toggle--selected" data-section-toggle="bio" data-ga-track-click="Section toggle: bio">
-                            <span class="data-completeness__label">Biographical</span>
-                            <span class="data-completeness__percentage"><%= @page.percentages.bio %>%</span>
-                        </span>
+                        <span class="data-completeness__label">Biographical</span>
+                        <span class="data-completeness__percentage"><%= @page.percentages.bio %>%</span>
                     </div>
                     <div class="data-completeness">
-                        <span class="section-toggle" data-section-toggle="social" data-ga-track-click="Section toggle: social">
-                            <span class="data-completeness__label">Social links</span>
-                            <span class="data-completeness__percentage"><%= @page.percentages.social %>%</span>
-                        </span>
+                        <span class="data-completeness__label">Social links</span>
+                        <span class="data-completeness__percentage"><%= @page.percentages.social %>%</span>
                     </div>
                     <div class="data-completeness">
-                        <span class="section-toggle" data-section-toggle="contacts" data-ga-track-click="Section toggle: contacts">
-                            <span class="data-completeness__label">Contact details</span>
-                            <span class="data-completeness__percentage"><%= @page.percentages.contacts %>%</span>
-                        </span>
+                        <span class="data-completeness__label">Contact details</span>
+                        <span class="data-completeness__percentage"><%= @page.percentages.contacts %>%</span>
                     </div>
                     <div class="data-completeness">
-                        <span class="section-toggle" data-section-toggle="identifiers" data-ga-track-click="Section toggle: identifiers">
-                            <span class="data-completeness__label">Identifiers</span>
-                            <span class="data-completeness__percentage"><%= @page.percentages.identifiers %>%</span>
-                        </span>
+                        <span class="data-completeness__label">Identifiers</span>
+                        <span class="data-completeness__percentage"><%= @page.percentages.identifiers %>%</span>
                     </div>
                 </div>
             </div>
@@ -110,11 +102,6 @@
             <div class="term-membership-table__title">
                 <h2>Members</h2>
 
-                <span class="person-card-filter">
-                    <label for="filter-input" class="fa fa-search"></label>
-                    <input type="text" class="js-filter-input" id="filter-input" placeholder="Search by name, place, etc…" data-ga-track-change="Filter field">
-                </span>
-
                 <div class="download-options">
                   <!-- download link as button? -->
                   <a class="button button--quarternary" href="/<%= @page.country.slug.downcase %>/<%= @page.house.slug.downcase %>/download.html" data-ga-track-click="Download term data">
@@ -122,6 +109,22 @@
                     Download <span class="large-screen-only">data</span>
                   </a>
                 </div>
+            </div>
+
+            <div class="card-filters">
+                <p class="card-filters__filter">
+                    <label for="filter-input">Search for:</label>
+                    <input type="text" class="js-filter-input" id="filter-input" placeholder="Name, place, etc…" data-ga-track-change="Filter field">
+                </p>
+                <p class="card-filters__filter">
+                    <label for="show-facet">Show details:</label>
+                    <select class="js-show-facet" id="show-facet">
+                        <option value="bio">Biographical</option>
+                        <option value="social">Social links</option>
+                        <option value="contacts">Contact details</option>
+                        <option value="identifiers">Identifiers</option>
+                    </select>
+                </p>
             </div>
 
             <div class="grid-list" data-active-section="bio">

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -114,11 +114,11 @@
             <div class="card-filters">
                 <p class="card-filters__filter">
                     <label for="filter-input">Search for:</label>
-                    <input type="text" class="js-filter-input" id="filter-input" placeholder="Name, place, etc…" data-ga-track-change="Filter field">
+                    <input type="text" class="form-control js-filter-input" id="filter-input" placeholder="Name, place, etc…" data-ga-track-change="Filter field">
                 </p>
                 <p class="card-filters__filter">
                     <label for="show-facet">Show details:</label>
-                    <select class="js-show-facet" id="show-facet">
+                    <select class="js-show-facet form-control" id="show-facet">
                         <option value="bio">Biographical</option>
                         <option value="social">Social links</option>
                         <option value="contacts">Contact details</option>

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -70,20 +70,28 @@
             <div class="container">
                 <div class="grid-list grid-list--vertically-center grid-list--narrow-columns">
                     <div class="data-completeness">
-                        <span class="data-completeness__label">Biographical</span>
-                        <span class="data-completeness__percentage"><%= @page.percentages.bio %>%</span>
+                        <span class="section-toggle section-toggle--selected" data-section-toggle="bio" data-ga-track-click="Section toggle: bio">
+                            <span class="data-completeness__label">Biographical</span>
+                            <span class="data-completeness__percentage"><%= @page.percentages.bio %>%</span>
+                        </span>
                     </div>
                     <div class="data-completeness">
-                        <span class="data-completeness__label">Social links</span>
-                        <span class="data-completeness__percentage"><%= @page.percentages.social %>%</span>
+                        <span class="section-toggle" data-section-toggle="social" data-ga-track-click="Section toggle: social">
+                            <span class="data-completeness__label">Social links</span>
+                            <span class="data-completeness__percentage"><%= @page.percentages.social %>%</span>
+                        </span>
                     </div>
                     <div class="data-completeness">
-                        <span class="data-completeness__label">Contact details</span>
-                        <span class="data-completeness__percentage"><%= @page.percentages.contacts %>%</span>
+                        <span class="section-toggle" data-section-toggle="contacts" data-ga-track-click="Section toggle: contacts">
+                            <span class="data-completeness__label">Contact details</span>
+                            <span class="data-completeness__percentage"><%= @page.percentages.contacts %>%</span>
+                        </span>
                     </div>
                     <div class="data-completeness">
-                        <span class="data-completeness__label">Identifiers</span>
-                        <span class="data-completeness__percentage"><%= @page.percentages.identifiers %>%</span>
+                        <span class="section-toggle" data-section-toggle="identifiers" data-ga-track-click="Section toggle: identifiers">
+                            <span class="data-completeness__label">Identifiers</span>
+                            <span class="data-completeness__percentage"><%= @page.percentages.identifiers %>%</span>
+                        </span>
                     </div>
                 </div>
             </div>
@@ -106,84 +114,94 @@
                 </a>
             </h2>
 
-            <div class="card-filters">
-                <p class="card-filters__filter">
-                    <label for="filter-input">Search for:</label>
-                    <input type="text" class="form-control js-filter-input" id="filter-input" placeholder="Name, place, etc…" data-ga-track-change="Filter field">
-                </p>
-                <p class="card-filters__filter">
-                    <label for="show-facet">Show details:</label>
-                    <select class="js-show-facet form-control" id="show-facet">
-                        <option value="bio">Biographical</option>
-                        <option value="social">Social links</option>
-                        <option value="contacts">Contact details</option>
-                        <option value="identifiers">Identifiers</option>
-                    </select>
-                </p>
-            </div>
+            <div class="js-fixed-parent">
 
-            <div class="grid-list" data-active-section="bio">
-
-              <% @page.people.each do |person| %>
-                <div class="js-filter-target">
-                    <div class="person-card" id="mem-<%= person.id %>">
-
-                        <div class="person-card__primary">
-
-                          <%# If person has an image, prepare a lazy-loaded version
-                              (which is display:none until JavaScript unhides it)
-                              and a fallback for non-javascript users, otherwise
-                              just show a generic placeholder image.  %>
-                          <% if person.image %>
-                            <img src="/images/person-placeholder-108px.png"
-                                 data-src="<%= person.proxy_image %>"
-                                 style="display: none"
-                                 class="person-card__image">
-                            <noscript><img src="<%= person.proxy_image %>" class="person-card__image"></noscript>
-                          <% else %>
-                            <img src="/images/person-placeholder-108px.png" class="person-card__image">
-                          <% end %>
-
-                            <h3 class="person-card__name"><%= person.name %></h3>
-
-                          <% person.memberships.each do |mem| %>
-                            <p class="person-card__politics">
-
-                              <%= [mem.group, mem.area].reject(&:nil?).map(&:name).join(" — ") %>
-
-                              <% if mem.start_date && mem.end_date %>
-                                <span class="person-card__politics__date">(<%= mem.start_date.to_s %> to <%= mem.end_date.to_s %>)</span>
-                              <% elsif mem.start_date %>
-                                <span class="person-card__politics__date">(from <%= mem.start_date.to_s %>)</span>
-                              <% elsif mem.end_date %>
-                                <span class="person-card__politics__date">(until <%= mem.end_date.to_s %>)</span>
-                              <% end %>
-                            </p>
-                          <% end %>
-                        </div>
-
-                        <% %i(bio social contacts identifiers).select { |s| person.send(s).any? }.each do |section| %>
-                          <div class="person-card__section person-card__section--<%= section %>">
-                            <table>
-                              <% person.send(section).each do |entry| %>
-                                <tr title="<%= entry.value %>">
-                                    <th><%= entry.type %></th>
-                                    <td>
-                                      <% if entry.link %>
-                                        <a href="<%= entry.link %>"><%= entry.value %></a>
-                                      <% else %>
-                                        <%= entry.value %>
-                                      <% end %>
-                                    </td>
-                                </tr>
-                              <% end %>
-                            </table>
-                          </div>
-                        <% end %>
-
+                <div class="js-fixed-child">
+                    <div class="card-filters">
+                        <p class="card-filters__filter">
+                            <label for="filter-input">Search for:</label>
+                            <span>
+                                <input type="text" class="form-control js-filter-input" id="filter-input" placeholder="Name, place, etc…" data-ga-track-change="Filter field">
+                            </span>
+                        </p>
+                        <p class="card-filters__filter">
+                            <label for="show-facet">Show details:</label>
+                            <span>
+                                <select class="js-show-facet form-control" id="show-facet">
+                                    <option value="bio">Biographical</option>
+                                    <option value="social">Social links</option>
+                                    <option value="contacts">Contact details</option>
+                                    <option value="identifiers">Identifiers</option>
+                                </select>
+                            </span>
+                        </p>
                     </div>
                 </div>
-              <% end %>
+
+                <div class="grid-list" data-active-section="bio">
+
+                  <% @page.people.each do |person| %>
+                    <div class="js-filter-target">
+                        <div class="person-card" id="mem-<%= person.id %>">
+
+                            <div class="person-card__primary">
+
+                              <%# If person has an image, prepare a lazy-loaded version
+                                  (which is display:none until JavaScript unhides it)
+                                  and a fallback for non-javascript users, otherwise
+                                  just show a generic placeholder image.  %>
+                              <% if person.image %>
+                                <img src="/images/person-placeholder-108px.png"
+                                     data-src="<%= person.proxy_image %>"
+                                     style="display: none"
+                                     class="person-card__image">
+                                <noscript><img src="<%= person.proxy_image %>" class="person-card__image"></noscript>
+                              <% else %>
+                                <img src="/images/person-placeholder-108px.png" class="person-card__image">
+                              <% end %>
+
+                                <h3 class="person-card__name"><%= person.name %></h3>
+
+                              <% person.memberships.each do |mem| %>
+                                <p class="person-card__politics">
+
+                                  <%= [mem.group, mem.area].reject(&:nil?).map(&:name).join(" — ") %>
+
+                                  <% if mem.start_date && mem.end_date %>
+                                    <span class="person-card__politics__date">(<%= mem.start_date.to_s %> to <%= mem.end_date.to_s %>)</span>
+                                  <% elsif mem.start_date %>
+                                    <span class="person-card__politics__date">(from <%= mem.start_date.to_s %>)</span>
+                                  <% elsif mem.end_date %>
+                                    <span class="person-card__politics__date">(until <%= mem.end_date.to_s %>)</span>
+                                  <% end %>
+                                </p>
+                              <% end %>
+                            </div>
+
+                            <% %i(bio social contacts identifiers).select { |s| person.send(s).any? }.each do |section| %>
+                              <div class="person-card__section person-card__section--<%= section %>">
+                                <table>
+                                  <% person.send(section).each do |entry| %>
+                                    <tr title="<%= entry.value %>">
+                                        <th><%= entry.type %></th>
+                                        <td>
+                                          <% if entry.link %>
+                                            <a href="<%= entry.link %>"><%= entry.value %></a>
+                                          <% else %>
+                                            <%= entry.value %>
+                                          <% end %>
+                                        </td>
+                                    </tr>
+                                  <% end %>
+                                </table>
+                              </div>
+                            <% end %>
+
+                        </div>
+                    </div>
+                  <% end %>
+
+                </div>
 
             </div>
 

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -99,17 +99,12 @@
     <div class="page-section page-section--grey">
         <div class="container">
 
-            <div class="term-membership-table__title">
-                <h2>Members</h2>
-
-                <div class="download-options">
-                  <!-- download link as button? -->
-                  <a class="button button--quarternary" href="/<%= @page.country.slug.downcase %>/<%= @page.house.slug.downcase %>/download.html" data-ga-track-click="Download term data">
-                    <i class="fa fa-download"></i>
-                    Download <span class="large-screen-only">data</span>
-                  </a>
-                </div>
-            </div>
+            <h2 class="text-center">
+                Members
+                <a href="/<%= @page.country.slug.downcase %>/<%= @page.house.slug.downcase %>/download.html" class="download-members" data-ga-track-click="Download term data">
+                    <i class="fa fa-download"></i> Download data
+                </a>
+            </h2>
 
             <div class="card-filters">
                 <p class="card-filters__filter">


### PR DESCRIPTION
Fixes #6273 by introducing a new dropdown menu that you click to switch the visible "section" of each person-card (eg: bio, contacts, social).

Fixes #5408 by attaching the new filter bar to the top of the window when scrolling.

There's space to add a "Group:" dropdown (ie: a reworking of #5349) but I've left that to be done in a different PR.

Screenshots don't really do the scrolling awesomeness justice, but we can try:

### Desktop width, no filters active

![screen shot 2016-08-10 at 14 44 09](https://cloud.githubusercontent.com/assets/739624/17556007/a95bd1ba-5f09-11e6-82b5-30af684e0316.png)

### Desktop width, filtered by search term

![screen shot 2016-08-10 at 14 50 44](https://cloud.githubusercontent.com/assets/739624/17556051/deeb8b7c-5f09-11e6-8e0b-6ed2d18bc425.png)

### Narrow device, filtered by search term, and also scrolled down to show how the filters attach to the top of the screen

(Sorry, arrows missing on the dropdown because Chrome device imitation is rubbish – they're there on the real devices)

![screen shot 2016-08-10 at 14 46 06](https://cloud.githubusercontent.com/assets/739624/17556070/f29596c2-5f09-11e6-9b60-778b93549d1e.png)

All tested and working in all the major browsers. Degrades nicely in IE8.