### PR TITLE
Switch to Everypolitician::Index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.swo
 
 _cached_data/*
+.rubocop-https---raw-githubusercontent-com-everypolitician-everypolitician-data-master--rubocop-base-yml

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 ruby '2.0.0'
 
 gem 'dotenv'
-gem 'everypolitician', '~> 0.12.0', github: 'everypolitician/everypolitician-ruby', branch: 'fixes-for-index-class'
+gem 'everypolitician', '~> 0.13.0', github: 'everypolitician/everypolitician-ruby'
 gem 'everypolitician-popolo', github: 'everypolitician/everypolitician-popolo'
 gem 'iso_country_codes'
 gem 'json'

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 ruby '2.0.0'
 
 gem 'dotenv'
-gem 'everypolitician', '~> 0.12.0', github: 'everypolitician/everypolitician-ruby'
+gem 'everypolitician', '~> 0.12.0', github: 'everypolitician/everypolitician-ruby', branch: 'fixes-for-index-class'
 gem 'everypolitician-popolo', github: 'everypolitician/everypolitician-popolo'
 gem 'iso_country_codes'
 gem 'json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,13 @@
 GIT
   remote: git://github.com/everypolitician/everypolitician-popolo.git
-  revision: 25b8a284b556b60dbe05ba11843b8743aca00975
+  revision: 4e6e75ddfece32889243595e7305ba9007e3c8b4
   specs:
     everypolitician-popolo (0.5.0)
 
 GIT
   remote: git://github.com/everypolitician/everypolitician-ruby.git
-  revision: 82dae6c9ef330cc3dadab549140854cd0d0f3f22
+  revision: 2d3ac22b87e8eda22b758a13508376209db2b14c
+  branch: fixes-for-index-class
   specs:
     everypolitician (0.12.0)
       everypolitician-popolo

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,10 +6,9 @@ GIT
 
 GIT
   remote: git://github.com/everypolitician/everypolitician-ruby.git
-  revision: 05b5ac9bdd48c3aec6c4b3bf7db0f392b5e26258
-  branch: fixes-for-index-class
+  revision: 5bc8a93be4b629bad51c4183cbab0f888b7f7fc4
   specs:
-    everypolitician (0.12.0)
+    everypolitician (0.13.0)
       everypolitician-popolo
 
 GIT
@@ -80,7 +79,7 @@ PLATFORMS
 
 DEPENDENCIES
   dotenv
-  everypolitician (~> 0.12.0)!
+  everypolitician (~> 0.13.0)!
   everypolitician-popolo!
   iso_country_codes
   json

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GIT
 
 GIT
   remote: git://github.com/everypolitician/everypolitician-ruby.git
-  revision: 2d3ac22b87e8eda22b758a13508376209db2b14c
+  revision: 05b5ac9bdd48c3aec6c4b3bf7db0f392b5e26258
   branch: fixes-for-index-class
   specs:
     everypolitician (0.12.0)

--- a/app.rb
+++ b/app.rb
@@ -191,7 +191,7 @@ get '/:country/:house/term-table/:id.html' do |country, house, termid|
 end
 
 get '/:country/download.html' do |country|
-  @page = Page::Download.new(country, index: EveryPolitician::Index.new(cjson))
+  @page = Page::Download.new(country, index: EveryPolitician::Index.new(index_url: cjson))
   # TODO: perhaps have a `valid?` method?
   halt(404) unless @page.country
   erb :country_download

--- a/app.rb
+++ b/app.rb
@@ -47,7 +47,7 @@ end
 set :erb, trim: '-'
 
 get '/' do
-  @page = Page::Home.new
+  @page = Page::Home.new(index: EveryPolitician::Index.new(index_url: cjson))
   erb :homepage
 end
 
@@ -191,7 +191,7 @@ get '/:country/:house/term-table/:id.html' do |country, house, termid|
 end
 
 get '/:country/download.html' do |country|
-  @page = Page::Download.new(country, cjson)
+  @page = Page::Download.new(country, index: EveryPolitician::Index.new(cjson))
   # TODO: perhaps have a `valid?` method?
   halt(404) unless @page.country
   erb :country_download

--- a/lib/page/download.rb
+++ b/lib/page/download.rb
@@ -4,14 +4,16 @@ require 'json'
 module Page
   class Download
     attr_reader :download_url
+    attr_reader :index
 
-    def initialize(slug, cjson)
+    def initialize(slug, index: EveryPolitician::Index.new)
       @slug = slug
-      @download_url = cjson
+      @download_url = index.index_url
+      @index = index
     end
 
     def country
-      EveryPolitician.country(slug)
+      index.country(slug)
     end
 
     private

--- a/lib/page/download.rb
+++ b/lib/page/download.rb
@@ -4,7 +4,6 @@ require 'json'
 module Page
   class Download
     attr_reader :download_url
-    attr_reader :index
 
     def initialize(slug, index: EveryPolitician::Index.new)
       @slug = slug
@@ -19,5 +18,6 @@ module Page
     private
 
     attr_reader :slug
+    attr_reader :index
   end
 end

--- a/lib/page/home.rb
+++ b/lib/page/home.rb
@@ -4,7 +4,6 @@ require_relative '../world'
 
 module Page
   class Home
-    attr_reader :index
     attr_reader :countries
 
     def initialize(index: Everypolitician::Index.new)
@@ -27,6 +26,8 @@ module Page
     end
 
     private
+
+    attr_reader :index
 
     def legislatures
       @_legislatures ||= countries.flat_map(&:legislatures)

--- a/lib/page/home.rb
+++ b/lib/page/home.rb
@@ -4,8 +4,10 @@ require_relative '../world'
 
 module Page
   class Home
-    def countries
-      @_countries ||= EveryPolitician.countries
+    attr_reader :countries
+
+    def initialize(index: Everypolitician::Index.new)
+      @countries = index.countries
     end
 
     def total_people

--- a/lib/page/home.rb
+++ b/lib/page/home.rb
@@ -4,9 +4,11 @@ require_relative '../world'
 
 module Page
   class Home
+    attr_reader :index
     attr_reader :countries
 
     def initialize(index: Everypolitician::Index.new)
+      @index = index
       @countries = index.countries
     end
 
@@ -20,7 +22,7 @@ module Page
 
     def world
       world_json.each do |slug, country|
-        country[:totalPeople] = EveryPolitician.country(slug.to_s).legislatures.map(&:person_count).inject(:+) rescue 0
+        country[:totalPeople] = index.country(slug.to_s).legislatures.map(&:person_count).inject(:+) rescue 0
       end
     end
 

--- a/t/page/download.rb
+++ b/t/page/download.rb
@@ -2,16 +2,13 @@ require 'minitest/autorun'
 require_relative '../../lib/page/download'
 require 'pry'
 
-CJSON = 'https://cdn.rawgit.com/everypolitician/everypolitician-data/%s/countries.json'.freeze
-SHA   = 'd8a4682f'.freeze
-
 describe 'Download' do
   describe 'Colombia' do
     subject do
-      # TODO: encapsulate + record this
-      cjson_src = CJSON % SHA
-      Everypolitician.countries_json = cjson_src
-      Page::Download.new('colombia', cjson_src)
+      Page::Download.new(
+        'colombia',
+        index: index_at_known_sha
+      )
     end
 
     describe 'country' do
@@ -33,7 +30,7 @@ describe 'Download' do
 
   describe 'Narnia' do
     it 'should have no country' do
-      Page::Download.new('narnia', CJSON % SHA).country.must_be_nil
+      Page::Download.new('narnia', index: index_at_known_sha).country.must_be_nil
     end
   end
 end

--- a/t/page/home.rb
+++ b/t/page/home.rb
@@ -1,15 +1,8 @@
-require 'minitest/autorun'
+require_relative '../test_helper'
 require_relative '../../lib/page/home'
 
-CJSON = 'https://cdn.rawgit.com/everypolitician/everypolitician-data/%s/countries.json'.freeze
-SHA   = 'd8a4682f'.freeze
-
 describe 'Homepage' do
-  subject do
-    # TODO: encapsulate + record this
-    Everypolitician.countries_json = CJSON % SHA
-    Page::Home.new
-  end
+  subject { Page::Home.new(index: index_at_known_sha) }
 
   describe 'countries' do
     it 'should include Colombian Senate' do

--- a/t/test_helper.rb
+++ b/t/test_helper.rb
@@ -1,11 +1,13 @@
 require 'minitest/autorun'
 
-class Minitest::Spec
-  def known_countries_json_url
-    'https://cdn.rawgit.com/everypolitician/everypolitician-data/d8a4682f/countries.json'
-  end
+module Minitest
+  class Spec
+    def known_countries_json_url
+      'https://cdn.rawgit.com/everypolitician/everypolitician-data/d8a4682f/countries.json'
+    end
 
-  def index_at_known_sha
-    @index_at_known_sha ||= EveryPolitician::Index.new(index_url: known_countries_json_url)
+    def index_at_known_sha
+      @index_at_known_sha ||= EveryPolitician::Index.new(index_url: known_countries_json_url)
+    end
   end
 end

--- a/t/test_helper.rb
+++ b/t/test_helper.rb
@@ -1,0 +1,7 @@
+require 'minitest/autorun'
+
+class Minitest::Spec
+  def index_at_known_sha
+    @index_at_known_sha ||= EveryPolitician::Index.new('d8a4682f')
+  end
+end

--- a/t/test_helper.rb
+++ b/t/test_helper.rb
@@ -1,7 +1,11 @@
 require 'minitest/autorun'
 
 class Minitest::Spec
+  def known_countries_json_url
+    'https://cdn.rawgit.com/everypolitician/everypolitician-data/d8a4682f/countries.json'
+  end
+
   def index_at_known_sha
-    @index_at_known_sha ||= EveryPolitician::Index.new('d8a4682f')
+    @index_at_known_sha ||= EveryPolitician::Index.new(index_url: known_countries_json_url)
   end
 end


### PR DESCRIPTION
This switches the existing page classes and their tests over to use `Everypolitician::Index`. It's currently pointing at the version of everypolitician-ruby in https://github.com/everypolitician/everypolitician-ruby/pull/44, so that will need to be changed back to `master` once that PR is merged.