### PR TITLE
WIP -- Reduce complexity of percentages method

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,10 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 3
-Metrics/AbcSize:
-  Max: 22
-
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:

--- a/lib/page/term_table.rb
+++ b/lib/page/term_table.rb
@@ -69,7 +69,8 @@ module Page
     CARDS = %i(social bio contacts identifiers).freeze
     Percentages = Struct.new(*CARDS)
     def percentages
-      pc = ->(card) { ((people.count { |p| p.send(card.to_s).any? } / people.count.to_f) * 100).floor }
+      people_count = people.count
+      pc = ->(card) { ((people_count { |p| p.send(card.to_s).any? } / people_count.to_f) * 100).floor }
       Percentages.new(*CARDS.map { |card| pc.call(card) })
     end
 


### PR DESCRIPTION
PR reduces complexity of #percentages by assigning value of `people.count` to variable so that `people.count` is called once only. Method now passes Rubocop's ABC test.