### PR TITLE
Remove `popolo_url` method

### DIFF
--- a/lib/page/term_table.rb
+++ b/lib/page/term_table.rb
@@ -46,10 +46,6 @@ module Page
       hashed_adjacent_terms[:current_term]
     end
 
-    def popolo_url
-      popolo_file.url
-    end
-
     def group_data
       @group_data ||= memberships_at_end_of_current_term
                       .group_by(&:on_behalf_of_id)

--- a/t/page/term_table.rb
+++ b/t/page/term_table.rb
@@ -41,10 +41,6 @@ describe 'TermTable' do
       subject.title.must_include '25'
     end
 
-    it 'has a url pointing to the popolo file' do
-      subject.popolo_url.must_equal 'https://cdn.rawgit.com/everypolitician/everypolitician-data/3df153b/data/Austria/Nationalrat/ep-popolo-v1.0.json'
-    end
-
     describe 'when calculating the group data' do
       it 'sends the right memberships' do
         subject.group_data.must_equal [


### PR DESCRIPTION
The term-table page doesn't need to expose the popolo_url any longer
(as downloads happen from a separate page now), so we can kill off this
method.