### PR TITLE
named parameters everywhere

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -192,7 +192,10 @@ get '/:country/:house/term-table/:id.html' do |country, house, termid|
 end
 
 get '/:country/download.html' do |country|
-  @page = Page::Download.new(country, index: EveryPolitician::Index.new(index_url: cjson))
+  @page = Page::Download.new(
+    country: country,
+    index:   EveryPolitician::Index.new(index_url: cjson)
+  )
   # TODO: perhaps have a `valid?` method?
   halt(404) unless @page.country
   erb :country_download

--- a/lib/page/download.rb
+++ b/lib/page/download.rb
@@ -4,21 +4,21 @@ require 'json'
 
 module Page
   class Download
-    attr_reader :download_url
-
-    def initialize(slug, index: EveryPolitician::Index.new)
-      @slug = slug
-      @download_url = index.index_url
+    def initialize(country:, index:)
+      @country_slug = country
       @index = index
     end
 
+    def download_url
+      index.index_url
+    end
+
     def country
-      index.country(slug)
+      index.country(country_slug)
     end
 
     private
 
-    attr_reader :slug
-    attr_reader :index
+    attr_reader :country_slug, :index
   end
 end

--- a/t/page/download.rb
+++ b/t/page/download.rb
@@ -7,8 +7,8 @@ describe 'Download' do
   describe 'Colombia' do
     subject do
       Page::Download.new(
-        'colombia',
-        index: index_at_known_sha
+        country: 'colombia',
+        index:   index_at_known_sha
       )
     end
 
@@ -31,7 +31,10 @@ describe 'Download' do
 
   describe 'Narnia' do
     it 'should have no country' do
-      Page::Download.new('narnia', index: index_at_known_sha).country.must_be_nil
+      Page::Download.new(
+        country: 'narnia',
+        index:   index_at_known_sha
+      ).country.must_be_nil
     end
   end
 end


### PR DESCRIPTION
Now that we're on ruby 2.3.1 we can be stricter about always requiring
named parameters to Page classes, and more flexible about how we say which
ones are required.