### PR TITLE
Pass full Membership objects to Term Table

### DIFF
--- a/lib/page/term_table.rb
+++ b/lib/page/term_table.rb
@@ -94,14 +94,12 @@ module Page
     end
 
     def person_memberships(person)
-      membership_lookup[person.id].map do |mem|
-        membership = {
-          start_date: mem.start_date,
-          end_date:   mem.end_date,
-        }
-        membership[:group] = org_lookup[mem.on_behalf_of_id].first.name if mem.on_behalf_of_id
-        membership[:area]  = area_lookup[mem.area_id].first.name if mem.area_id
-        membership
+      membership_lookup[person.id].each do |mem|
+        group = org_lookup[mem.on_behalf_of_id].first.name if mem.on_behalf_of_id
+        group = '' if group.to_s.downcase == 'unknown'
+        area = area_lookup[mem.area_id].first.name if mem.area_id
+        mem.define_singleton_method(:group) { group || '' }
+        mem.define_singleton_method(:area)  { area  || '' }
       end
     end
 

--- a/t/page/term_table.rb
+++ b/t/page/term_table.rb
@@ -78,10 +78,10 @@ describe 'TermTable' do
 
       it 'has a single membership' do
         af.memberships.count.must_equal 1
-        af.memberships.first[:start_date].must_equal '2013-10-29'
-        af.memberships.first[:end_date].must_equal nil
-        af.memberships.first[:group].must_equal 'ÖVP'
-        af.memberships.first[:area].must_equal 'Wahlkreis: 3B – Waldviertel'
+        af.memberships.first.start_date.must_equal '2013-10-29'
+        af.memberships.first.end_date.must_equal nil
+        af.memberships.first.group.must_equal 'ÖVP'
+        af.memberships.first.area.must_equal 'Wahlkreis: 3B – Waldviertel'
       end
 
       it 'has two entries on bio card' do

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -151,14 +151,14 @@
                           <% person.memberships.each do |mem| %>
                             <p class="person-card__politics">
 
-                              <%= [mem[:group].to_s, mem[:area].to_s].reject { |s| s.empty? || s.downcase == 'unknown' }.join(" — ") %>
+                              <%= [mem.group, mem.area].reject(&:empty?).join(" — ") %>
 
-                              <% if !mem[:start_date].to_s.empty? and !mem[:end_date].to_s.empty? %>
-                                <span class="person-card__politics__date">(<%= mem[:start_date].to_s %> to <%= mem[:end_date].to_s %>)</span>
-                              <% elsif !mem[:start_date].to_s.empty? %>
-                                <span class="person-card__politics__date">(from <%= mem[:start_date].to_s %>)</span>
-                              <% elsif !mem[:end_date].to_s.empty? %>
-                                <span class="person-card__politics__date">(until <%= mem[:end_date].to_s %>)</span>
+                              <% if mem.start_date && mem.end_date %>
+                                <span class="person-card__politics__date">(<%= mem.start_date.to_s %> to <%= mem.end_date.to_s %>)</span>
+                              <% elsif mem.start_date %>
+                                <span class="person-card__politics__date">(from <%= mem.start_date.to_s %>)</span>
+                              <% elsif mem.end_date %>
+                                <span class="person-card__politics__date">(until <%= mem.end_date.to_s %>)</span>
                               <% end %>
                             </p>
                           <% end %>


### PR DESCRIPTION
Make the memberships on the Term Table page full Membership objects. To
do this we need to add `area` and `group` methods.

(`everypolitician-popolo` should really give us these, but until it does,
we need to construct them ourselves.)

![screen shot 2016-08-28 at 17 35 50](https://cloud.githubusercontent.com/assets/57483/18035103/6028da24-6d46-11e6-9179-c9577e1c5b68.png)
