### PR TITLE
Extract a countries page class

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -52,9 +52,7 @@ get '/' do
 end
 
 get '/countries.html' do
-  @countries = ALL_COUNTRIES.to_a
-  @world = WORLD.to_a
-  @cjson = cjson
+  @page = Page::Countries.new
   erb :countries
 end
 

--- a/lib/page/countries.rb
+++ b/lib/page/countries.rb
@@ -1,0 +1,18 @@
+require 'everypolitician'
+require_relative '../world'
+
+module Page
+  class Countries
+    def countries
+      @countries ||= EveryPolitician.countries
+    end
+
+    def download_url
+      @download_url ||= EveryPolitician.countries_json
+    end
+
+    def world
+      @world ||= World.new.as_json.to_a
+    end
+  end
+end

--- a/t/page/countries.rb
+++ b/t/page/countries.rb
@@ -1,0 +1,26 @@
+require 'minitest/autorun'
+require_relative '../../lib/page/countries'
+require 'pry'
+
+CJSON = 'https://cdn.rawgit.com/everypolitician/everypolitician-data/%s/countries.json'.freeze
+SHA   = 'd8a4682f'.freeze
+
+describe 'Countries' do
+  subject do
+    Page::Countries.new
+  end
+
+  it 'has a list of all countries in Everypolitician' do
+    assert_equal subject.countries.first[:name], 'Abkhazia'
+  end
+
+  it 'has a url pointing to the last version of the db' do
+    datasource = CJSON % SHA
+    Everypolitician.countries_json = datasource
+    assert subject.download_url.match(datasource)
+  end
+
+  it 'has a list of all countries in the world' do
+    assert_equal subject.world.length, 245
+  end
+end

--- a/views/countries.erb
+++ b/views/countries.erb
@@ -2,14 +2,14 @@
     <div class="container">
 
         <div class="text-center">
-            <h2>Data from <%= @countries.length %> countries</h2>
-            <p>But we’re still missing <%= @world.length - @countries.length %>.
+            <h2>Data from <%= @page.countries.length %> countries</h2>
+            <p>But we’re still missing <%= @page.world.length - @page.countries.length %>.
               <a href="/needed.html">Can you help?</a>
         </div>
 
         <div id="vmap" style="width: 100%; height: 400px; margin: 3em auto; max-width: 840px;"></div>
 
-        <% countries_sorted = @countries.sort_by { |c| c[:name] } %>
+        <% countries_sorted = @page.countries.sort_by { |c| c[:name] } %>
         <% current_letter = countries_sorted[0][:name].upcase[0,1] %>
 
         <h3 class="country-list__section-header"><%= current_letter %></h3>
@@ -38,12 +38,12 @@
 </div>
 
 <div class="text-center">
-    <a href="<%= @cjson %>"><i class="fa fa-download"></i> Download <span class="large-screen-only">country metadata</span> as JSON</a>
+    <a href="<%= @page.download_url %>"><i class="fa fa-download"></i> Download <span class="large-screen-only">country metadata</span> as JSON</a>
 </div>
 
 <script type="text/javascript">
   var ep_countries = {};
-  <% @countries.each do |country| %>
+  <% @page.countries.each do |country| %>
     ep_countries['<%= country[:code].upcase %>'] = '<%= country[:slug].downcase %>';
   <% end -%>
     ep_countries['_0'] = 'kosovo';
@@ -79,4 +79,3 @@
   };
   jQuery(document).ready(draw_map());
 </script>
-


### PR DESCRIPTION
This PR extracts a countries page class from the app route.

While we wait for #14661 to be merged, these tests set the `CJSON` and `SHA` variables and the `countries_json` for the test to work, which adds another pair of warnings when running the tests, but hopefully those could be removed soon.

I'm not sure if I am exposing too much implementation details when I do:
```ruby
assert_equal subject.countries.first[:name], 'Abkhazia'
```
