### PR TITLE
remove unused WORLD

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -25,9 +25,6 @@ ALL_COUNTRIES = JSON.parse(open(cjson).read, symbolize_names: true).each do |c|
   c[:url] = c[:slug].downcase
 end
 
-wjson = File.read('world.json')
-WORLD = JSON.parse(wjson, symbolize_names: true)
-
 DOCS_URL = 'http://docs.everypolitician.org'
 
 # Can't do server-side redirection on a GitHub Pages-hosted static site, so the


### PR DESCRIPTION
`wjson` and `WORLD` have now been successfully encapsulated in each of the `Page` classes which require them, so we can get rid of the global in `app.rb`