### PR TITLE
Extract a Country page class

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -58,7 +58,7 @@ get '/countries.html' do
 end
 
 get '/:country/' do |country|
-  @page = Page::Country.new(country, ALL_COUNTRIES)
+  @page = Page::Country.new(country)
   pass unless @page.country
   erb :country
 end

--- a/app.rb
+++ b/app.rb
@@ -58,7 +58,8 @@ get '/countries.html' do
 end
 
 get '/:country/' do |country|
-  @page = Page::Country.new(country)
+  SHA   = cjson.split('/')[-2]
+  @page = Page::Country.new(country, SHA)
   pass unless @page.country
   erb :country
 end

--- a/app.rb
+++ b/app.rb
@@ -58,8 +58,8 @@ get '/countries.html' do
 end
 
 get '/:country/' do |country|
-  @country = ALL_COUNTRIES.find { |c| c[:url] == country } || pass
-  @page_title = "EveryPolitician: #{@country[:name]}"
+  @page = Page::Country.new(country, ALL_COUNTRIES)
+  pass unless @page.country
   erb :country
 end
 

--- a/app.rb
+++ b/app.rb
@@ -58,8 +58,10 @@ get '/countries.html' do
 end
 
 get '/:country/' do |country|
-  SHA   = cjson.split('/')[-2]
-  @page = Page::Country.new(country, SHA)
+  @page = Page::Country.new(
+    country: country,
+    index:   EveryPolitician::Index.new(index_url: cjson)
+  )
   pass unless @page.country
   erb :country
 end

--- a/lib/page/country.rb
+++ b/lib/page/country.rb
@@ -1,22 +1,23 @@
+# frozen_string_literal: true
 require 'everypolitician'
 
 module Page
   class Country
-    def initialize(slug, ref = 'master')
-      @slug = slug
-      @ref  = ref
+    def initialize(country:, index:)
+      @slug  = country
+      @index = index
     end
 
     def country
-      @country ||= EveryPolitician::Index.new(ref).country(slug)
+      index.country(slug)
     end
 
     def title
-      "EveryPolitician: #{country.name}" if country
+      "EveryPolitician: #{country.name}"
     end
 
     private
 
-    attr_reader :slug, :ref
+    attr_reader :slug, :index
   end
 end

--- a/lib/page/country.rb
+++ b/lib/page/country.rb
@@ -2,10 +2,14 @@ require 'everypolitician'
 
 module Page
   class Country
-    attr_reader :country, :title
-    def initialize(country)
-      @country = EveryPolitician.country(country)
-      @title   = "EveryPolitician: #{@country[:name]}" if @country
+    attr_reader :title
+    def initialize(slug)
+      @slug    = slug
+      @title   = "EveryPolitician: #{country[:name]}" if country
+    end
+
+    def country
+      EveryPolitician.country(@slug)
     end
   end
 end

--- a/lib/page/country.rb
+++ b/lib/page/country.rb
@@ -1,9 +1,11 @@
+require 'everypolitician'
+
 module Page
   class Country
     attr_reader :country, :title
-    def initialize(country, all_countries)
-      @country = all_countries.find { |c| c[:url] == country }
-      @title = "EveryPolitician: #{@country[:name]}" if @country
+    def initialize(country)
+      @country = EveryPolitician.country(country)
+      @title   = "EveryPolitician: #{@country[:name]}" if @country
     end
   end
 end

--- a/lib/page/country.rb
+++ b/lib/page/country.rb
@@ -7,11 +7,15 @@ module Page
     end
 
     def country
-      EveryPolitician.country(@slug)
+      @country ||= EveryPolitician.country(slug)
     end
 
     def title
       "EveryPolitician: #{country[:name]}" if country
     end
+
+    private
+
+    attr_reader :slug
   end
 end

--- a/lib/page/country.rb
+++ b/lib/page/country.rb
@@ -2,20 +2,21 @@ require 'everypolitician'
 
 module Page
   class Country
-    def initialize(slug)
+    def initialize(slug, ref = 'master')
       @slug = slug
+      @ref  = ref
     end
 
     def country
-      @country ||= EveryPolitician.country(slug)
+      @country ||= EveryPolitician::Index.new(ref).country(slug)
     end
 
     def title
-      "EveryPolitician: #{country[:name]}" if country
+      "EveryPolitician: #{country.name}" if country
     end
 
     private
 
-    attr_reader :slug
+    attr_reader :slug, :ref
   end
 end

--- a/lib/page/country.rb
+++ b/lib/page/country.rb
@@ -2,14 +2,16 @@ require 'everypolitician'
 
 module Page
   class Country
-    attr_reader :title
     def initialize(slug)
