### PR TITLE
Removing hash references from term_table.erb

### DIFF
--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -1,6 +1,6 @@
 <div class="page-section" id="term">
     <div class="container text-center">
-        <h1><span class="avatar"><i class="fa fa-university"></i></span> <%= @page.current_term[:name] %></h1>
+        <h1><span class="avatar"><i class="fa fa-university"></i></span> <%= @page.current_term.name %></h1>
       <% unless @page.current_term[:start_date].to_s.empty? and @page.current_term[:end_date].to_s.empty? %>
         <p><%= @page.current_term[:start_date] %> – <%= @page.current_term[:end_date] or 'current' %></p>
       <% end %>
@@ -21,8 +21,8 @@
               <span class="term-navigation__jump">Jump to:
                   <select class="js-navigation-menu" data-ga-track-select="Jump to term by date">
                     <% @page.terms.each do |t| %>
-                      <option value="<%= term_table_url(@page.country, @page.house, t) %>" <% if t[:name] == @page.current_term[:name] %>selected<% end %>>
-                        <%= t[:name] %>
+                      <option value="<%= term_table_url(@page.country, @page.house, t) %>" <% if t.name == @page.current_term.name %>selected<% end %>>
+                        <%= t.name %>
                         <% unless t[:start_date].to_s.empty? and t[:end_date].to_s.empty? %>
                           (<%= t[:start_date] %>–<%= t[:end_date] or 'current' %>)
                         <% end %>

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -1,8 +1,8 @@
 <div class="page-section" id="term">
     <div class="container text-center">
         <h1><span class="avatar"><i class="fa fa-university"></i></span> <%= @page.current_term.name %></h1>
-      <% unless @page.current_term[:start_date].to_s.empty? and @page.current_term[:end_date].to_s.empty? %>
-        <p><%= @page.current_term[:start_date] %> – <%= @page.current_term[:end_date] or 'current' %></p>
+      <% if @page.current_term.start_date || @page.current_term.end_date %>
+        <p><%= @page.current_term.start_date %> – <%= @page.current_term.end_date or 'current' %></p>
       <% end %>
     </div>
 </div>
@@ -23,8 +23,8 @@
                     <% @page.terms.each do |t| %>
                       <option value="<%= term_table_url(@page.country, @page.house, t) %>" <% if t.name == @page.current_term.name %>selected<% end %>>
                         <%= t.name %>
-                        <% unless t[:start_date].to_s.empty? and t[:end_date].to_s.empty? %>
-                          (<%= t[:start_date] %>–<%= t[:end_date] or 'current' %>)
+                        <% if t.start_date || t.end_date %>
+                          (<%= t.start_date %>–<%= t.end_date or 'current' %>)
                         <% end %>
                       </option>
                     <% end %>


### PR DESCRIPTION
Replaced:
@page.current_term[:name]
@page.terms.first[:name]
@page.current_term[:end_date]
@page.current_term[:name]
@page.terms.first[:start_date]
@page.terms.first[:end_date]

Will tackle remains []s in separate PRs:
@page.people...
@page.group_data...
@page.percentages...