### PR TITLE
WIP -- Reduce complexity of group_data method

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,10 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 3
-Metrics/AbcSize:
-  Max: 22
-
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:

--- a/lib/page/term_table.rb
+++ b/lib/page/term_table.rb
@@ -55,8 +55,8 @@ module Page
     end
 
     SeatCount = Struct.new(:group_id, :name, :member_count)
-    def party_seat_counts(memberships_grouped_by_party)
-      memberships_grouped_by_party
+    def party_seat_counts(grouped_memberships)
+      grouped_memberships
         .map { |group_id, mems| [org_lookup[group_id].first, mems] }
         .sort_by { |group, mems| [-mems.count, group.name] }
         .map     { |group, mems| SeatCount.new(group.id.split('/').last, group.name, mems.count) }

--- a/lib/page/term_table.rb
+++ b/lib/page/term_table.rb
@@ -42,17 +42,24 @@ module Page
       term
     end
 
-    SeatCount = Struct.new(:group_id, :name, :member_count)
     def group_data
-      @group_data ||= term
-                      .memberships_at_end
-                      .group_by(&:on_behalf_of_id)
-                      .map     { |group_id, mems| [org_lookup[group_id].first, mems] }
-                      .sort_by { |group, mems| [-mems.count, group.name] }
-                      .map     { |group, mems| SeatCount.new(group.id.split('/').last, group.name, mems.count) }
-
+      @group_data ||= party_seat_counts(memberships_grouped_by_party)
       @group_data = [] if @group_data.length == 1
       @group_data
+    end
+
+    def memberships_grouped_by_party
+      term
+        .memberships_at_end
+        .group_by(&:on_behalf_of_id)
+    end
+
+    SeatCount = Struct.new(:group_id, :name, :member_count)
+    def party_seat_counts(memberships_grouped_by_party)
+      memberships_grouped_by_party
+        .map { |group_id, mems| [org_lookup[group_id].first, mems] }
+        .sort_by { |group, mems| [-mems.count, group.name] }
+        .map     { |group, mems| SeatCount.new(group.id.split('/').last, group.name, mems.count) }
     end
 
     def people


### PR DESCRIPTION
term-table.rb contains three methods with an ABC count that fails Rubocop's tests. (https://github.com/everypolitician/viewer-sinatra/issues/15249)

Tackling the first one -- #group_data -- by breaking it into separate methods.