### PR TITLE
Use country methods in template

### DIFF
--- a/views/countries.erb
+++ b/views/countries.erb
@@ -32,7 +32,7 @@
 <script type="text/javascript">
   var ep_countries = {};
   <% @page.countries.each do |country| %>
-    ep_countries['<%= country[:code].upcase %>'] = '<%= country[:slug].downcase %>';
+    ep_countries['<%= country.code.upcase %>'] = '<%= country.slug.downcase %>';
   <% end -%>
     ep_countries['_0'] = 'kosovo';
     ep_countries['-99'] = 'northern-cyprus';


### PR DESCRIPTION
Instead of calling keys on the hash, the template now uses the methods provided by the `Country` object.