### PR TITLE
Make SeatCount a struct

### DIFF
--- a/lib/page/term_table.rb
+++ b/lib/page/term_table.rb
@@ -41,19 +41,14 @@ module Page
       term
     end
 
+    SeatCount = Struct.new(:group_id, :name, :member_count)
     def group_data
       @group_data ||= term
                       .memberships_at_end
                       .group_by(&:on_behalf_of_id)
-                      .map     { |group_id, mems| [org_lookup[group_id], mems] }
+                      .map     { |group_id, mems| [org_lookup[group_id].first, mems] }
                       .sort_by { |group, mems| [-mems.count, group.name] }
-                      .map do    |group, mems|
-        {
-          group_id:     group.id.split('/').last,
-          name:         group.name,
-          member_count: mems.count,
-        }
-      end
+                      .map     { |group, mems| SeatCount.new(group.id.split('/').last, group.name, mems.count) }
 
       @group_data = [] if @group_data.length == 1
       @group_data

--- a/t/page/term_table.rb
+++ b/t/page/term_table.rb
@@ -44,15 +44,16 @@ describe 'TermTable' do
 
     describe 'when calculating the group data' do
       it 'sends the right memberships' do
-        subject.group_data.must_equal [
-          { group_id: 'spÖ', name: 'SPÖ', member_count: 51 },
-          { group_id: 'Övp', name: 'ÖVP', member_count: 51 },
-          { group_id: 'fpÖ', name: 'FPÖ', member_count: 38 },
-          { group_id: 'grüne', name: 'Grüne', member_count: 24 },
-          { group_id: 'neos', name: 'NEOS', member_count: 9 },
-          { group_id: 'team_stronach', name: 'Team Stronach', member_count: 6 },
-          { group_id: 'ohne_(none)', name: 'ohne (none)', member_count: 3 },
-        ]
+        group_data = subject.group_data
+        group_data.count.must_equal 7
+
+        group_data.first.group_id.must_equal 'spÖ'
+        group_data.first.name.must_equal 'SPÖ'
+        group_data.first.member_count.must_equal 51
+
+        group_data.last.group_id.must_equal 'ohne_(none)'
+        group_data.last.name.must_equal 'ohne (none)'
+        group_data.last.member_count.must_equal 3
       end
 
       # TODO: it 'does not include group data if there is only a single group'

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -50,10 +50,10 @@
             </div>
             <ul class="grid-list grid-list--vertically-center">
               <% @page.group_data.each do |party| %>
-                <li id="party-<%= party[:group_id] %>"><div class="avatar-unit">
+                <li id="party-<%= party.group_id %>"><div class="avatar-unit">
                     <span class="avatar"><i class="fa fa-users"></i></span>
-                    <h3><%= party[:name].to_s.empty? ? 'Independent' : party[:name] %></h3>
-                    <p><span class="seatcount"><%= party[:member_count] %></span> seat<% if party[:member_count] > 1 %>s<% end %></p>
+                    <h3><%= party.name.to_s.empty? ? 'Independent' : party.name %></h3>
+                    <p><span class="seatcount"><%= party.member_count %></span> seat<% if party.member_count > 1 %>s<% end %></p>
                 </div></li>
               <% end %>
             </ul>


### PR DESCRIPTION
By making the SeatCount a Struct, rather than plain Hash, we can
simplify the logic a little, take a small step towards extracting it
elsewhere, and remove some more direct hash lookups from the templates.