-      @slug    = slug
-      @title   = "EveryPolitician: #{country[:name]}" if country
+      @slug = slug
     end
 
     def country
       EveryPolitician.country(@slug)
+    end
+
+    def title
+      "EveryPolitician: #{country[:name]}" if country
     end
   end
 end

--- a/lib/page/country.rb
+++ b/lib/page/country.rb
@@ -1,0 +1,9 @@
+module Page
+  class Country
+    attr_reader :country, :title
+    def initialize(country, all_countries)
+      @country = all_countries.find { |c| c[:url] == country }
+      @title = "EveryPolitician: #{@country[:name]}" if @country
+    end
+  end
+end

--- a/t/page/country.rb
+++ b/t/page/country.rb
@@ -1,0 +1,29 @@
+require 'minitest/autorun'
+require_relative '../../lib/page/country'
+require 'pry'
+
+describe 'Country' do
+  let(:all_countries) do
+    [
+      {
+        name: 'Abkhazia',
+        url:  'abkhazia',
+      },
+    ]
+  end
+
+  it 'detects that a country is not missing' do
+    page = Page::Country.new('abkhazia', all_countries)
+    refute_nil page.country
+  end
+
+  it 'sets the title of the page if the country exists' do
+    page = Page::Country.new('abkhazia', all_countries)
+    page.title.must_include 'Abkhazia'
+  end
+
+  it 'detects that a country is missing' do
+    page = Page::Country.new('narnia', all_countries)
+    assert_nil page.country
+  end
+end

--- a/t/page/country.rb
+++ b/t/page/country.rb
@@ -1,22 +1,22 @@
+# frozen_string_literal: true
 require 'minitest/autorun'
 require_relative '../../lib/page/country'
-require 'pry'
-
-SHA = 'd8a4682f'.freeze
 
 describe 'Country' do
-  it 'an existing country has a name' do
-    page = Page::Country.new('Abkhazia', SHA)
-    page.country.name.must_equal 'Abkhazia'
+  subject { Page::Country.new(country: 'abkhazia', index: index_at_known_sha) }
+
+  it 'has the country' do
+    subject.country.name.must_equal 'Abkhazia'
   end
 
-  it 'sets the title of the page if the country exists' do
-    page = Page::Country.new('Abkhazia', SHA)
-    page.title.must_include 'Abkhazia'
+  it 'sets the title of the page' do
+    subject.title.must_include 'Abkhazia'
   end
 
   it 'detects that a country is missing' do
-    page = Page::Country.new('narnia', SHA)
-    assert_nil page.country
+    Page::Country.new(
+      country: 'narnia',
+      index:   index_at_known_sha
+    ).country.must_be_nil
   end
 end

--- a/t/page/country.rb
+++ b/t/page/country.rb
@@ -3,9 +3,9 @@ require_relative '../../lib/page/country'
 require 'pry'
 
 describe 'Country' do
-  it 'detects that a country is not missing' do
+  it 'an existing country has a name' do
     page = Page::Country.new('abkhazia')
-    refute_nil page.country
+    assert_equal page.country[:name], 'Abkhazia'
   end
 
   it 'sets the title of the page if the country exists' do

--- a/t/page/country.rb
+++ b/t/page/country.rb
@@ -2,19 +2,21 @@ require 'minitest/autorun'
 require_relative '../../lib/page/country'
 require 'pry'
 
+SHA = 'd8a4682f'.freeze
+
 describe 'Country' do
   it 'an existing country has a name' do
-    page = Page::Country.new('abkhazia')
-    assert_equal page.country[:name], 'Abkhazia'
+    page = Page::Country.new('Abkhazia', SHA)
+    page.country.name.must_equal 'Abkhazia'
   end
 
   it 'sets the title of the page if the country exists' do
-    page = Page::Country.new('abkhazia')
+    page = Page::Country.new('Abkhazia', SHA)
     page.title.must_include 'Abkhazia'
   end
 
   it 'detects that a country is missing' do
-    page = Page::Country.new('narnia')
+    page = Page::Country.new('narnia', SHA)
     assert_nil page.country
   end
 end

--- a/t/page/country.rb
+++ b/t/page/country.rb
@@ -3,27 +3,18 @@ require_relative '../../lib/page/country'
 require 'pry'
 
 describe 'Country' do
-  let(:all_countries) do
-    [
-      {
-        name: 'Abkhazia',
-        url:  'abkhazia',
-      },
-    ]
-  end
-
   it 'detects that a country is not missing' do
-    page = Page::Country.new('abkhazia', all_countries)
+    page = Page::Country.new('abkhazia')
     refute_nil page.country
   end
 
   it 'sets the title of the page if the country exists' do
-    page = Page::Country.new('abkhazia', all_countries)
+    page = Page::Country.new('abkhazia')
     page.title.must_include 'Abkhazia'
   end
 
   it 'detects that a country is missing' do
