### PR TITLE
Download Page: pass a Country not a Slug

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -60,10 +60,9 @@ get '/:country/:house/term-table/:id.html' do |country, house, termid|
   erb :term_table
 end
 
-get '/:country/download.html' do |country|
+get '/:country/download.html' do |slug|
+  pass unless country = settings.index.country(slug)
   @page = Page::Download.new(country: country, index: settings.index)
-  # TODO: move this (and others like it) to a pre-check instead
-  halt(404) unless @page.country
   erb :country_download
 end
 

--- a/lib/page/download.rb
+++ b/lib/page/download.rb
@@ -2,8 +2,10 @@
 
 module Page
   class Download
+    attr_reader :country
+
     def initialize(country:, index:)
-      @country_slug = country
+      @country = country
       @index = index
     end
 
@@ -15,12 +17,8 @@ module Page
       index.index_url
     end
 
-    def country
-      index.country(country_slug)
-    end
-
     private
 
-    attr_reader :country_slug, :index
+    attr_reader :index
   end
 end

--- a/t/page/download.rb
+++ b/t/page/download.rb
@@ -6,7 +6,7 @@ describe 'Download' do
   describe 'Colombia' do
     subject do
       Page::Download.new(
-        country: 'colombia',
+        country: index_at_known_sha.country('colombia'),
         index:   index_at_known_sha
       )
     end
@@ -25,15 +25,6 @@ describe 'Download' do
       it 'should be at rawgit' do
         subject.download_url.must_include 'cdn.rawgit.com'
       end
-    end
-  end
-
-  describe 'Narnia' do
-    it 'should have no country' do
-      Page::Download.new(
-        country: 'narnia',
-        index:   index_at_known_sha
-      ).country.must_be_nil
     end
   end
 end


### PR DESCRIPTION
in keeping with how we're now constructing other Page objects, pass
through an actual Country object (`pass`-ing if we can't make one), not
just a slug.