### PR TITLE
Remove JSON from download template

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 ruby '2.3.1'
 
 gem 'dotenv'
-gem 'everypolitician', '~> 0.14.0', github: 'everypolitician/everypolitician-ruby'
+gem 'everypolitician', '~> 0.15.0', github: 'everypolitician/everypolitician-ruby'
 gem 'everypolitician-popolo', github: 'everypolitician/everypolitician-popolo'
 gem 'iso_country_codes'
 gem 'json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,9 +6,9 @@ GIT
 
 GIT
   remote: git://github.com/everypolitician/everypolitician-ruby.git
-  revision: dd630850b8a4659269d6f70705c28b3b3afb20a5
+  revision: 9345f50c7e18827e8b2ce0722bb632f883b74141
   specs:
-    everypolitician (0.14.0)
+    everypolitician (0.15.0)
       everypolitician-popolo
 
 GIT
@@ -88,7 +88,7 @@ PLATFORMS
 
 DEPENDENCIES
   dotenv
-  everypolitician (~> 0.14.0)!
+  everypolitician (~> 0.15.0)!
   everypolitician-popolo!
   iso_country_codes
   json

--- a/views/country_download.erb
+++ b/views/country_download.erb
@@ -1,14 +1,14 @@
 <div class="page-section page-section--grey text-center">
   <div class="container">
-    <h3>Download data for politicians in <%= @page.country[:name] %>.</h3>
+    <h3>Download data for politicians in <%= @page.country.name %>.</h3>
   </div>
 </div>
-<% @page.country[:legislatures].each do |house| %>
+<% @page.country.legislatures.each do |house| %>
   <div class="page-section">
     <div class="container">
-      <div class="country__legislature" id="legislature-<%= house[:slug].downcase %>" data-house="<%= house[:slug].downcase %>">
+      <div class="country__legislature" id="legislature-<%= house.slug.downcase %>" data-house="<%= house.slug.downcase %>">
         <div class="country__legislature__header">
-          <h2><%= house[:name] %></h2>
+          <h2><%= house.name %></h2>
         </div>
         <p>
           Read more about
@@ -30,7 +30,7 @@
             </p>
             <p>
               <a class="button button--download"
-                href="<%= house[:popolo_url] %>">
+                href="<%= house.popolo_url %>">
                 <i class="fa fa-download"></i>
                 <span class="large-screen-only">Download as</span> JSON
               </a>
@@ -47,7 +47,7 @@
             </p>
             <p>
               <a class="button button--download"
-                href="https://cdn.rawgit.com/everypolitician/everypolitician-data/<%= house[:sha] %>/<%= house[:names] %>">
+                href="https://cdn.rawgit.com/everypolitician/everypolitician-data/<%= house.sha %>/<%= house[:names] %>">
                 <i class="fa fa-download"></i>
                 <span class="large-screen-only">Download</span> names.csv
               </a>
@@ -62,21 +62,21 @@
         data on these politicians; great for spreadsheets, perfect for
         quick analysis.
       </p>
-      <ul class="grid-list grid-list--vertically-center" id="terms-<%= house[:slug].downcase %>">
-        <% house[:legislative_periods].each do |t| %>
-          <li id="term-<%= house[:slug].downcase %>-<%= t[:slug].downcase %>" style="margin-bottom:1.5em">
+      <ul class="grid-list grid-list--vertically-center" id="terms-<%= house.slug.downcase %>">
+        <% house.legislative_periods.each do |t| %>
+          <li id="term-<%= house.slug.downcase %>-<%= t.slug.downcase %>" style="margin-bottom:1.5em">
             <div class="avatar-unit">
               <span class="avatar"><i class="fa fa-university"></i></span>
-              <a href="<%= term_table_url(@page.country, house, t) %>"><h3><%= t[:name] %></h3></a>
+              <a href="<%= term_table_url(@page.country, house, t) %>"><h3><%= t.name %></h3></a>
               <p>
-                <% unless t[:start_date].to_s.empty? and t[:end_date].to_s.empty? %>
-                  <%= t[:start_date] %> - <%= t[:end_date] %>
+                <% unless t.start_date.to_s.empty? and t.end_date.to_s.empty? %>
+                 <%= t.start_date %> - <%=  t.end_date rescue '' %>
                 <% end %>
               </p>
             </div>
             <div class="avatar-unit">
               <a class="button button--small button--download" style="margin:0.5em 0"
-                href="<%= t[:csv_url] %>">
+                href="<%= t.csv_url %>">
                 <i class="fa fa-download"></i>
                 <span class="large-screen-only">Download</span> CSV
               </a>
@@ -93,7 +93,7 @@
     <div class="layout-equal-columns">
       <div class="first-column">
         <p>
-          Want politicians who aren’t from <%= @page.country[:name] %>?
+          Want politicians who aren’t from <%= @page.country.name %>?
           No problem: we’ve got the world covered.
         </p>
         <p>

--- a/views/country_download.erb
+++ b/views/country_download.erb
@@ -69,8 +69,8 @@
               <span class="avatar"><i class="fa fa-university"></i></span>
               <a href="<%= term_table_url(@page.country, house, t) %>"><h3><%= t.name %></h3></a>
               <p>
-                <% unless t.start_date.to_s.empty? and t.end_date.to_s.empty? %>
-                 <%= t.start_date %> - <%=  t.end_date rescue '' %>
+                <% if t.start_date || t.end_date %>
+                 <%= t.start_date %> - <%=  t.end_date %>
                 <% end %>
               </p>
             </div>


### PR DESCRIPTION
Removing JSON references from download template

Removes all but one (house[:names] depends on new method implemented in EP Ruby (https://github.com/everypolitician/everypolitician-ruby/issues/49)).