### PR TITLE
Let World return a suitable Country

### DIFF
--- a/lib/world.rb
+++ b/lib/world.rb
@@ -9,6 +9,17 @@ class World
     @_wjson ||= JSON.parse(File.read(file), symbolize_names: true)
   end
 
+  # super-simplistic adapter for the inner data. Over time it might make
+  # sense to properly extract this to its own class, but for now we just
+  # want to tidy the interface up a little so that this is substitutable
+  # for an `everypolitician-ruby` Country in a few well-defined places.
+
+  Country = Struct.new(:url, :name, :names)
+  def country(slug)
+    return unless found = as_json[slug.to_sym]
+    Country.new(slug, found[:displayName], found[:allNames])
+  end
+
   private
 
   attr_reader :file

--- a/t/helpers/world.rb
+++ b/t/helpers/world.rb
@@ -7,4 +7,13 @@ describe 'World' do
   it 'should know other names for countries' do
     subject.as_json[:estonia][:allNames].must_include 'Estland'
   end
+
+  it 'should give us countries as objects' do
+    subject.country('american-samoa').name.must_equal 'American Samoa'
+    subject.country('american-samoa').url.must_equal 'american-samoa'
+  end
+
+  it 'should have no match for non-country' do
+    subject.country('narnia').must_be_nil
+  end
 end


### PR DESCRIPTION
We want to be able to plug a Country into the wrapper template so that
we can call `.name` and `.url` on it, without caring about whether it
originated from the `countries.json` or `world.json` files. So use a
Struct as a simple Adapter within the World class to allow us to call
these methods on the data from there.