### PR TITLE
Add rake task for downloading missing everypolitician-data fixtures

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -27,3 +27,9 @@ Rake::TestTask.new do |t|
 end
 
 RuboCop::RakeTask.new
+
+task 'everypolitician-data', [:path] do |_, args|
+  fixture_path = Pathname.new(File.join('t/fixtures/everypolitician-data', args[:path]))
+  mkdir_p(fixture_path.dirname)
+  fixture_path.write(open("https://cdn.rawgit.com/everypolitician/everypolitician-data/#{args[:path]}").read)
+end

--- a/t/test_helper.rb
+++ b/t/test_helper.rb
@@ -30,6 +30,8 @@ module Minitest
     def stub_everypolitician_data_request(path)
       stub_request(:get, "https://cdn.rawgit.com/everypolitician/everypolitician-data/#{path}")
         .to_return(body: File.read("t/fixtures/everypolitician-data/#{path}"))
+    rescue Errno::ENOENT => e
+      raise "#{e.message}\n\nTo download this fixture run the following\n\n\tbundle exec rake 'everypolitician-data[#{path}]'\n"
     end
 
     private


### PR DESCRIPTION
Following on from https://github.com/everypolitician/viewer-sinatra/pull/15129 this provides a handy rake task to run when you want to quickly download a missing fixture for `stub_everypolitician_data_request`.