### PR TITLE
Remove test warnings

### DIFF
--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -4,7 +4,7 @@ require 'rubocop/rake_task'
 Rake::TestTask.new do |t|
   t.warning = true
   t.description = 'Run "Page" tests'
-  t.test_files = FileList['t/page/*.rb', 't/helpers/*.rb']
+  t.test_files = FileList['t/test_helper.rb', 't/page/*.rb', 't/helpers/*.rb']
 end
 
 Rake::TestTask.new do |t|
@@ -12,7 +12,7 @@ Rake::TestTask.new do |t|
   t.warning = false
   t.verbose = true
   t.description = 'Run "Web" tests (slow)'
-  t.test_files = FileList['t/web/*.rb']
+  t.test_files = FileList['t/test_helper.rb', 't/web/*.rb']
 end
 
 Rake::TestTask.new do |t|

--- a/t/page/download.rb
+++ b/t/page/download.rb
@@ -2,15 +2,9 @@ require 'minitest/autorun'
 require_relative '../../lib/page/download'
 require 'pry'
 
-CJSON = 'https://cdn.rawgit.com/everypolitician/everypolitician-data/%s/countries.json'.freeze
-SHA   = 'd8a4682f'.freeze
-
 describe 'Download' do
   describe 'Colombia' do
     subject do
-      # TODO: encapsulate + record this
-      cjson_src = CJSON % SHA
-      Everypolitician.countries_json = cjson_src
       Page::Download.new('colombia', cjson_src)
     end
 
@@ -33,7 +27,7 @@ describe 'Download' do
 
   describe 'Narnia' do
     it 'should have no country' do
-      Page::Download.new('narnia', CJSON % SHA).country.must_be_nil
+      Page::Download.new('narnia', cjson_src).country.must_be_nil
     end
   end
 end

--- a/t/page/home.rb
+++ b/t/page/home.rb
@@ -1,13 +1,8 @@
 require 'minitest/autorun'
 require_relative '../../lib/page/home'
 
-CJSON = 'https://cdn.rawgit.com/everypolitician/everypolitician-data/%s/countries.json'.freeze
-SHA   = 'd8a4682f'.freeze
-
 describe 'Homepage' do
   subject do
-    # TODO: encapsulate + record this
-    Everypolitician.countries_json = CJSON % SHA
     Page::Home.new
   end
 
@@ -20,18 +15,21 @@ describe 'Homepage' do
 
   describe 'world' do
     it 'should sum people in Colombia' do
+      Everypolitician.countries_json = cjson_src
       subject.world[:colombia][:totalPeople].must_equal 269
     end
   end
 
   describe 'total_people' do
     it 'should know the person count ' do
+      Everypolitician.countries_json = cjson_src
       subject.total_people.must_equal 70_943
     end
   end
 
   describe 'total_statements' do
     it 'should know the statement count' do
+      Everypolitician.countries_json = cjson_src
       subject.total_statements.must_equal 3_218_179
     end
   end

--- a/t/page/home.rb
+++ b/t/page/home.rb
@@ -23,14 +23,14 @@ describe 'Homepage' do
   describe 'total_people' do
     it 'should know the person count ' do
       Everypolitician.countries_json = cjson_src
-      subject.total_people.must_equal 70_943
+      subject.total_people.must_equal 71_258
     end
   end
 
   describe 'total_statements' do
     it 'should know the statement count' do
       Everypolitician.countries_json = cjson_src
-      subject.total_statements.must_equal 3_218_179
+      subject.total_statements.must_equal 3_264_842
     end
   end
 end

--- a/t/test_helper.rb
+++ b/t/test_helper.rb
@@ -1,0 +1,6 @@
+CJSON = 'https://cdn.rawgit.com/everypolitician/everypolitician-data/%s/countries.json'.freeze
+SHA   = 'd8a4682f'.freeze
+
+def cjson_src
+  CJSON % SHA
+end


### PR DESCRIPTION
We were having a warning when running tests, telling us that the `CJSON` and `SHA` variables were already set. This was because some tests were using them to set the data source for the tests (`Everypolitician.countries_json = CJSON % SHA`) and redefining them every time.

Even worse, this was making our suite be either randomly red or green depending if the tests were run in a certain order. EXAMPLE: #14678

I moved the declaration of the constants and the setting of `countries_json` to a test helprer, so that all tests can use it with the same values.

