### PR TITLE
require_relative World

### DIFF
--- a/lib/page/home.rb
+++ b/lib/page/home.rb
@@ -1,6 +1,6 @@
 require 'everypolitician'
 require 'json'
-require 'world'
+require_relative '../world'
 
 module Page
   class Home


### PR DESCRIPTION
The app doesn't like us just 'require'-ing this directly. This is an
easy fix, but a little bit unsatisfying, not least because the tests
were passing without this, so it implies a deeper underlying problem
that we really need to address more generally.