### PR TITLE
rearrange the Wikidata page test

### DIFF
--- a/t/page/house_wikidata.rb
+++ b/t/page/house_wikidata.rb
@@ -2,46 +2,40 @@
 require 'test_helper'
 require_relative '../../lib/page/house_wikidata'
 
+def page_for(country, house)
+  Page::HouseWikidata.new(
+    country: country,
+    house:   house,
+    index:   index_at_known_sha
+  )
+end
+
 describe 'HouseWikidata' do
-  subject do
-    Page::HouseWikidata.new(
-      country: 'austria',
-      house:   'nationalrat',
-      index:   index_at_known_sha
-    )
-  end
+  let(:austria_page)  { page_for('austria',  'nationalrat') }
+  let(:alderney_page) { page_for('alderney', 'states')      }
+  let(:uganda_page)   { page_for('uganda',   'parliament')  }
 
   it 'should return a house' do
-    subject.house.name.must_equal 'Nationalrat'
+    austria_page.house.name.must_equal 'Nationalrat'
   end
 
   it 'should return a title' do
-    subject.title.must_equal 'EveryPolitician: Austria — Nationalrat'
+    austria_page.title.must_equal 'EveryPolitician: Austria — Nationalrat'
   end
 
   it 'should pass a list of people with wikidata' do
-    subject.people_with_wikidata.map(&:name).must_include 'Cornelia Ecker'
+    austria_page.people_with_wikidata.map(&:name).must_include 'Cornelia Ecker'
   end
 
   it 'should pass an empty array when there are no people with wikidata' do
-    test_page = Page::HouseWikidata.new(
-      country: 'alderney',
-      house:   'states',
-      index:   index_at_known_sha
-    )
-    test_page.people_with_wikidata.must_be_empty
+    alderney_page.people_with_wikidata.must_be_empty
   end
 
   it 'should pass an empty array when there are no people without wikidata' do
-    subject.people_without_wikidata.must_be_empty
+    austria_page.people_without_wikidata.must_be_empty
   end
 
   it 'should pass a list of people without wikidata' do
-    test_page = Page::HouseWikidata.new(
-      country: 'uganda',
-      house:   'parliament',
-      index:   index_at_known_sha
-    )
-    test_page.people_without_wikidata.map(&:name).must_include 'Boaz Kafuda'
+    uganda_page.people_without_wikidata.map(&:name).must_include 'Boaz Kafuda'
   end
 end


### PR DESCRIPTION
Extract the set up of the Pages out to helper functions, so that the
intent of each test is more clearly visible.