### PR TITLE
Simplify the test stubbing

### DIFF
--- a/t/page/house_wikidata.rb
+++ b/t/page/house_wikidata.rb
@@ -9,14 +9,22 @@ def page_for(country, house)
 end
 
 describe 'HouseWikidata' do
-  let(:austria_page)  { page_for('austria',  'nationalrat') }
-  let(:alderney_page) { page_for('alderney', 'states')      }
-  let(:uganda_page)   { page_for('uganda',   'parliament')  }
+  let(:austria_page) do
+    stub_everypolitician_data_request('3df153b/data/Austria/Nationalrat/ep-popolo-v1.0.json')
+    page_for('austria', 'nationalrat')
+  end
+
+  let(:alderney_page) do
+    stub_everypolitician_data_request('beb21e5/data/Alderney/States/ep-popolo-v1.0.json')
+    page_for('alderney', 'states')
+  end
+
+  let(:uganda_page) do
+    stub_everypolitician_data_request('0cef4ab/data/Uganda/Parliament/ep-popolo-v1.0.json')
+    page_for('uganda', 'parliament')
+  end
 
   before do
-    stub_everypolitician_data_request('3df153b/data/Austria/Nationalrat/ep-popolo-v1.0.json')
-    stub_everypolitician_data_request('beb21e5/data/Alderney/States/ep-popolo-v1.0.json')
-    stub_everypolitician_data_request('0cef4ab/data/Uganda/Parliament/ep-popolo-v1.0.json')
   end
 
   it 'should return a house' do

--- a/t/page/house_wikidata.rb
+++ b/t/page/house_wikidata.rb
@@ -10,17 +10,17 @@ end
 
 describe 'HouseWikidata' do
   let(:austria_page) do
-    stub_everypolitician_data_request('3df153b/data/Austria/Nationalrat/ep-popolo-v1.0.json')
+    stub_popolo('3df153b', 'Austria/Nationalrat')
     page_for('austria', 'nationalrat')
   end
 
   let(:alderney_page) do
-    stub_everypolitician_data_request('beb21e5/data/Alderney/States/ep-popolo-v1.0.json')
+    stub_popolo('beb21e5', 'Alderney/States')
     page_for('alderney', 'states')
   end
 
   let(:uganda_page) do
-    stub_everypolitician_data_request('0cef4ab/data/Uganda/Parliament/ep-popolo-v1.0.json')
+    stub_popolo('0cef4ab', 'Uganda/Parliament')
     page_for('uganda', 'parliament')
   end
 

--- a/t/page/needed.rb
+++ b/t/page/needed.rb
@@ -3,17 +3,8 @@ require_relative '../../lib/page/needed'
 require 'test_helper'
 
 describe 'Needed' do
-  before do
-    stub_request(:get, 'https://api.github.com/repos/everypolitician/everypolitician-data/issues?labels=New%20Country,To%20Find&per_page=100')
-      .to_return(body: File.read('t/fixtures/github-issues-to-find.json'), headers: { 'Content-Type' => 'application/json' })
-
-    stub_request(:get, 'https://api.github.com/repos/everypolitician/everypolitician-data/issues?labels=New%20Country,To%20Scrape&per_page=100')
-      .to_return(body: '{}', headers: { 'Content-Type' => 'application/json' })
-    stub_request(:get, 'https://api.github.com/repos/everypolitician/everypolitician-data/issues?labels=New%20Country,3%20-%20WIP&per_page=100')
-      .to_return(body: '{}', headers: { 'Content-Type' => 'application/json' })
-  end
-
   subject do
+    stub_github_api
     Page::Needed.new(access_token: ENV['GITHUB_ACCESS_TOKEN'])
   end
 

--- a/t/page/term_table.rb
+++ b/t/page/term_table.rb
@@ -4,11 +4,8 @@ require_relative '../../lib/page/term_table'
 
 describe 'TermTable' do
   describe 'Austria' do
-    before do
-      stub_everypolitician_data_request('3df153b/data/Austria/Nationalrat/ep-popolo-v1.0.json')
-    end
-
     subject do
+      stub_everypolitician_data_request('3df153b/data/Austria/Nationalrat/ep-popolo-v1.0.json')
       Page::TermTable.new(
         term: index_at_known_sha.country('austria').legislature('nationalrat').term('25')
       )

