### PR TITLE
Rename route slugs for consistency

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -50,9 +50,9 @@ get '/:country/:house/wikidata' do |country_slug, house_slug|
   erb :house_wikidata
 end
 
-get '/:country/:house/term-table/:id.html' do |cslug, hslug, termid|
-  pass unless country = settings.index.country(cslug)
-  pass unless house   = country.legislature(hslug)
+get '/:country/:house/term-table/:id.html' do |country_slug, house_slug, termid|
+  pass unless country = settings.index.country(country_slug)
+  pass unless house   = country.legislature(house_slug)
   pass unless term    = house.term(termid)
   @page = Page::TermTable.new(term: term)
   erb :term_table

--- a/app.rb
+++ b/app.rb
@@ -43,9 +43,9 @@ get '/:country/' do |country_slug|
   erb :country_missing
 end
 
-get '/:country/:house/wikidata' do |country, house|
-  pass unless country = settings.index.country(country)
-  pass unless house   = country.legislature(house)
+get '/:country/:house/wikidata' do |country_slug, house_slug|
+  pass unless country = settings.index.country(country_slug)
+  pass unless house   = country.legislature(house_slug)
   @page = Page::HouseWikidata.new(house: house)
   erb :house_wikidata
 end

--- a/app.rb
+++ b/app.rb
@@ -58,8 +58,8 @@ get '/:country/:house/term-table/:id.html' do |country_slug, house_slug, termid|
   erb :term_table
 end
 
-get '/:country/download.html' do |slug|
-  pass unless country = settings.index.country(slug)
+get '/:country/download.html' do |country_slug|
+  pass unless country = settings.index.country(country_slug)
   @page = Page::Download.new(country: country, index: settings.index)
   erb :country_download
 end

--- a/app.rb
+++ b/app.rb
@@ -37,8 +37,8 @@ get '/:country/' do |country_slug|
   erb :country
 end
 
-get '/:country/' do |country|
-  @page = Page::MissingCountry.new(country: country)
+get '/:country/' do |country_slug|
+  @page = Page::MissingCountry.new(country: country_slug)
   pass unless @page.country
   erb :country_missing
 end

--- a/app.rb
+++ b/app.rb
@@ -31,8 +31,8 @@ get '/countries.html' do
   erb :countries
 end
 
-get '/:country/' do |slug|
-  pass unless country = settings.index.country(slug)
+get '/:country/' do |country_slug|
+  pass unless country = settings.index.country(country_slug)
   @page = Page::Country.new(country: country)
   erb :country
 end


### PR DESCRIPTION
We found that there was not a consistent way of naming the slugs in the app routes so we renamed them to be less confusing and consistent.

For example some times there was `cslug`, some times `slug`, some times `country` (the latter was also confusing because there is a `country` that refers to the instance of a `Country` but was also refering to the slug), etc.

All the routes now have their slugs renamed to `country_slug` and `house_slug`.