### PR TITLE
Add a `person_count` to Everypolitician::Country

### DIFF
--- a/lib/everypolitician_extensions.rb
+++ b/lib/everypolitician_extensions.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+module EveryPolitician
+  module CountryExtension
+    def person_count
+      legislatures.map(&:person_count).inject(:+)
+    end
+  end
+end
+
+EveryPolitician::Country.include EveryPolitician::CountryExtension

--- a/lib/page/home.rb
+++ b/lib/page/home.rb
@@ -2,14 +2,7 @@
 require 'everypolitician'
 require 'json'
 require_relative '../world'
-
-module Everypolitician
-  class Country
-    def person_count
-      legislatures.map(&:person_count).inject(:+)
-    end
-  end
-end
+require_relative '../everypolitician_extensions'
 
 module Page
   class Home

--- a/lib/page/home.rb
+++ b/lib/page/home.rb
@@ -3,6 +3,14 @@ require 'everypolitician'
 require 'json'
 require_relative '../world'
 
+module Everypolitician
+  class Country
+    def person_count
+      legislatures.map(&:person_count).inject(:+)
+    end
+  end
+end
+
 module Page
   class Home
     attr_reader :countries
@@ -22,7 +30,7 @@ module Page
 
     def world
       world_json.each do |slug, country|
-        country[:totalPeople] = index.country(slug.to_s).legislatures.map(&:person_count).inject(:+) rescue 0
+        country[:totalPeople] = index.country(slug.to_s).person_count rescue 0
       end
     end
 


### PR DESCRIPTION
EveryPolitician::Country only has a person_count on a Legislature.
Let's pretend it also has one on a Country.

We might want to actually _add_ this to `everypolitician-ruby`, but
it's not totally clear year whether it's something that's generally
useful enough, so let's live with it here for a while first, and then
decide.