### PR TITLE
add fragment id (#) to download button href, targeting specific legislature

### DIFF
--- a/views/country.erb
+++ b/views/country.erb
@@ -13,7 +13,7 @@
         <div class="country__legislature__header">
           <h3><%= house[:name] %></h3>
           <!-- download link as button? -->
-          <a class="button button--quarternary" href="download.html">
+          <a class="button button--quarternary" href="download.html#legislature-<%= house[:slug].downcase %>">
             <i class="fa fa-download"></i>
             Download <span class="large-screen-only">data</span>
           </a>

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -117,7 +117,7 @@
 
                 <div class="download-options">
                   <!-- download link as button? -->
-                  <a class="button button--quarternary" href="../../download.html" data-ga-track-click="Download term data">
+                  <a class="button button--quarternary" href="../../download.html#legislature-<%= @house[:slug].downcase %>" data-ga-track-click="Download term data">
                     <i class="fa fa-download"></i>
                     Download <span class="large-screen-only">data</span>
                   </a>


### PR DESCRIPTION
Adds anchor tags to download buttons to ensure that when the user lands on the download page, they do so at the correct legislature (which matters in bicameral systems, that is, if there is more than one).

Legislature-specific download buttons occur here:

* each country page (where available terms are _listed_)
* each term table page

Closes #14423 (which is a distillation of the first part of #11911).

Note the targets for these anchor tags (`id`) are already in place, so adding the # to the URL is sufficient for this to work.

