### PR TITLE
Remove indirect access in layout template

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -59,12 +59,12 @@
                 <div class="site-header__logo">
                     <h2>
                       <% if @country %>
-                        <a href="/<%= @country[:slug].downcase %>/"><%= @country[:name] %></a>
+                        <a href="/<%= @country.slug.downcase %>/"><%= @country.name %></a>
                       <% else %>
                         <a href="/"><span class="header-logo">EveryPolitician</span></a>
                       <% end %>
                     </h2>
-                    <% if @house %><h3><%= @house[:name] %></h3><% end %>
+                    <% if @house %><h3><%= @house.name %></h3><% end %>
                 </div>
                 <div class="site-header__navigation site-header__navigation--primary">
                     <nav role="navigation">


### PR DESCRIPTION
Replace all calls to `house[:name]`, `country[:slug]` etc to direct
method calls (`house.name`, `country.slug`)