### PR TITLE
Upgrade to everypolitician-ruby 0.12

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 ruby '2.0.0'
 
 gem 'dotenv'
-gem 'everypolitician', '~> 0.11.0', github: 'everypolitician/everypolitician-ruby'
+gem 'everypolitician', '~> 0.12.0', github: 'everypolitician/everypolitician-ruby'
 gem 'everypolitician-popolo', github: 'everypolitician/everypolitician-popolo'
 gem 'iso_country_codes'
 gem 'json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,9 +6,9 @@ GIT
 
 GIT
   remote: git://github.com/everypolitician/everypolitician-ruby.git
-  revision: 63d04059421bf239849a0b77a30d623a4ec98b59
+  revision: 82dae6c9ef330cc3dadab549140854cd0d0f3f22
   specs:
-    everypolitician (0.11.0)
+    everypolitician (0.12.0)
       everypolitician-popolo
 
 GIT
@@ -78,7 +78,7 @@ PLATFORMS
 
 DEPENDENCIES
   dotenv
-  everypolitician (~> 0.11.0)!
+  everypolitician (~> 0.12.0)!
   everypolitician-popolo!
   iso_country_codes
   json

--- a/lib/page/download.rb
+++ b/lib/page/download.rb
@@ -3,12 +3,19 @@ require 'json'
 
 module Page
   class Download
-    attr_reader :country, :download_url
+    attr_reader :download_url
 
-    def initialize(country, cjson)
-      # TODO: fix after everypolitician-ruby/issues/38
-      @country = EveryPolitician.country(country) rescue nil
+    def initialize(slug, cjson)
+      @slug = slug
       @download_url = cjson
     end
+
+    def country
+      EveryPolitician.country(slug)
+    end
+
+    private
+
+    attr_reader :slug
   end
 end


### PR DESCRIPTION
Switch to the newest version of everypolitician-ruby where looking up a
missing country returns `nil` rather than throwing an exception.

A new rule of thumb also arises from this: keep logic out of `initialize` as much as possible.