### PR TITLE
Split the exhaustive web tests to a separate rake task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 cache: bundler
 script:
-  - bundle exec rake test
+  - bundle exec rake test:all
   - bundle exec rake rubocop
   - scripts/release.sh
 sudo: false

--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -2,7 +2,21 @@ require 'rake/testtask'
 require 'rubocop/rake_task'
 
 Rake::TestTask.new do |t|
-  t.pattern = 't/**/*.rb'
+  t.warning = true
+  t.test_files = FileList['t/page/*.rb']
+end
+
+Rake::TestTask.new do |t|
+  t.name = 'test:web'
+  t.warning = false
+  t.verbose = true
+  t.test_files = FileList['t/web/*.rb']
+end
+
+Rake::TestTask.new do |t|
+  t.name = 'test:all'
+  t.verbose = true
+  t.test_files = FileList['t/**/*.rb']
 end
 
 RuboCop::RakeTask.new

--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -3,6 +3,7 @@ require 'rubocop/rake_task'
 
 Rake::TestTask.new do |t|
   t.warning = true
+  t.description = 'Run "Page" tests'
   t.test_files = FileList['t/page/*.rb']
 end
 
@@ -10,12 +11,14 @@ Rake::TestTask.new do |t|
   t.name = 'test:web'
   t.warning = false
   t.verbose = true
+  t.description = 'Run "Web" tests (slow)'
   t.test_files = FileList['t/web/*.rb']
 end
 
 Rake::TestTask.new do |t|
   t.name = 'test:all'
   t.verbose = true
+  t.description = 'Run all tests (slow)'
   t.test_files = FileList['t/**/*.rb']
 end
 


### PR DESCRIPTION
Running the entire test suite takes forever because it has to make sure
that every country works as a fully rendered page.

If we split those out to a separate `rake test:web` target, and ensure that
`rake test:all` runs all of them, then we can still run the full test suite
when needed, but the day-to-day run of the Page tests can be lightning
fast.