### PR TITLE
Remove githubfile class

### DIFF
--- a/lib/everypolitician_extensions.rb
+++ b/lib/everypolitician_extensions.rb
@@ -9,28 +9,6 @@ module EveryPolitician
       legislatures.map(&:person_count).inject(:+)
     end
   end
-
-  class GithubFile
-    GH_PATH = 'https://cdn.rawgit.com/everypolitician/everypolitician-data/%s/%s'
-
-    # TODO: investigate whether we can remove this caching
-    # (possibly easier to just remove this entire class)
-    def initialize(file, sha, cache_dir = '_cached_data')
-      @url = GH_PATH % [sha, file]
-
-      FileUtils.mkpath cache_dir
-      @cache_file = File.join cache_dir, sha + '-' + file.tr('/', '-')
-    end
-
-    attr_reader :url
-
-    def raw
-      @_data ||= begin
-        File.write(@cache_file, open(@url).read) unless File.exist? @cache_file
-        File.read(@cache_file)
-      end
-    end
-  end
 end
 
 EveryPolitician::Country.include EveryPolitician::CountryExtension


### PR DESCRIPTION
There is no need to use the `GitHubFile` helper anymore to build the popolo url and file, since legislatures have a `popolo` and `popolo_url` methods that can be used instead.

Also, since this class is not needed anymore, as EP-ruby and EP-popolo libraries already provide that functionality, this class is not used anywhere at this point.

This PR removes that class from the `CountryExtensions` helper and uses the proper methods from the EP-ruby legislature class.