### PR TITLE
Remove csv_url method from Page::TermTable

### DIFF
--- a/lib/page/term_table.rb
+++ b/lib/page/term_table.rb
@@ -47,7 +47,7 @@ module Page
     end
 
     def csv_url
-      current_term[:csv_url]
+      current_term.csv_url
     end
 
     def popolo_url

--- a/lib/page/term_table.rb
+++ b/lib/page/term_table.rb
@@ -46,10 +46,6 @@ module Page
       hashed_adjacent_terms[:current_term]
     end
 
-    def csv_url
-      current_term.csv_url
-    end
-
     def popolo_url
       popolo_file.url
     end

--- a/t/page/term_table.rb
+++ b/t/page/term_table.rb
@@ -41,10 +41,6 @@ describe 'TermTable' do
       subject.title.must_include '25'
     end
 
-    it 'has a url pointing to the csv file' do
-      subject.csv_url.must_equal 'https://cdn.rawgit.com/everypolitician/everypolitician-data/3df153b/data/Austria/Nationalrat/term-25.csv'
-    end
-
     it 'has a url pointing to the popolo file' do
       subject.popolo_url.must_equal 'https://cdn.rawgit.com/everypolitician/everypolitician-data/3df153b/data/Austria/Nationalrat/ep-popolo-v1.0.json'
     end


### PR DESCRIPTION
<s>Now that the EP-ruby has been updated to use the right `csv_url` coming from the data in terms, we can switch to calling the method instead of accessing the raw data through the hash key.</s>

The Term Table page no longer displays download links directly (these are now on the Download page), so we don't need a  `csv_url` method. 