### PR TITLE
pass Country object, not slug, to Country Page

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -32,9 +32,9 @@ get '/countries.html' do
   erb :countries
 end
 
-get '/:country/' do |country|
-  @page = Page::Country.new(country: country, index: settings.index)
-  pass unless @page.country
+get '/:country/' do |slug|
+  pass unless country = settings.index.country(slug)
+  @page = Page::Country.new(country: country)
   erb :country
 end
 
@@ -66,7 +66,7 @@ end
 
 get '/:country/download.html' do |country|
   @page = Page::Download.new(country: country, index: settings.index)
-  # TODO: perhaps have a `valid?` method?
+  # TODO: move this (and others like it) to a pre-check instead
   halt(404) unless @page.country
   erb :country_download
 end

--- a/lib/page/country.rb
+++ b/lib/page/country.rb
@@ -2,21 +2,14 @@
 
 module Page
   class Country
-    def initialize(country:, index:)
-      @slug  = country
-      @index = index
+    attr_reader :country
+
+    def initialize(country:)
+      @country = country
     end
 
     def title
       "EveryPolitician: #{country.name}"
     end
-
-    def country
-      index.country(slug)
-    end
-
-    private
-
-    attr_reader :slug, :index
   end
 end

--- a/t/page/country.rb
+++ b/t/page/country.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
-require 'minitest/autorun'
+require 'test_helper'
 require_relative '../../lib/page/country'
 
 describe 'Country' do
-  subject { Page::Country.new(country: 'abkhazia', index: index_at_known_sha) }
+  subject { Page::Country.new(country: index_at_known_sha.country('abkhazia')) }
 
   it 'has the country' do
     subject.country.name.must_equal 'Abkhazia'
@@ -11,12 +11,5 @@ describe 'Country' do
 
   it 'sets the title of the page' do
     subject.title.must_include 'Abkhazia'
-  end
-
-  it 'detects that a country is missing' do
-    Page::Country.new(
-      country: 'narnia',
-      index:   index_at_known_sha
-    ).country.must_be_nil
   end
 end


### PR DESCRIPTION
If we instantiate a Country object with a slug for a country for which we don't have data, bad things ensue. Rather than making that the job of the Page object, have it require an already-instantiated (and thus valid) Country object, and make the route responsible for generating that. This approach should considerably simplify error handling everywhere and provide a cleaner separation of concerns.


Fixing up the template for this page will happen in another PR, as it's blocked by https://github.com/everypolitician/everypolitician-ruby/issues/46, and we can get this change through without waiting for that.