### PR TITLE
Turn Percentages into a Struct

### DIFF
--- a/lib/page/term_table.rb
+++ b/lib/page/term_table.rb
@@ -73,14 +73,11 @@ module Page
       end
     end
 
+    CARDS = %i(social bio contacts identifiers).freeze
+    Percentages = Struct.new(*CARDS)
     def percentages
       pc = ->(card) { ((people.count { |p| p[card].any? } / people.count.to_f) * 100).floor }
-      {
-        social:      pc.call(:social),
-        bio:         pc.call(:bio),
-        contacts:    pc.call(:contacts),
-        identifiers: pc.call(:identifiers),
-      }
+      Percentages.new(*CARDS.map { |card| pc.call(card) })
     end
 
     private

--- a/t/page/term_table.rb
+++ b/t/page/term_table.rb
@@ -132,8 +132,10 @@ describe 'TermTable' do
     end
 
     it 'knows percentage of people that have special data' do
-      expected = { social: 20, bio: 100, contacts: 93, identifiers: 100 }
-      subject.percentages.must_equal expected
+      subject.percentages[:social].must_equal 20
+      subject.percentages[:bio].must_equal 100
+      subject.percentages[:contacts].must_equal 93
+      subject.percentages[:identifiers].must_equal 100
     end
   end
 

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -72,25 +72,25 @@
                     <div class="data-completeness">
                         <span class="section-toggle section-toggle--selected" data-section-toggle="bio" data-ga-track-click="Section toggle: bio">
                             <span class="data-completeness__label">Biographical</span>
-                            <span class="data-completeness__percentage"><%= @page.percentages[:bio] %>%</span>
+                            <span class="data-completeness__percentage"><%= @page.percentages.bio %>%</span>
                         </span>
                     </div>
                     <div class="data-completeness">
                         <span class="section-toggle" data-section-toggle="social" data-ga-track-click="Section toggle: social">
                             <span class="data-completeness__label">Social links</span>
-                            <span class="data-completeness__percentage"><%= @page.percentages[:social] %>%</span>
+                            <span class="data-completeness__percentage"><%= @page.percentages.social %>%</span>
                         </span>
                     </div>
                     <div class="data-completeness">
                         <span class="section-toggle" data-section-toggle="contacts" data-ga-track-click="Section toggle: contacts">
                             <span class="data-completeness__label">Contact details</span>
-                            <span class="data-completeness__percentage"><%= @page.percentages[:contacts] %>%</span>
+                            <span class="data-completeness__percentage"><%= @page.percentages.contacts %>%</span>
                         </span>
                     </div>
                     <div class="data-completeness">
                         <span class="section-toggle" data-section-toggle="identifiers" data-ga-track-click="Section toggle: identifiers">
                             <span class="data-completeness__label">Identifiers</span>
-                            <span class="data-completeness__percentage"><%= @page.percentages[:identifiers] %>%</span>
+                            <span class="data-completeness__percentage"><%= @page.percentages.identifiers %>%</span>
                         </span>
                     </div>
                 </div>


### PR DESCRIPTION
As part of the process of replacing all direct data-structure lookups with method calls on objects, create a lightweight Struct to represent the percentage data for each type of Card.

![screen shot 2016-08-28 at 16 06 41](https://cloud.githubusercontent.com/assets/57483/18034630/925987b2-6d39-11e6-9254-a355bd27739b.png)
