### PR TITLE
require ruby 2.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ script:
   - scripts/release.sh
 sudo: false
 rvm:
-  - 2.0.0
+  - 2.3.1
 notifications:
   slack:
     secure: GVD9d+kwR5hzab5ZnWugbCkp9QSYyheSrABWkD+LmpMcWcx7jijajSn4LLvDi/zHYn1MdOBcPe08hSygmpm7ViUApp0EJcSzE4BLU/5oAs+ANV0Qq6jsssMlyo3v8eRAqHNiLxAiAsz+lc0EZWfQnSW8kHzzbO3NeYq1NRL5CgQ=

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.0.0'
+ruby '2.3.1'
 
 gem 'dotenv'
 gem 'everypolitician', '~> 0.13.0', github: 'everypolitician/everypolitician-ruby'


### PR DESCRIPTION
As we’re moving to using named parameters everywhere, 2.0.0 isn’t really
good enough anymore — we want at least 2.1.0 so we get required parameters.

With libraries we want to stick to the oldest plausible version rather than
forcing users to upgrade their ruby, but with an app like this we can be a
lot more relaxed. So if we’re upgrading anyway, we may as well go to 2.3.1