### PR TITLE
separate release and build process

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -10,7 +10,7 @@ sudo apt-get update
 
 # Install required packages
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
-  ruby2.0 ruby2.0-dev git build-essential libxslt1-dev
+  ruby2.0 ruby2.0-dev git build-essential libxslt1-dev zlib1g-dev
 
 # Add cd /vagrant to ~/.bashrc
 grep -qG "cd /vagrant" "$HOME/.bashrc" || echo "cd /vagrant" >> "$HOME/.bashrc"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -11,11 +11,14 @@ add_ssh_key() {
   ssh-add deploy_key.pem
 }
 
-update_viewer_static() {
+build_viewer_static() {
   bundle exec ruby app.rb &
   while ! nc -z localhost 4567; do sleep 1; done
   cd /tmp
   wget -nv -m localhost:4567/status/all_countries.html || (echo "wget exited with non-zero exit code: $?" >&2 && exit 1)
+}
+
+deploy_viewer_static() {
   git clone "git@github.com:everypolitician/viewer-static.git"
   cd viewer-static
   git checkout gh-pages
@@ -38,10 +41,11 @@ update_politician_image_proxy() {
 }
 
 main() {
+  build_viewer_static
   if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
     add_ssh_key
     if [[ "$TRAVIS_BRANCH" == "master" ]]; then
-      update_viewer_static
+      deploy_viewer_static
     fi
     # update_politician_image_proxy
   fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -41,9 +41,9 @@ update_politician_image_proxy() {
 }
 
 main() {
+  add_ssh_key
   build_viewer_static
   if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
-    add_ssh_key
     if [[ "$TRAVIS_BRANCH" == "master" ]]; then
       deploy_viewer_static
     fi


### PR DESCRIPTION
Split the viewer-sinatra build and deploy process into two functions and always call the build process. The deploy process is only called when we are on the master branch.