### PR TITLE
Fix the spider_base template

### DIFF
--- a/lib/page/spider_base.rb
+++ b/lib/page/spider_base.rb
@@ -3,12 +3,18 @@ require_relative '../world.rb'
 
 module Page
   class SpiderBase
-    def world
-      World.new.as_json
-    end
-
     def title
       'EveryPolitician: Robots Start Here'
+    end
+
+    def countries
+      world.countries
+    end
+
+    private
+
+    def world
+      World.new
     end
   end
 end

--- a/lib/world.rb
+++ b/lib/world.rb
@@ -10,6 +10,10 @@ class World
     @_wjson ||= JSON.parse(File.read(file), symbolize_names: true)
   end
 
+  def countries
+    as_json.keys.map { |slug| country(slug) }.sort_by(&:name)
+  end
+
   # super-simplistic adapter for the inner data. Over time it might make
   # sense to properly extract this to its own class, but for now we just
   # want to tidy the interface up a little so that this is substitutable

--- a/t/helpers/world.rb
+++ b/t/helpers/world.rb
@@ -17,4 +17,9 @@ describe 'World' do
   it 'should have no match for non-country' do
     subject.country('narnia').must_be_nil
   end
+
+  it 'has a list of countries sorted alphabetically by name' do
+    subject.countries.first.name.must_equal 'Abkhazia'
+    subject.countries.last.name.must_equal  'Åland Islands'
+  end
 end

--- a/t/page/spider_base.rb
+++ b/t/page/spider_base.rb
@@ -5,7 +5,11 @@ require_relative '../../lib/page/spider_base'
 describe 'SpiderBase' do
   subject { Page::SpiderBase.new }
 
-  it 'should have a World hash' do
-    subject.world[:bahamas][:displayName].must_equal 'Bahamas'
+  it 'has a title' do
+    subject.title.must_include 'Robots'
+  end
+
+  it 'has the list of all countries' do
+    subject.countries.count.must_equal 245
   end
 end

--- a/t/web/spider_base.rb
+++ b/t/web/spider_base.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require 'test_helper'
+require_relative '../../app'
+
+describe 'SpiderBase' do
+  subject { Nokogiri::HTML(last_response.body) }
+
+  describe 'when viewing the status/all_countries page' do
+    before { get '/status/all_countries.html' }
+
+    it 'has every link pointing to that country’s slug' do
+      subject.css('.grid-list a/@href').first.text.must_equal '/abkhazia/'
+    end
+
+    it 'has every list item displaying that country’s name' do
+      subject.css('.grid-list h3').first.text.must_equal 'Abkhazia'
+    end
+  end
+end

--- a/views/spider_base.erb
+++ b/views/spider_base.erb
@@ -1,11 +1,11 @@
 <div class="page-section" id="home">
     <div class="container">
         <ul class="grid-list grid-list--vertically-center">
-          <% @page.world.sort_by { |k, _| k }.each do |k, v| %>
+          <% @page.countries.each do |country| %>
             <li>
-                <a class="avatar-unit" href="/<%= k %>/">
+                <a class="avatar-unit" href="/<%= country.slug.downcase %>/">
                     <span class="avatar"><i class="fa fa-users"></i></span>
-                    <h3><%= v[:displayName] %></h3>
+                    <h3><%= country.name %></h3>
                 </a>
             </li>
           <% end %>


### PR DESCRIPTION
The `spider_base` template now uses the `countries` method instead of manipulating a JSON object.