### PR TITLE
Move methods from TermTable to Term

### DIFF
--- a/lib/everypolitician_extensions.rb
+++ b/lib/everypolitician_extensions.rb
@@ -24,7 +24,14 @@ module EveryPolitician
       current
     end
   end
+
+  module LegislativePeriodExtension
+    def memberships
+      legislature.popolo.memberships.select { |m| m.legislative_period_id == id }
+    end
+  end
 end
 
 EveryPolitician::Country.include EveryPolitician::CountryExtension
 EveryPolitician::Legislature.include EveryPolitician::LegislatureExtension
+EveryPolitician::LegislativePeriod.include EveryPolitician::LegislativePeriodExtension

--- a/lib/everypolitician_extensions.rb
+++ b/lib/everypolitician_extensions.rb
@@ -27,7 +27,13 @@ module EveryPolitician
 
   module LegislativePeriodExtension
     def memberships
-      legislature.popolo.memberships.select { |m| m.legislative_period_id == id }
+      @m ||= legislature.popolo.memberships.select { |m| m.legislative_period_id == id }
+    end
+
+    def memberships_at_end
+      memberships.select do |mem|
+        mem.end_date.to_s.empty? || mem.end_date == end_date
+      end
     end
   end
 end

--- a/lib/everypolitician_extensions.rb
+++ b/lib/everypolitician_extensions.rb
@@ -13,9 +13,15 @@ module EveryPolitician
   module LegislatureExtension
     # UK.legislature('Commons').term(65)
     def term(termid)
-      legislative_periods.find do |t|
-        t.id.split('/').last == termid.to_s
+      after, current, before = [nil, legislative_periods, nil]
+                               .flatten
+                               .each_cons(3)
+                               .find do |_, term, _|
+        term.id.split('/').last == termid.to_s
       end
+      current.define_singleton_method(:prev) { before }
+      current.define_singleton_method(:next) { after }
+      current
     end
   end
 end

--- a/lib/page/term_table.rb
+++ b/lib/page/term_table.rb
@@ -42,7 +42,8 @@ module Page
     end
 
     def group_data
-      @group_data ||= memberships_at_end_of_current_term
+      @group_data ||= term
+                      .memberships_at_end
                       .group_by(&:on_behalf_of_id)
                       .map     { |group_id, mems| [org_lookup[group_id], mems] }
                       .sort_by { |group, mems| [-mems.count, group.name] }
@@ -123,12 +124,6 @@ module Page
 
     def popolo
       @popolo ||= house.popolo
-    end
-
-    def memberships_at_end_of_current_term
-      @maeoct ||= current_term_memberships.select do |mem|
-        mem.end_date.to_s.empty? || mem.end_date == current_term[:end_date]
-      end
     end
 
     def wanted

--- a/lib/page/term_table.rb
+++ b/lib/page/term_table.rb
@@ -121,10 +121,6 @@ module Page
 
     attr_reader :term
 
-    def term_id
-      term.id.split('/').last
-    end
-
     def popolo
       @popolo ||= house.popolo
     end
@@ -182,9 +178,7 @@ module Page
     end
 
     def current_term_memberships
-      @current_term_memberships ||= popolo.memberships.select do |mem|
-        mem.legislative_period_id.split('/').last == term_id
-      end
+      @ctm ||= term.memberships
     end
 
     def people_for_current_term

--- a/lib/page/term_table.rb
+++ b/lib/page/term_table.rb
@@ -30,15 +30,15 @@ module Page
     end
 
     def next_term
-      hashed_adjacent_terms[:prev_term]
+      term.next
     end
 
     def prev_term
-      hashed_adjacent_terms[:next_term]
+      term.prev
     end
 
     def current_term
-      hashed_adjacent_terms[:current_term]
+      term
     end
 
     def group_data
@@ -127,18 +127,6 @@ module Page
 
     def popolo
       @popolo ||= house.popolo
-    end
-
-    def hashed_adjacent_terms
-      (@prev_term, @current_term, @next_term) = adjacent_terms
-      { next_term: @next_term, current_term: @current_term, prev_term: @prev_term }
-    end
-
-    def adjacent_terms
-      [nil, terms, nil]
-        .flatten
-        .each_cons(3)
-        .find { |_before, current, _after| current.slug == term_id }
     end
 
     def memberships_at_end_of_current_term


### PR DESCRIPTION
* Let a Term know its next/prev term
* Add LegislativePeriod.memberships
* Add LegislativePeriod.members_at_end

These let us pull more of the logic out of the TermTable Page, and onto the Term itself.