### PR TITLE
Remove all brackets from the term page class

### DIFF
--- a/lib/page/term_table.rb
+++ b/lib/page/term_table.rb
@@ -12,7 +12,7 @@ module Page
     end
 
     def title
-      parts = [country.name, house[:name], current_term[:name]]
+      parts = [country.name, house.name, current_term.name]
       "EveryPolitician: #{parts.join(' - ')}"
     end
 
@@ -25,13 +25,13 @@ module Page
     end
 
     def house
-      country[:legislatures].find do |h|
-        h[:slug].downcase == house_slug.downcase
+      country.legislatures.find do |house|
+        house.slug.downcase == house_slug.downcase
       end
     end
 
     def terms
-      house[:legislative_periods]
+      house.legislative_periods
     end
 
     def next_term
@@ -59,7 +59,7 @@ module Page
                       .group_by(&:on_behalf_of_id)
                       .map     { |group_id, mems| [org_lookup[group_id], mems] }
                       .sort_by { |group, mems| [-mems.count, group.name] }
-                      .map     do |group, mems|
+                      .map do    |group, mems|
         {
           group_id:     group.id.split('/').last,
           name:         group.name,
@@ -139,7 +139,7 @@ module Page
     end
 
     def popolo_file
-      @popolo_file ||= EveryPolitician::GithubFile.new(house[:popolo], house[:sha])
+      @popolo_file ||= EveryPolitician::GithubFile.new(house[:popolo], house.sha)
     end
 
     def hashed_adjacent_terms
@@ -151,7 +151,7 @@ module Page
       [nil, terms, nil]
         .flatten
         .each_cons(3)
-        .find { |_before, current, _after| current[:slug] == term_id }
+        .find { |_before, current, _after| current.slug == term_id }
     end
 
     def memberships_at_end_of_current_term
@@ -190,7 +190,7 @@ module Page
 
     def image_proxy_url(id)
       'https://mysociety.github.io/politician-image-proxy' \
-      "/#{country[:slug]}/#{house[:slug]}/#{id}/140x140.jpeg"
+      "/#{country.slug}/#{house.slug}/#{id}/140x140.jpeg"
     end
 
     # Caches for faster lookup

--- a/t/page/term_table.rb
+++ b/t/page/term_table.rb
@@ -22,11 +22,11 @@ describe 'TermTable' do
     end
 
     it 'finds nationalrat as a legislature' do
-      subject.house[:name].must_equal 'Nationalrat'
+      subject.house.name.must_equal 'Nationalrat'
     end
 
     it 'has a list of terms for Austria' do
-      subject.terms.first[:start_date].must_equal '2013-09-29'
+      subject.terms.first.start_date.to_s.must_equal '2013-09-29'
     end
 
     it 'shows the name in the title' do
@@ -106,15 +106,15 @@ describe 'TermTable' do
     end
 
     it 'knows about the current term' do
-      subject.current_term[:slug].must_equal '55'
+      subject.current_term.slug.must_equal '55'
     end
 
     it 'knows about the previous term' do
-      subject.prev_term[:slug].must_equal '54'
+      subject.prev_term.slug.must_equal '54'
     end
 
     it 'knows about the next term' do
-      subject.next_term[:slug].must_equal '56'
+      subject.next_term.slug.must_equal '56'
     end
   end
 end


### PR DESCRIPTION
When I started working on another template I realized that the term table class was using a lot of brackets as well instead of the methods, so I decided to make this change first before updating the term table template.

Things spotted but not fixed here, as they will require a bit more work, so maybe they must each have their own PR:

* in the Popolo::JSON instance, we are calling `popolo.popolo[:meta][:sources]`. Maybe we could add a method to that class to return these sources.

* in `current_term[:csv_url]`, this is something that was proposed but not added yet, there is an issue about it: https://github.com/everypolitician/everypolitician-ruby/issues/32 

* in `house[:popolo]` I guess it refers to the `popolo_url`, however, I think a new vcr cassete might be needed, as this happens at the moment:

```ruby
> house[:popolo]
"data/Northern_Ireland/Assembly/ep-popolo-v1.0.json"
> house.popolo_url
"https://cdn.rawgit.com/everypolitician/everypolitician-data/1a17862/data/Northern_Ireland/Assembly/ep-popolo-v1.0.json"
```
so the tests fail if I change that. Will make a specific PR for that.