### PR TITLE
Remove the GithubFile reference in the term table

### DIFF
--- a/lib/page/term_table.rb
+++ b/lib/page/term_table.rb
@@ -125,11 +125,7 @@ module Page
     attr_reader :country_slug, :house_slug, :term_id, :index
 
     def popolo
-      @popolo ||= EveryPolitician::Popolo.parse(popolo_file.raw)
-    end
-
-    def popolo_file
-      @popolo_file ||= EveryPolitician::GithubFile.new(house[:popolo], house.sha)
+      @popolo ||= house.popolo
     end
 
     def hashed_adjacent_terms


### PR DESCRIPTION
There is no need to use the GitHubFile helper anymore to build the popolo url and file, since legislatures have popolo and popolo_url methods that can be used instead.

(cherry-picked from https://github.com/everypolitician/viewer-sinatra/pull/14954)