### PR TITLE
fix incorrect nesting of email check

### DIFF
--- a/lib/page/term_table.rb
+++ b/lib/page/term_table.rb
@@ -87,24 +87,23 @@ module Page
         p[:bio] << { type: 'Died', value: person.death_date } if person.death_date
         p[:bio] << { type: 'Prefix', value: person.honorific_prefix } if person.honorific_prefix
         p[:bio] << { type: 'Suffix', value: person.honorific_suffix } if person.honorific_suffix
-        p[:contacts] << { type: 'Email', value: person.email, link: "mailto:#{person.email}" }
 
-        if person.email
-          p[:contacts] << { type: 'Phone', value: person.phone } if person.phone
-          p[:contacts] << { type: 'Fax', value: person.fax } if person.fax
+        p[:contacts] << { type: 'Email', value: person.email, link: "mailto:#{person.email}" } if person.email
+        p[:contacts] << { type: 'Phone', value: person.phone } if person.phone
+        p[:contacts] << { type: 'Fax', value: person.fax } if person.fax
 
-          top_identifiers.each do |scheme|
-            id = person.identifiers.find { |i| i[:scheme] == scheme }
-            next if id.nil?
-            identifier = { type: id[:scheme], value: id[:identifier] }
-            if identifier[:type] == 'wikidata'
-              identifier[:link] = "https://www.wikidata.org/wiki/#{id[:identifier]}"
-            elsif identifier[:type] == 'viaf'
-              identifier[:link] = "https://viaf.org/viaf/#{id[:identifier]}/"
-            end
-            p[:identifiers] << identifier
+        top_identifiers.each do |scheme|
+          id = person.identifiers.find { |i| i[:scheme] == scheme }
+          next if id.nil?
+          identifier = { type: id[:scheme], value: id[:identifier] }
+          if identifier[:type] == 'wikidata'
+            identifier[:link] = "https://www.wikidata.org/wiki/#{id[:identifier]}"
+          elsif identifier[:type] == 'viaf'
+            identifier[:link] = "https://viaf.org/viaf/#{id[:identifier]}/"
           end
+          p[:identifiers] << identifier
         end
+
         p
       end
     end

--- a/t/page/term_table.rb
+++ b/t/page/term_table.rb
@@ -66,7 +66,7 @@ describe 'TermTable' do
     end
 
     it 'knows percentage of people that have special data' do
-      expected = { social: 20, bio: 100, contacts: 100, identifiers: 93 }
+      expected = { social: 20, bio: 100, contacts: 93, identifiers: 100 }
       subject.percentages.must_equal expected
     end
 
@@ -82,9 +82,6 @@ describe 'TermTable' do
         contacts:    [{ type: 'Email', value: 'angela.fichtinger@parlament.gv.at', link: 'mailto:angela.fichtinger@parlament.gv.at' }],
         identifiers: [{ type: 'wikidata', value: 'Q15783437', link: 'https://www.wikidata.org/wiki/Q15783437' }, { type: 'parlaments_at', value: '83146' }],
       }
-    end
-
-    def percentages
     end
   end
 


### PR DESCRIPTION
the check should apply to the prior block (should we show email), not
the following one (should we show other contacts and identifiers)

Fixes https://github.com/everypolitician/viewer-sinatra/issues/15204

![screen shot 2016-08-27 at 16 27 45](https://cloud.githubusercontent.com/assets/57483/18028300/4a9e8448-6c73-11e6-81f1-800fa3c587d5.png)