--- a/t/page/term_table.rb
+++ b/t/page/term_table.rb
@@ -5,7 +5,7 @@ require_relative '../../lib/page/term_table'
 describe 'TermTable' do
   describe 'Austria' do
     subject do
-      stub_everypolitician_data_request('3df153b/data/Austria/Nationalrat/ep-popolo-v1.0.json')
+      stub_popolo('3df153b', 'Austria/Nationalrat')
       Page::TermTable.new(
         term: index_at_known_sha.country('austria').legislature('nationalrat').term('25')
       )

--- a/t/test_helper.rb
+++ b/t/test_helper.rb
@@ -17,10 +17,18 @@ module Minitest
       Sinatra::Application
     end
 
+    def stub_json(url, file = nil)
+      stub_request(:get, url)
+        .to_return(
+          body:    file ? File.read("t/fixtures/#{file}.json") : '{}',
+          headers: { 'Content-Type' => 'application/json' }
+        )
+    end
+
     before do
       cj_file = %r{#{cdn}/#{ep_repo}/\w+/countries.json}
       fixture = Pathname.new('t/fixtures/d8a4682f-countries.json')
-      WebMock.stub_request(:get, cj_file) .to_return(body: fixture.read)
+      stub_request(:get, cj_file).to_return(body: fixture.read)
     end
 
     def index_at_known_sha
@@ -32,6 +40,15 @@ module Minitest
         .to_return(body: File.read("t/fixtures/everypolitician-data/#{path}"))
     rescue Errno::ENOENT => error
       raise "#{error.message}\n\nTo download this fixture run the following\n\n\tbundle exec rake 'everypolitician-data[#{path}]'\n"
+    end
+
+    def stub_github_api
+      stub_json(
+        'https://api.github.com/repos/everypolitician/everypolitician-data/issues?labels=New%20Country,To%20Find&per_page=100',
+        'github-issues-to-find'
+      )
+      stub_json('https://api.github.com/repos/everypolitician/everypolitician-data/issues?labels=New%20Country,To%20Scrape&per_page=100')
+      stub_json('https://api.github.com/repos/everypolitician/everypolitician-data/issues?labels=New%20Country,3%20-%20WIP&per_page=100')
     end
 
     private

--- a/t/test_helper.rb
+++ b/t/test_helper.rb
@@ -42,6 +42,10 @@ module Minitest
       raise "#{error.message}\n\nTo download this fixture run the following\n\n\tbundle exec rake 'everypolitician-data[#{path}]'\n"
     end
 
+    def stub_popolo(sha, legislature)
+      stub_everypolitician_data_request("#{sha}/data/#{legislature}/ep-popolo-v1.0.json")
+    end
+
     def stub_github_api
       stub_json(
         'https://api.github.com/repos/everypolitician/everypolitician-data/issues?labels=New%20Country,To%20Find&per_page=100',

--- a/t/web/needed.rb
+++ b/t/web/needed.rb
@@ -3,20 +3,13 @@ require 'test_helper'
 require_relative '../../app'
 
 describe 'Needed' do
-  before do
-    stub_request(:get, 'https://api.github.com/repos/everypolitician/everypolitician-data/issues?labels=New%20Country,To%20Find&per_page=100')
-      .to_return(body: File.read('t/fixtures/github-issues-to-find.json'), headers: { 'Content-Type' => 'application/json' })
-
-    stub_request(:get, 'https://api.github.com/repos/everypolitician/everypolitician-data/issues?labels=New%20Country,To%20Scrape&per_page=100')
-      .to_return(body: '{}', headers: { 'Content-Type' => 'application/json' })
-    stub_request(:get, 'https://api.github.com/repos/everypolitician/everypolitician-data/issues?labels=New%20Country,3%20-%20WIP&per_page=100')
-      .to_return(body: '{}', headers: { 'Content-Type' => 'application/json' })
-  end
-
   subject { Nokogiri::HTML(last_response.body) }
 
   describe 'when viewing the What’s Needed page' do
-    before { get '/needed.html' }
+    before do
+      stub_github_api
+      get '/needed.html'
+    end
 
     it 'should need a scraper for Eritrea' do
       last_response.body.must_include 'Eritrea'

--- a/t/web/term_table/australia.rb
+++ b/t/web/term_table/australia.rb
@@ -5,11 +5,6 @@ require_relative '../../../app'
 describe 'Per Country Tests: Australia' do
   subject { Nokogiri::HTML(last_response.body) }
 
-  before do
-    stub_everypolitician_data_request('6139efe/data/Australia/Representatives/ep-popolo-v1.0.json')
-    stub_everypolitician_data_request('f8dcbd9/data/Australia/Senate/ep-popolo-v1.0.json')
-  end
-
   describe 'Country page' do
     before       { get '/australia/' }
     let(:house)  { subject.css('#terms-representatives') }
@@ -25,7 +20,10 @@ describe 'Per Country Tests: Australia' do
   end
 
   describe 'Representatives' do
-    before { get '/australia/representatives/term-table/44.html' }
+    before do
+      stub_everypolitician_data_request('6139efe/data/Australia/Representatives/ep-popolo-v1.0.json')
+      get '/australia/representatives/term-table/44.html'
+    end
 
     it 'should include a Representative' do
       subject.css('div.grid-list').text.must_include 'Tony Abbott'
@@ -52,7 +50,10 @@ describe 'Per Country Tests: Australia' do
   end
 
   describe 'Senate' do
-    before { get '/australia/senate/term-table/44.html' }
+    before do
+      stub_everypolitician_data_request('f8dcbd9/data/Australia/Senate/ep-popolo-v1.0.json')
+      get '/australia/senate/term-table/44.html'
+    end
 
     it 'should include a Senator' do
       subject.css('div.grid-list').text.must_include 'Alan Eggleston'

--- a/t/web/term_table/party_groupings.rb
+++ b/t/web/term_table/party_groupings.rb
@@ -3,31 +3,36 @@ require 'test_helper'
 require_relative '../../../app'
 
 describe 'Party Groupings section' do
-  before do
-    stub_everypolitician_data_request('beb21e5/data/Alderney/States/ep-popolo-v1.0.json')
-    stub_everypolitician_data_request('f88ce37/data/Estonia/Riigikogu/ep-popolo-v1.0.json')
-    stub_everypolitician_data_request('75b7651/data/Transnistria/Supreme_Council/ep-popolo-v1.0.json')
-  end
-
   subject { Nokogiri::HTML(last_response.body) }
   let(:heading) { subject.css('.party-groupings__title h2').text }
 
   describe 'only Independent' do
-    before { get '/alderney/states/term-table/2014.html' }
+    before do
+      stub_everypolitician_data_request('beb21e5/data/Alderney/States/ep-popolo-v1.0.json')
+      get '/alderney/states/term-table/2014.html'
+    end
+
     it 'should have no party groupings (all Independent)' do
       heading.must_be_empty
     end
   end
 
   describe 'only Unknown' do
-    before { get '/transnistria/supreme-council/term-table/6.html' }
+    before do
+      stub_everypolitician_data_request('75b7651/data/Transnistria/Supreme_Council/ep-popolo-v1.0.json')
+      get '/transnistria/supreme-council/term-table/6.html'
+    end
+
     it 'should have no party groupings (all Unknown)' do
       heading.must_be_empty
     end
   end
 
   describe 'regular section' do
-    before { get '/estonia/riigikogu/term-table/13.html' }
+    before do
+      stub_everypolitician_data_request('f88ce37/data/Estonia/Riigikogu/ep-popolo-v1.0.json')
+      get '/estonia/riigikogu/term-table/13.html'
+    end
     it 'should have party groupings' do
       heading.must_equal 'Party Groupings'
     end

--- a/t/web/wikidata.rb
+++ b/t/web/wikidata.rb
@@ -9,7 +9,7 @@ describe 'Wikidata' do
 
   describe 'Croatia' do
     before do
-      stub_everypolitician_data_request('6e39048/data/Croatia/Sabor/ep-popolo-v1.0.json')
+      stub_popolo('6e39048', 'Croatia/Sabor')
       get '/croatia/sabor/wikidata'
     end
 


### PR DESCRIPTION
Factor out some more helper methods for test stubbing, and move the
setup closer to where it's used in each test case, so that the pattern
is easier to detect, and copy in other files.