### PR TITLE
Extract country page class

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -59,10 +59,10 @@ get '/countries.html' do
 end
 
 get '/:country/' do |country|
-  if @country = ALL_COUNTRIES.find { |c| c[:url] == country }
-    @page_title = "EveryPolitician: #{@country[:name]}"
+  @page = Page::Country.new(country, ALL_COUNTRIES, WORLD)
+  if @page.country
     erb :country
-  elsif @missing = WORLD[country.to_sym]
+  elsif @page.missing
     erb :country_missing
   else
     halt(404)

--- a/lib/page/country.rb
+++ b/lib/page/country.rb
@@ -1,0 +1,13 @@
+module Page
+  class Country
+    attr_reader :country, :title, :missing
+    def initialize(country, all_countries, world)
+      @country = all_countries.find { |c| c[:url] == country }
+      if @country
+        @title = "EveryPolitician: #{@country[:name]}"
+      else
+        @missing = world[country.to_sym]
+      end
+    end
+  end
+end

--- a/t/page/country.rb
+++ b/t/page/country.rb
@@ -1,0 +1,33 @@
+require 'minitest/autorun'
+require_relative '../../lib/page/country'
+require 'pry'
+
+describe 'Country' do
+  it 'detects that a country exists' do
+    page = Page::Country.new('abkhazia', all_countries, world)
+    refute_nil page.country
+  end
+
+  it 'sets the title of the page if the country exists' do
+    page = Page::Country.new('abkhazia', all_countries, world)
+    page.title.must_include 'Abkhazia'
+  end
+
+  it 'detects that a country is missing' do
+    page = Page::Country.new('eritrea', all_countries, world)
+    refute_nil page.missing
+  end
+
+  def all_countries
+    [
+      {
+        "name": 'Abkhazia',
+        "url":  'abkhazia',
+      },
+    ]
+  end
+
+  def world
+    { "eritrea": {} }
+  end
+end

--- a/t/page/country.rb
+++ b/t/page/country.rb
@@ -3,6 +3,17 @@ require_relative '../../lib/page/country'
 require 'pry'
 
 describe 'Country' do
+  let(:all_countries) do
+    [
+      {
+        name: 'Abkhazia',
+        url:  'abkhazia',
+      },
+    ]
+  end
+
+  let(:world) { { eritrea: {} } }
+
   it 'detects that a country exists' do
     page = Page::Country.new('abkhazia', all_countries, world)
     refute_nil page.country
@@ -16,18 +27,5 @@ describe 'Country' do
   it 'detects that a country is missing' do
     page = Page::Country.new('eritrea', all_countries, world)
     refute_nil page.missing
-  end
-
-  def all_countries
-    [
-      {
-        "name": 'Abkhazia',
-        "url":  'abkhazia',
-      },
-    ]
-  end
-
-  def world
-    { "eritrea": {} }
   end
 end

--- a/views/country.erb
+++ b/views/country.erb
@@ -1,6 +1,6 @@
 <div class="page-section page-section--grey text-center">
   <div class="container">
-    <h3>We’re cataloguing every politician in <%= @country[:name] %>.</h3>
+    <h3>We’re cataloguing every politician in <%= @page.country[:name] %>.</h3>
     <p>We currently have information for…</p>
   </div>
 </div>
@@ -8,7 +8,7 @@
 <div class="page-section">
   <div class="container">
 
-    <% @country[:legislatures].each do |house| %>
+    <% @page.country[:legislatures].each do |house| %>
       <div class="country__legislature">
         <div class="country__legislature__header">
           <h3><%= house[:name] %></h3>
@@ -21,7 +21,7 @@
         <ul class="grid-list grid-list--vertically-center" id="terms-<%= house[:slug].downcase %>">
           <% house[:legislative_periods].each do |t| %>
             <li>
-              <a class="avatar-unit" href="<%= term_table_url(@country, house, t) %>">
+              <a class="avatar-unit" href="<%= term_table_url(@page.country, house, t) %>">
                 <span class="avatar"><i class="fa fa-university"></i></span>
                 <h3><%= t[:name] %></h3>
                 <% unless t[:start_date].to_s.empty? and t[:end_date].to_s.empty? %>
@@ -45,7 +45,7 @@
   <div class="container">
 
     <div class="gender-balance-promo">
-      <h3>Help us collect gender information for <%= @country[:name] %> by playing our fiendishly addictive online game, Gender Balance!</h3>
+      <h3>Help us collect gender information for <%= @page.country[:name] %> by playing our fiendishly addictive online game, Gender Balance!</h3>
       <p>Swipe your way through politicians in a flash, and work your way up our leaderboard.</p>
       <p><a href="http://gender-balance.org" class="button button--primary">Play Gender Balance now</a></p>
 

--- a/views/country_missing.erb
+++ b/views/country_missing.erb
@@ -1,6 +1,6 @@
 <div class="container" id="country_missing">
   <div class="page-section">
     <h2>Sorry!</h2>
-    <p>We haven’t got data for <%= @missing[:displayName] %> yet. Here’s how to <a href="http://docs.everypolitician.org/contribute.html">help us find it</a>.</p>
+    <p>We haven’t got data for <%= @page.missing[:displayName] %> yet. Here’s how to <a href="http://docs.everypolitician.org/contribute.html">help us find it</a>.</p>
   </div>
 </div>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -1,3 +1,6 @@
+<% @page_title = @page.title   if (@page and @page.respond_to? :title) %>
+<% @country    = @page.country if (@page and @page.respond_to? :country) %>
+
 <!DOCTYPE html>
 <html class="no-js">
 <head>


### PR DESCRIPTION
This pull request extracts part of the logic under the `/:country/` route into its own class `Country`.

* The relevant templates were updated to use the member fields of the class instance.

* The main layout template had to be updated since it was using `@page_title`, which we don't need to pass to the template as the `Country` class has its own `title` member. So now, if we pass a `@page` instance and the `title` is available, we use it. The `@page_title` is used to render the title of the page in the browser.

* Since we also don't have a `@country` when we are passing a `@page`, the same had to be done so that the main template layout uses the `country` field of the `@page` if it is available. The `@country` is used in the main layout template to render the heading of the page in the page's body.
