### PR TITLE
Simplify the countries loop

### DIFF
--- a/views/countries.erb
+++ b/views/countries.erb
@@ -8,24 +8,11 @@
         </div>
 
         <div id="vmap" style="width: 100%; height: 400px; margin: 3em auto; max-width: 840px;"></div>
-
-        <% countries_sorted = @page.countries.sort_by { |c| c.name } %>
-        <% current_letter = countries_sorted[0].name.upcase[0,1] %>
-
-        <h3 class="country-list__section-header"><%= current_letter %></h3>
+        <% @page.countries.group_by { |c| c.name.chr }.each do |letter, countries| %>
+        <h3 class="country-list__section-header"><%= letter.upcase %></h3>
 
         <ul class="grid-list grid-list--vertically-center">
-          <% countries_sorted.each do |c| %>
-
-          <% if c.name.upcase[0,1] != current_letter %>
-          <% current_letter = c.name.upcase[0,1] %>
-        </ul>
-
-        <h3 class="country-list__section-header"><%= current_letter %></h3>
-
-        <ul class="grid-list grid-list--vertically-center">
-          <% end %>
-
+          <% countries.each do |c| %>
             <li>
                 <a class="avatar-unit" href="/<%= c.slug.downcase %>/">
                     <span class="avatar"><i class="fa fa-users"></i></span>
@@ -34,6 +21,7 @@
             </li>
           <% end %>
         </ul>
+      <% end %>
     </div>
 </div>
 


### PR DESCRIPTION
Grouping the countries by the start letter is a little bit mind-bending
(and requires some duplication), so replace it with an explicit
`group_by`.

We should perhaps push more of this logic out into the Page, but this is
a quick win in the meantime.