### PR TITLE
Add "frozen_string_literal: true" everywhere

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,8 @@
 AllCops:
-  Exclude: 
+  Exclude:
     - 'Vagrantfile'
     - 'vendor/**/*'
+  TargetRubyVersion: 2.3.1
 
 inherit_from: 
   - https://raw.githubusercontent.com/everypolitician/everypolitician-data/master/.rubocop_base.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ AllCops:
   Exclude:
     - 'Vagrantfile'
     - 'vendor/**/*'
-  TargetRubyVersion: 2.3.1
+  TargetRubyVersion: 2.3
 
 inherit_from: 
   - https://raw.githubusercontent.com/everypolitician/everypolitician-data/master/.rubocop_base.yml

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source 'https://rubygems.org'
 
 ruby '2.3.1'

--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rake/testtask'
 require 'rubocop/rake_task'
 

--- a/app.rb
+++ b/app.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'cgi'
 require 'dotenv'
 require 'octokit'
@@ -27,7 +28,7 @@ end
 wjson = File.read('world.json')
 WORLD = JSON.parse(wjson, symbolize_names: true)
 
-DOCS_URL = 'http://docs.everypolitician.org'.freeze
+DOCS_URL = 'http://docs.everypolitician.org'
 
 # Can't do server-side redirection on a GitHub Pages-hosted static site, so the
 # kindest next-best-thing is to have a placeholder with meta HTTP-refresh.

--- a/config.ru
+++ b/config.ru
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 require './app'
 run Sinatra::Application

--- a/lib/page/download.rb
+++ b/lib/page/download.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'everypolitician'
 require 'json'
 

--- a/lib/page/home.rb
+++ b/lib/page/home.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'everypolitician'
 require 'json'
 require_relative '../world'

--- a/lib/popolo_helper.rb
+++ b/lib/popolo_helper.rb
@@ -1,9 +1,10 @@
+# frozen_string_literal: true
 require 'open-uri'
 require 'fileutils'
 
 module EveryPolitician
   class GithubFile
-    GH_PATH = 'https://cdn.rawgit.com/everypolitician/everypolitician-data/%s/%s'.freeze
+    GH_PATH = 'https://cdn.rawgit.com/everypolitician/everypolitician-data/%s/%s'
 
     def initialize(file, sha, cache_dir = '_cached_data')
       @url = GH_PATH % [sha, file]

--- a/lib/world.rb
+++ b/lib/world.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'json'
 
 class World

--- a/t/helpers/world.rb
+++ b/t/helpers/world.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'minitest/autorun'
 require_relative '../../lib/world'
 

--- a/t/page/download.rb
+++ b/t/page/download.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'minitest/autorun'
 require_relative '../../lib/page/download'
 require 'pry'

--- a/t/page/home.rb
+++ b/t/page/home.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative '../test_helper'
 require_relative '../../lib/page/home'
 

--- a/t/test_helper.rb
+++ b/t/test_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'minitest/autorun'
 
 module Minitest

--- a/t/web/basic.rb
+++ b/t/web/basic.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ENV['RACK_ENV'] = 'test'
 
 require_relative '../../app'

--- a/t/web/needed.rb
+++ b/t/web/needed.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ENV['RACK_ENV'] = 'test'
 
 require_relative '../../app'

--- a/t/web/popolo_helper.rb
+++ b/t/web/popolo_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ENV['RACK_ENV'] = 'test'
 
 require_relative '../../app'

--- a/t/web/term_table/all_countries.rb
+++ b/t/web/term_table/all_countries.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ENV['RACK_ENV'] = 'test'
 
 require_relative '../../../app'

--- a/t/web/term_table/australia.rb
+++ b/t/web/term_table/australia.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ENV['RACK_ENV'] = 'test'
 
 require_relative '../../../app'

--- a/t/web/term_table/finland.rb
+++ b/t/web/term_table/finland.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ENV['RACK_ENV'] = 'test'
 
 require_relative '../../../app'

--- a/t/web/term_table/malaysia.rb
+++ b/t/web/term_table/malaysia.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ENV['RACK_ENV'] = 'test'
 
 require_relative '../../../app'

--- a/t/web/term_table/ni.rb
+++ b/t/web/term_table/ni.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ENV['RACK_ENV'] = 'test'
 
 require_relative '../../../app'

--- a/t/web/term_table/nz.rb
+++ b/t/web/term_table/nz.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ENV['RACK_ENV'] = 'test'
 
 require_relative '../../../app'

--- a/t/web/term_table/party_groupings.rb
+++ b/t/web/term_table/party_groupings.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ENV['RACK_ENV'] = 'test'
 
 require_relative '../../../app'

--- a/t/web/term_table/seat_count.rb
+++ b/t/web/term_table/seat_count.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ENV['RACK_ENV'] = 'test'
 
 require_relative '../../../app'


### PR DESCRIPTION
Now that we're on Ruby 2.3 Rubocop is suggesting that we use the new
'frozen_string_literal' everywhere, in preparation for 3.0. Helpfully,
`rubocop -a` even does it for us…