### PR TITLE
Simplify term_table_url

### DIFF
--- a/lib/popolo_helper.rb
+++ b/lib/popolo_helper.rb
@@ -6,7 +6,7 @@ module Popolo
       '/%s/%s/term-table/%s.html' % [
         term.country.slug.downcase,
         term.legislature.slug.downcase,
-        term.csv_url[/term-(.*?).csv/, 1],
+        term.slug,
       ]
     end
 

--- a/lib/popolo_helper.rb
+++ b/lib/popolo_helper.rb
@@ -2,8 +2,12 @@
 
 module Popolo
   module Helper
-    def term_table_url(c, h, t)
-      '/%s/%s/term-table/%s.html' % [c[:slug].downcase, h[:slug].downcase, t[:csv][/term-(.*?).csv/, 1]]
+    def term_table_url(term)
+      '/%s/%s/term-table/%s.html' % [
+        term.country.slug.downcase,
+        term.legislature.slug.downcase,
+        term.csv_url[/term-(.*?).csv/, 1],
+      ]
     end
 
     # http://stackoverflow.com/questions/1078347/is-there-a-rails-trick-to-adding-commas-to-large-numbers

--- a/views/country.erb
+++ b/views/country.erb
@@ -21,7 +21,7 @@
         <ul class="grid-list grid-list--vertically-center" id="terms-<%= house.slug.downcase %>">
           <% house.legislative_periods.each do |term| %>
             <li>
-              <a class="avatar-unit" href="<%= term_table_url(@page.country, house, term) %>">
+              <a class="avatar-unit" href="<%= term_table_url(term) %>">
                 <span class="avatar"><i class="fa fa-university"></i></span>
                 <h3><%= term.name %></h3>
                 <% if term.start_date || term.end_date %>

--- a/views/country_download.erb
+++ b/views/country_download.erb
@@ -67,7 +67,7 @@
           <li id="term-<%= house.slug.downcase %>-<%= t.slug.downcase %>" style="margin-bottom:1.5em">
             <div class="avatar-unit">
               <span class="avatar"><i class="fa fa-university"></i></span>
-              <a href="<%= term_table_url(@page.country, house, t) %>"><h3><%= t.name %></h3></a>
+              <a href="<%= term_table_url(t) %>"><h3><%= t.name %></h3></a>
               <p>
                 <% if t.start_date || t.end_date %>
                  <%= t.start_date %> - <%=  t.end_date %>
@@ -196,4 +196,3 @@ $('.button.toggle-term-display').on("click", function(e){
   $('#terms-' + house + " li.hidden-term").slideToggle();
 })
 </script>
-

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -12,7 +12,7 @@
         <div class="container">
             <div class="term-navigation">
               <% if @page.prev_term %>
-                <a href="<%= term_table_url(@page.country, @page.house, @page.prev_term) %>" class="term-navigation__prev" data-ga-track-click="Show previous term">
+                <a href="<%= term_table_url(@page.prev_term) %>" class="term-navigation__prev" data-ga-track-click="Show previous term">
                     <i class="fa fa-arrow-left"></i>
                     Earlier
                 </a>
@@ -21,7 +21,7 @@
               <span class="term-navigation__jump">Jump to:
                   <select class="js-navigation-menu" data-ga-track-select="Jump to term by date">
                     <% @page.terms.each do |t| %>
-                      <option value="<%= term_table_url(@page.country, @page.house, t) %>" <% if t.name == @page.current_term.name %>selected<% end %>>
+                      <option value="<%= term_table_url(t) %>" <% if t.name == @page.current_term.name %>selected<% end %>>
                         <%= t.name %>
                         <% if t.start_date || t.end_date %>
                           (<%= t.start_date %>–<%= t.end_date || 'current' %>)
@@ -32,7 +32,7 @@
               </span>
 
               <% if @page.next_term %>
-                <a href="<%= term_table_url(@page.country, @page.house, @page.next_term) %>" class="term-navigation__next" data-ga-track-click="Show next term">
+                <a href="<%= term_table_url(@page.next_term) %>" class="term-navigation__next" data-ga-track-click="Show next term">
                     Later
                     <i class="fa fa-arrow-right"></i>
                 </a>


### PR DESCRIPTION
The `term_table_url` method in the popolo helper was simplify so that it is passed just a term, and the country and legislature are obtained from it using `term.country` and `term.legislature`.

I also changed the bracket notation and used the instance methods (`.slug` and `csv_url`) instead.

Finally, I updated the templates using it, **country.erb**, **country_download.erb** and **term_table.erb**.

Fixes #15241