### PR TITLE
Extract missing country page

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -66,7 +66,7 @@ get '/:country/' do |country|
 end
 
 get '/:country/' do |country|
-  @page = Page::MissingCountry.new(country)
+  @page = Page::MissingCountry.new(country: country)
   pass unless @page.country
   erb :country_missing
 end

--- a/app.rb
+++ b/app.rb
@@ -66,7 +66,8 @@ get '/:country/' do |country|
 end
 
 get '/:country/' do |country|
-  @missing = WORLD[country.to_sym] || halt(404)
+  @page = Page::MissingCountry.new(country)
+  pass unless @page.country
   erb :country_missing
 end
 

--- a/lib/page/missing_country.rb
+++ b/lib/page/missing_country.rb
@@ -1,0 +1,17 @@
+require_relative '../world'
+
+module Page
+  class MissingCountry
+    def initialize(slug)
+      @slug = slug
+    end
+
+    def country
+      @country ||= World.new.country(slug)
+    end
+
+    private
+
+    attr_reader :slug
+  end
+end

--- a/lib/page/missing_country.rb
+++ b/lib/page/missing_country.rb
@@ -2,8 +2,8 @@ require_relative '../world'
 
 module Page
   class MissingCountry
-    def initialize(slug)
-      @slug = slug
+    def initialize(country:)
+      @slug = country
     end
 
     def country

--- a/lib/page/missing_country.rb
+++ b/lib/page/missing_country.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative '../world'
 
 module Page

--- a/t/page/missing_country.rb
+++ b/t/page/missing_country.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'minitest/autorun'
 require_relative '../../lib/page/missing_country'
 require 'pry'

--- a/t/page/missing_country.rb
+++ b/t/page/missing_country.rb
@@ -4,12 +4,12 @@ require 'pry'
 
 describe 'MissingCountry' do
   it 'has a display name' do
-    page = Page::MissingCountry.new('eritrea')
+    page = Page::MissingCountry.new(country: 'eritrea')
     page.country.name.must_equal 'Eritrea'
   end
 
   it 'returns nil if country does not exist' do
-    page = Page::MissingCountry.new('narnia')
+    page = Page::MissingCountry.new(country: 'narnia')
     assert_nil page.country
   end
 end

--- a/t/page/missing_country.rb
+++ b/t/page/missing_country.rb
@@ -1,0 +1,15 @@
+require 'minitest/autorun'
+require_relative '../../lib/page/missing_country'
+require 'pry'
+
+describe 'MissingCountry' do
+  it 'has a display name' do
+    page = Page::MissingCountry.new('eritrea')
+    page.country.name.must_equal 'Eritrea'
+  end
+
+  it 'returns nil if country does not exist' do
+    page = Page::MissingCountry.new('narnia')
+    assert_nil page.country
+  end
+end

--- a/views/country_missing.erb
+++ b/views/country_missing.erb
@@ -1,6 +1,6 @@
 <div class="container" id="country_missing">
   <div class="page-section">
     <h2>Sorry!</h2>
-    <p>We haven’t got data for <%= @missing[:displayName] %> yet. Here’s how to <a href="http://docs.everypolitician.org/contribute.html">help us find it</a>.</p>
+    <p>We haven’t got data for <%= @page.country.name %> yet. Here’s how to <a href="http://docs.everypolitician.org/contribute.html">help us find it</a>.</p>
   </div>
 </div>


### PR DESCRIPTION
This PR extracts a missing country-page to be used by the :country route when information for a country is missing in everypolitician data.

The route was updated as well as the template that receives the `@page` instance from said route.