-    page = Page::Country.new('narnia', all_countries)
+    page = Page::Country.new('narnia')
     assert_nil page.country
   end
 end

--- a/views/country.erb
+++ b/views/country.erb
@@ -1,6 +1,6 @@
 <div class="page-section page-section--grey text-center">
   <div class="container">
-    <h3>We’re cataloguing every politician in <%= @page.country[:name] %>.</h3>
+    <h3>We’re cataloguing every politician in <%= @page.country.name %>.</h3>
     <p>We currently have information for…</p>
   </div>
 </div>
@@ -8,7 +8,7 @@
 <div class="page-section">
   <div class="container">
 
-    <% @page.country[:legislatures].each do |house| %>
+    <% @page.country.legislatures.each do |house| %>
       <div class="country__legislature">
         <div class="country__legislature__header">
           <h3><%= house[:name] %></h3>
@@ -45,7 +45,7 @@
   <div class="container">
 
     <div class="gender-balance-promo">
-      <h3>Help us collect gender information for <%= @page.country[:name] %> by playing our fiendishly addictive online game, Gender Balance!</h3>
+      <h3>Help us collect gender information for <%= @page.country.name %> by playing our fiendishly addictive online game, Gender Balance!</h3>
       <p>Swipe your way through politicians in a flash, and work your way up our leaderboard.</p>
       <p><a href="http://gender-balance.org" class="button button--primary">Play Gender Balance now</a></p>
 

--- a/views/country.erb
+++ b/views/country.erb
@@ -8,7 +8,7 @@
 <div class="page-section">
   <div class="container">
 
-    <% @page.country.legislatures.each do |house| %>
+    <% @page.country.legislatures.map(&:raw_data).each do |house| %>
       <div class="country__legislature">
         <div class="country__legislature__header">
           <h3><%= house[:name] %></h3>

--- a/views/country.erb
+++ b/views/country.erb
@@ -1,6 +1,6 @@
 <div class="page-section page-section--grey text-center">
   <div class="container">
-    <h3>We’re cataloguing every politician in <%= @country[:name] %>.</h3>
+    <h3>We’re cataloguing every politician in <%= @page.country[:name] %>.</h3>
     <p>We currently have information for…</p>
   </div>
 </div>
@@ -8,7 +8,7 @@
 <div class="page-section">
   <div class="container">
 
-    <% @country[:legislatures].each do |house| %>
+    <% @page.country[:legislatures].each do |house| %>
       <div class="country__legislature">
         <div class="country__legislature__header">
           <h3><%= house[:name] %></h3>
@@ -21,7 +21,7 @@
         <ul class="grid-list grid-list--vertically-center" id="terms-<%= house[:slug].downcase %>">
           <% house[:legislative_periods].each do |t| %>
             <li>
-              <a class="avatar-unit" href="<%= term_table_url(@country, house, t) %>">
+              <a class="avatar-unit" href="<%= term_table_url(@page.country, house, t) %>">
                 <span class="avatar"><i class="fa fa-university"></i></span>
                 <h3><%= t[:name] %></h3>
                 <% unless t[:start_date].to_s.empty? and t[:end_date].to_s.empty? %>
@@ -45,7 +45,7 @@
   <div class="container">
 
     <div class="gender-balance-promo">
-      <h3>Help us collect gender information for <%= @country[:name] %> by playing our fiendishly addictive online game, Gender Balance!</h3>
+      <h3>Help us collect gender information for <%= @page.country[:name] %> by playing our fiendishly addictive online game, Gender Balance!</h3>
       <p>Swipe your way through politicians in a flash, and work your way up our leaderboard.</p>
       <p><a href="http://gender-balance.org" class="button button--primary">Play Gender Balance now</a></p>
 

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -1,3 +1,6 @@
+<% @page_title = @page.title   if (@page and @page.respond_to? :title) %>
+<% @country    = @page.country if (@page and @page.respond_to? :country) %>
+
 <!DOCTYPE html>
 <html class="no-js">
 <head>


### PR DESCRIPTION
This pull request extracts the logic under the first `/:country/` route into a class `Country`.

* The relevant templates were updated to use the member fields of the class instance.

* The main layout template had to be updated since it was using `@page_title`, which we don't need to pass to the template as the `Country` class has its own `title` member. So now, if we pass a `@page` instance and the `title` is available, we use it. The `@page_title` is used to render the title of the page in the browser.

* Since we also don't have a `@country` when we are passing a `@page`, the same had to be done so that the main template layout uses the `country` field of the `@page` if it is available. The `@country` is used in the main layout template to render the heading of the page in the page's body.

----

Test page: https://everypolitician-viewe-pr-14617.herokuapp.com/british-virgin-islands/
