### PR TITLE
Update EP-ruby version to 0.17

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 ruby '2.3.1'
 
 gem 'dotenv'
-gem 'everypolitician', '~> 0.15.0', github: 'everypolitician/everypolitician-ruby'
+gem 'everypolitician', '~> 0.17.0', github: 'everypolitician/everypolitician-ruby'
 gem 'everypolitician-popolo', github: 'everypolitician/everypolitician-popolo'
 gem 'iso_country_codes'
 gem 'json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,9 +6,9 @@ GIT
 
 GIT
   remote: git://github.com/everypolitician/everypolitician-ruby.git
-  revision: 9345f50c7e18827e8b2ce0722bb632f883b74141
+  revision: 6ed485846e1624fd9441f777e190d3ea31efed7e
   specs:
-    everypolitician (0.15.0)
+    everypolitician (0.17.0)
       everypolitician-popolo
 
 GIT
@@ -88,7 +88,7 @@ PLATFORMS
 
 DEPENDENCIES
   dotenv
-  everypolitician (~> 0.15.0)!
+  everypolitician (~> 0.17.0)!
   everypolitician-popolo!
   iso_country_codes
   json


### PR DESCRIPTION
This PR updates the version of the `everypolitician-ruby` gem so that it uses the last changes, in particular, the changes in the `csv_url` methods in the `Legislature` and `LegislativePeriod` classes.