### PR TITLE
Split out the separate routes to /country

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -59,14 +59,14 @@ get '/countries.html' do
 end
 
 get '/:country/' do |country|
-  if @country = ALL_COUNTRIES.find { |c| c[:url] == country }
-    @page_title = "EveryPolitician: #{@country[:name]}"
-    erb :country
-  elsif @missing = WORLD[country.to_sym]
-    erb :country_missing
-  else
-    halt(404)
-  end
+  @country = ALL_COUNTRIES.find { |c| c[:url] == country } || pass
+  @page_title = "EveryPolitician: #{@country[:name]}"
+  erb :country
+end
+
+get '/:country/' do |country|
+  @missing = WORLD[country.to_sym] || halt(404)
+  erb :country_missing
 end
 
 get '/:country/:house/wikidata' do |country, house|


### PR DESCRIPTION
Rather than rolling our own logic for which type of page to display for
/country, depending on whether it's a country we have data for; know about
but have no data; or don't know about — simply let Sinatra take care of
those by supplying multiple routes.

This should help make https://github.com/everypolitician/viewer-sinatra/pull/14613 clearer and cleaner.