### PR TITLE
Fix header link

### DIFF
--- a/lib/world.rb
+++ b/lib/world.rb
@@ -15,7 +15,7 @@ class World
   # want to tidy the interface up a little so that this is substitutable
   # for an `everypolitician-ruby` Country in a few well-defined places.
 
-  Country = Struct.new(:url, :name, :names)
+  Country = Struct.new(:slug, :name, :names)
   def country(slug)
     return unless found = as_json[slug.to_sym]
     Country.new(slug, found[:displayName], found[:allNames])

--- a/t/helpers/world.rb
+++ b/t/helpers/world.rb
@@ -11,7 +11,7 @@ describe 'World' do
 
   it 'should give us countries as objects' do
     subject.country('american-samoa').name.must_equal 'American Samoa'
-    subject.country('american-samoa').url.must_equal 'american-samoa'
+    subject.country('american-samoa').slug.must_equal 'american-samoa'
   end
 
   it 'should have no match for non-country' do

--- a/t/web/term_table/finland.rb
+++ b/t/web/term_table/finland.rb
@@ -13,6 +13,10 @@ describe 'Per Country Tests' do
   describe 'Finland' do
     before { get '/finland/eduskunta/term-table/35.html' }
 
+    it 'should link to the country page' do
+      subject.css('.site-header h2 a/@href').text.must_equal '/finland/'
+    end
+
     it 'should have have its name' do
       subject.css('#term h1').text.must_include 'Eduskunta 35'
     end

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -59,7 +59,7 @@
                 <div class="site-header__logo">
                     <h2>
                       <% if @country %>
-                        <a href="/<%= @country[:url] %>/"><%= @country[:name] %></a>
+                        <a href="/<%= @country[:slug].downcase %>/"><%= @country[:name] %></a>
                       <% else %>
                         <a href="/"><span class="header-logo">EveryPolitician</span></a>
                       <% end %>


### PR DESCRIPTION
The `:url` member of the `Country` struct was renamed to `:slug` to play well with the real `Country` objects.

The main layout was calling a `:url` field in the `@country` returned by the currently displayed page, but `Country` objects don't have a url member, they have a `:slug` instead.

So by making the titles work for world countries, we broke it for EP countries.
After renaming `:url` to `:slug` in world countries, it should work for both types of country.

The main layout headings now call `@country[:slug]` instead of `@country[:url]`
so that both world-countries and EP-countries heading link to the right url.

Fixes #14816 