### PR TITLE
Extend Popolo::Membership with #group and #area

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,6 +20,15 @@ Rake::TestTask.new do |t|
 end
 
 Rake::TestTask.new do |t|
+  t.name = 'test:extensions'
+  t.warning = false
+  t.verbose = true
+  t.description = 'Run "Everypolitician extensions" tests'
+  t.test_files = FileList['t/everypolitician_extensions/**/*.rb']
+  t.libs << 't'
+end
+
+Rake::TestTask.new do |t|
   t.name = 'test:all'
   t.verbose = true
   t.description = 'Run all tests (slow)'

--- a/lib/everypolitician_extensions.rb
+++ b/lib/everypolitician_extensions.rb
@@ -38,8 +38,19 @@ module EveryPolitician
       end
     end
   end
+
+  module MembershipExtension
+    def group
+      popolo.organizations.find_by(id: on_behalf_of_id)
+    end
+
+    def area
+      popolo.areas.find_by(id: area_id)
+    end
+  end
 end
 
 EveryPolitician::Country.include EveryPolitician::CountryExtension
 EveryPolitician::Legislature.include EveryPolitician::LegislatureExtension
 EveryPolitician::LegislativePeriod.include EveryPolitician::LegislativePeriodExtension
+EveryPolitician::Popolo::Membership.include Everypolitician::MembershipExtension

--- a/lib/everypolitician_extensions.rb
+++ b/lib/everypolitician_extensions.rb
@@ -40,10 +40,14 @@ module EveryPolitician
   end
 
   module MembershipExtension
+    # The political group (party / faction) this membership is held on behalf of
+    # @return [Everypolitician::Popolo::Organization]
     def group
       popolo.organizations.find_by(id: on_behalf_of_id)
     end
 
+    # The area that this membership belongs to
+    # @return [Everypolitician::Popolo::Area]
     def area
       popolo.areas.find_by(id: area_id)
     end

--- a/t/everypolitician_extensions/membership_extension.rb
+++ b/t/everypolitician_extensions/membership_extension.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require 'test_helper'
+require_relative '../../lib/everypolitician_extensions.rb'
+
+describe 'MembershipExtensions' do
+  subject do
+    stub_popolo('3df153b', 'Austria/Nationalrat')
+    index_at_known_sha.country('austria')
+                      .legislature('nationalrat')
+                      .popolo
+                      .memberships
+                      .first
+  end
+
+  it 'should return an organization with the expected id' do
+    subject.group.id.must_equal 'party/spÖ'
+  end
+
+  it 'should return an Organization object' do
+    subject.group.class.must_equal Everypolitician::Popolo::Organization
+  end
+
+  it 'should return an area with the expected id' do
+    subject.area.id.must_equal 'area/wahlkreis:_6d_–_obersteiermark'
+  end
+
+  it 'should return an Area object' do
+    subject.area.class.must_equal Everypolitician::Popolo::Area
+  end
+end

--- a/t/everypolitician_extensions/membership_extension.rb
+++ b/t/everypolitician_extensions/membership_extension.rb
@@ -28,3 +28,22 @@ describe 'MembershipExtensions' do
     subject.area.class.must_equal Everypolitician::Popolo::Area
   end
 end
+
+describe 'MembershipExtensions -- memberships with no known groups or area names' do
+  subject do
+    stub_popolo('2b38667', 'Afghanistan/Wolesi_Jirga')
+    index_at_known_sha.country('afghanistan')
+                      .legislature('wolesi-jirga')
+                      .popolo
+                      .memberships
+                      .first
+  end
+
+  it 'should return nil if a membership has no group data' do
+    subject.area.must_be_nil
+  end
+
+  it 'should return "unkown" if membership’s area name is unknown' do
+    subject.group.name.must_equal 'unknown'
+  end
+end

--- a/t/fixtures/everypolitician-data/2b38667/data/Afghanistan/Wolesi_Jirga/ep-popolo-v1.0.json
+++ b/t/fixtures/everypolitician-data/2b38667/data/Afghanistan/Wolesi_Jirga/ep-popolo-v1.0.json
@@ -1,0 +1,7630 @@
+{
+  "posts": [
+
+  ],
+  "persons": [
+    {
+      "gender": "male",
+      "id": "232322d9-e229-4207-a48c-4c1ad43ec948",
+      "identifiers": [
+        {
+          "identifier": "1942",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/abdul%20ghafar.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/abdul%20ghafar.jpg"
+        }
+      ],
+      "name": "ABDUL Ghafar",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=7&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "29403f9b-587a-401d-b0ea-6b20ad64b401",
+      "identifiers": [
+        {
+          "identifier": "1977",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "ABDUL HAY",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=2&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "cd736630-a4da-463f-abbf-120b868bcecd",
+      "identifiers": [
+        {
+          "identifier": "1893",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "ABDUL Rahim Ayoobi",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=14&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "7092d108-ac19-49a7-b38a-2c9e00d5dac6",
+      "identifiers": [
+        {
+          "identifier": "1894",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "ATAULLAH JAN HABIB",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=14&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "2dc3c971-fa70-4264-b674-c8d0ce818e4a",
+      "identifiers": [
+        {
+          "identifier": "1738",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/abas-ebrahim-zadeh-m.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/abas-ebrahim-zadeh-m.jpg"
+        }
+      ],
+      "name": "Abas Ebrahimzada , balkh",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=38&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "a3015c20-f9bb-413e-823d-40488d1e9e17",
+      "identifiers": [
+        {
+          "identifier": "2009",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/abdol-ahmad-dorani.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/abdol-ahmad-dorani.jpg"
+        }
+      ],
+      "name": "Abdul Ahmad Durany",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "eba294a0-2c03-4528-8ae3-25920b0061c0",
+      "identifiers": [
+        {
+          "identifier": "1850",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-abdulhafiz-mansor.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-abdulhafiz-mansor.JPG"
+        }
+      ],
+      "name": "Abdul Hafiz Mansoor",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=20&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "671dd348-c48b-4ce0-b0aa-9f7df4b8da4e",
+      "identifiers": [
+        {
+          "identifier": "1892",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Abdul Khaliq Barekzai",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=14&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "24b0e8dd-2b3a-445f-9271-56028d627a17",
+      "identifiers": [
+        {
+          "identifier": "2010",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/abdulmajidwardak.s.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/abdulmajidwardak.s.JPG"
+        }
+      ],
+      "name": "Abdul Majeed Wardak",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "0968d7bf-61ee-4deb-bb56-242feed3415f",
+      "identifiers": [
+        {
+          "identifier": "1707",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/Abdul%20Rauf%20Enami-Monshi.jpeg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/Abdul%20Rauf%20Enami-Monshi.jpeg"
+        }
+      ],
+      "name": "Abdul Raoof Anamy , Badakhshan",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=42&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "cad39770-2a15-4547-8e3e-ca882957da63",
+      "identifiers": [
+        {
+          "identifier": "1882",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Abdul Wadud Payman",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=16&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "d4e3003a-72c4-46c4-9457-3757617823af",
+      "identifiers": [
+        {
+          "identifier": "1959",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Abdul hadi Jamshidi",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=5&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "a88e5420-e689-456e-b1c3-aac6194a8d71",
+      "identifiers": [
+        {
+          "identifier": "1976",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Abdul jabar",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=2&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "84672f50-6a66-4244-9005-6d99bca88922",
+      "identifiers": [
+        {
+          "identifier": "1774",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/darzyabi-m.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/darzyabi-m.jpg"
+        }
+      ],
+      "name": "Abdul satar",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=33&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "6dec5eb4-db61-4f95-97d7-8710a50b5e8d",
+      "identifiers": [
+        {
+          "identifier": "1984",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-abdolvodod-popal.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-abdolvodod-popal.jpg"
+        }
+      ],
+      "name": "Abdul wadood popal",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=2&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "d7118bdf-99fb-4bd1-9260-24bceaca8963",
+      "identifiers": [
+        {
+          "identifier": "1851",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/abdolrasol-sayaf-m.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/abdolrasol-sayaf-m.jpg"
+        }
+      ],
+      "name": "Abdulrab Rasool Sayaf",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=20&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "given_name": "Abdul",
+      "id": "b4a823f1-4912-4704-8228-018e6237697f",
+      "identifiers": [
+        {
+          "identifier": "1903",
+          "scheme": "everypolitician_legacy"
+        },
+        {
+          "identifier": "Q19609474",
+          "scheme": "wikidata"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/Copy%20of%20Copy%20of%20ebrahini-raoofi.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/Copy%20of%20Copy%20of%20ebrahini-raoofi.jpg"
+        }
+      ],
+      "links": [
+        {
+          "note": "Wikipedia (en)",
+          "url": "https://en.wikipedia.org/wiki/Abdul_Rauf_Ibrahimi"
+        }
+      ],
+      "name": "Abdulraoof Ebrahimi",
+      "other_names": [
+        {
+          "name": "Abdul Rauf Ibrahimi",
+          "note": "alternate"
+        },
+        {
+          "lang": "en",
+          "name": "Abdul Rauf Ibrahimi",
+          "note": "multilingual"
+        },
+        {
+          "lang": "it",
+          "name": "Abdul Rauf Ibrahimi",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nl",
+          "name": "Abdul Rauf Ibrahimi",
+          "note": "multilingual"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=12&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "given_name": "Ahmad",
+      "id": "52457972-cd7c-4871-af30-ed21d050d5cb",
+      "identifiers": [
+        {
+          "identifier": "1953",
+          "scheme": "everypolitician_legacy"
+        },
+        {
+          "identifier": "Q4695285",
+          "scheme": "wikidata"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "links": [
+        {
+          "note": "Wikipedia (en)",
+          "url": "https://en.wikipedia.org/wiki/Ahmad_Behzad"
+        }
+      ],
+      "name": "Ahmad Behzad",
+      "other_names": [
+        {
+          "lang": "de",
+          "name": "Ahmad Behzad",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Ahmad Behzad",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fr",
+          "name": "Ahmad Behzad",
+          "note": "multilingual"
+        },
+        {
+          "lang": "it",
+          "name": "Ahmad Behzad",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nl",
+          "name": "Ahmad Behzad",
+          "note": "multilingual"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=6&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "b79f4c80-1d4d-4a96-aeda-47260efbb0b9",
+      "identifiers": [
+        {
+          "identifier": "1954",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/farhad-majidi-m.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/farhad-majidi-m.JPG"
+        }
+      ],
+      "name": "Ahmad farhad majidi",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=6&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "82a9881d-751c-4d8c-8d16-990db11032e2",
+      "identifiers": [
+        {
+          "identifier": "1949",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Ahmadullah mohaed",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=7&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "4e74aa84-39df-4a3e-a210-1e205d0d1107",
+      "identifiers": [
+        {
+          "identifier": "1773",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/bazmohammad-jozjani-m.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/bazmohammad-jozjani-m.JPG"
+        }
+      ],
+      "name": "Alhaj Baz Mohammad Jawzjani",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=33&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "given_name": "Ali",
+      "id": "08501fa8-ab5d-48a9-b669-8123e6235748",
+      "identifiers": [
+        {
+          "identifier": "1806",
+          "scheme": "everypolitician_legacy"
+        },
+        {
+          "identifier": "Q4724600",
+          "scheme": "wikidata"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-aliakbar-ghasemi.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-aliakbar-ghasemi.jpg"
+        }
+      ],
+      "links": [
+        {
+          "note": "Wikipedia (en)",
+          "url": "https://en.wikipedia.org/wiki/Ali_Akbar_Qasimi"
+        }
+      ],
+      "name": "Ali Akbar Qausimi",
+      "other_names": [
+        {
+          "name": "Ali Akbar Qasimi",
+          "note": "alternate"
+        },
+        {
+          "lang": "de",
+          "name": "Ali Akbar Qasimi",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Ali Akbar Qasimi",
+          "note": "multilingual"
+        },
+        {
+          "lang": "es",
+          "name": "Ali Akbar Qasimi",
+          "note": "multilingual"
+        },
+        {
+          "lang": "hu",
+          "name": "Ali Akbar Qasimi",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nl",
+          "name": "Ali Akbar Qasimi",
+          "note": "multilingual"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=27&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "720abc9a-c17e-4b96-9c5a-afddf79df213",
+      "identifiers": [
+        {
+          "identifier": "1836",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/allah-gol-mojahed-m.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/allah-gol-mojahed-m.jpg"
+        }
+      ],
+      "name": "Allahgul mojahid",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=23&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "19915231-0be5-42a6-95f8-d2e8504544be",
+      "identifiers": [
+        {
+          "identifier": "1929",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-amirkhan-yar.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-amirkhan-yar.jpg"
+        }
+      ],
+      "name": "Amir Khan Yaar",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=9&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "69e8a01d-18ad-4fac-8742-b030e1d161f4",
+      "identifiers": [
+        {
+          "identifier": "1928",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Amir jan dawlat zai",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=9&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "given_name": "Anwar",
+      "id": "bf9341bf-d027-46f4-b4e2-51d48ec374a2",
+      "identifiers": [
+        {
+          "identifier": "1837",
+          "scheme": "everypolitician_legacy"
+        },
+        {
+          "identifier": "Q4778042",
+          "scheme": "wikidata"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "links": [
+        {
+          "note": "Wikipedia (en)",
+          "url": "https://en.wikipedia.org/wiki/Anwar_Khan_Auriakhel"
+        }
+      ],
+      "name": "Anwar khan oryakheel",
+      "other_names": [
+        {
+          "name": "Anwar Khan Auriakhel",
+          "note": "alternate"
+        },
+        {
+          "lang": "de",
+          "name": "Anwar Khan Auriakhel",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Anwar Khan Auriakhel",
+          "note": "multilingual"
+        },
+        {
+          "lang": "es",
+          "name": "Anwar Khan Auriakhel",
+          "note": "multilingual"
+        },
+        {
+          "lang": "hu",
+          "name": "Anwar Khan Auriakhel",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nl",
+          "name": "Anwar Khan Auriakhel",
+          "note": "multilingual"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=22&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "ec0d7dc6-e87a-48b8-8f5b-505d32d7e18c",
+      "identifiers": [
+        {
+          "identifier": "1930",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Aryan yoon",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=9&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "10e4fc18-18b6-4397-a4db-0ce100dcca02",
+      "identifiers": [
+        {
+          "identifier": "1784",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-asdullah-soadati.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-asdullah-soadati.jpg"
+        }
+      ],
+      "name": "Assaduallah Sadati",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=31&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "df0701e5-1e2c-4853-8cbb-8cce0fc17120",
+      "identifiers": [
+        {
+          "identifier": "1838",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/baktash-seyavash-m.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/baktash-seyavash-m.JPG"
+        }
+      ],
+      "name": "BAKTASH SYAWASH",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=22&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "8de38d62-6768-423e-a677-3248709cebc7",
+      "identifiers": [
+        {
+          "identifier": "1822",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/bashir-ahmad-tayenj-m.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/bashir-ahmad-tayenj-m.JPG"
+        }
+      ],
+      "name": "Basher Ahmad- Tahyanj",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=25&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "e9a790e6-0e5c-4b2c-8f17-66668d49a2e8",
+      "identifiers": [
+        {
+          "identifier": "1888",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "BeBe Hamida Yosofzai",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=15&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "872197b7-0a66-4d89-8fbe-a093fac8fcf6",
+      "identifiers": [
+        {
+          "identifier": "1885",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Chahary",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=15&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "b712d0d7-0ef2-4bfd-8277-e87740e3cf6b",
+      "identifiers": [
+        {
+          "identifier": "1800",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-jaman-shah-etemadi.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-jaman-shah-etemadi.JPG"
+        }
+      ],
+      "name": "Chiman shah Eetimady",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=28&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "3300b50f-ab92-4f8f-b62d-1e9cb4ee42fa",
+      "identifiers": [
+        {
+          "identifier": "1938",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "DR.Esmatullah Shenwary",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=8&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "5784b757-9bfe-472c-9633-67d088b73cab",
+      "identifiers": [
+        {
+          "identifier": "1712",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/nelofar-ebrahimi.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/nelofar-ebrahimi.JPG"
+        }
+      ],
+      "name": "DR.Nelofar Ebrahimi",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=41&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "9101c9ce-9b7f-4669-8b59-4b8a97890091",
+      "identifiers": [
+        {
+          "identifier": "1718",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Delawar aymaq , baghlan",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=41&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "a825541a-3658-4aed-84e6-81335901008d",
+      "identifiers": [
+        {
+          "identifier": "1775",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/dr-enayatullah-abor-farahmand-m.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/dr-enayatullah-abor-farahmand-m.JPG"
+        }
+      ],
+      "name": "Dr Enayatuallha babor farahmand",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=33&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "9246439e-3b92-4806-8c30-278749c666b5",
+      "identifiers": [
+        {
+          "identifier": "1964",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-mohammad-saleh-saljoghi.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-mohammad-saleh-saljoghi.jpg"
+        }
+      ],
+      "name": "Dr Mohammad Saleh Saljoqai",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=4&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "25d7c071-785c-4dd0-95c3-1773a6fc619c",
+      "identifiers": [
+        {
+          "identifier": "1755",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Dr Mojib- Rahman",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=36&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "b6e17eb7-75a2-495a-8a38-f21442a66eee",
+      "identifiers": [
+        {
+          "identifier": "1830",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-naghibullah-fayegh.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-naghibullah-fayegh.jpg"
+        }
+      ],
+      "name": "Dr Naqibullah Faiq",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=24&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "b1a2cf91-2d42-4995-8e31-4ab589630246",
+      "identifiers": [
+        {
+          "identifier": "1763",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-dr-zahi-soadat.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-dr-zahi-soadat.jpg"
+        }
+      ],
+      "name": "Dr zoheir Sadat",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=35&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "92308bfc-a99c-4ec8-b96a-75952429890d",
+      "identifiers": [
+        {
+          "identifier": "1852",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/abidullah-kalimzay-m.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/abidullah-kalimzay-m.JPG"
+        }
+      ],
+      "name": "Dr. Ubaidullah Kallamzai",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=20&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "given_name": "Abdul",
+      "id": "bd587a92-a390-46d5-8d82-65b9e2d08418",
+      "identifiers": [
+        {
+          "identifier": "1805",
+          "scheme": "everypolitician_legacy"
+        },
+        {
+          "identifier": "Q4665606",
+          "scheme": "wikidata"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-addol-qaum-sajjadi.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-addol-qaum-sajjadi.jpg"
+        }
+      ],
+      "links": [
+        {
+          "note": "Wikipedia (en)",
+          "url": "https://en.wikipedia.org/wiki/Abdul_Qayyum_Sajjadi"
+        }
+      ],
+      "name": "Dr.abdul qaum sajadi , samanghan",
+      "other_names": [
+        {
+          "name": "Abdul Qayyum Sajjadi",
+          "note": "alternate"
+        },
+        {
+          "lang": "de",
+          "name": "Abdul Qayyum Sajjadi",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Abdul Qayyum Sajjadi",
+          "note": "multilingual"
+        },
+        {
+          "lang": "es",
+          "name": "Abdul Qayyum Sajjadi",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fr",
+          "name": "Abdul Qayyum Sajjadi",
+          "note": "multilingual"
+        },
+        {
+          "lang": "hu",
+          "name": "Abdul Qayyum Sajjadi",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nl",
+          "name": "Abdul Qayyum Sajjadi",
+          "note": "multilingual"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=27&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "38ef2d81-58d2-4389-b185-9aa1de10f110",
+      "identifiers": [
+        {
+          "identifier": "2007",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/hamida.akbari.s.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/hamida.akbari.s.JPG"
+        }
+      ],
+      "name": "Engineer Hameda Akbary",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=1&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "bfdb3455-0930-4a36-80df-fa8c72a89781",
+      "identifiers": [
+        {
+          "identifier": "1827",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-mohammadhashem-ortagh.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-mohammadhashem-ortagh.jpg"
+        }
+      ],
+      "name": "Engineer Mohammad Hashim Artaq",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=24&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "1e890b59-bd79-4f5b-8afa-066af7bc8d45",
+      "identifiers": [
+        {
+          "identifier": "1810",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/nafisa-azimi-m.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/nafisa-azimi-m.jpg"
+        }
+      ],
+      "name": "Engineer Nafisai Azimi",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=26&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "d8deefe3-e8c1-4037-9c3c-5600eea57823",
+      "identifiers": [
+        {
+          "identifier": "2511",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/syed-akram.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/syed-akram.jpg"
+        }
+      ],
+      "name": "Engineer Sayed Ikram",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "39b3e3e2-4f1c-4913-8e23-6fbdec0c97c8",
+      "identifiers": [
+        {
+          "identifier": "1867",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-erfanullah-erfan.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-erfanullah-erfan.jpg"
+        }
+      ],
+      "name": "Erfanullah",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=18&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "3f6253b7-9be7-42e3-8651-f41a4446b9c7",
+      "identifiers": [
+        {
+          "identifier": "1868",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-ezatullah-atef.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-ezatullah-atef.jpg"
+        }
+      ],
+      "name": "Ezatullah Atef",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=17&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "bf76811e-0a03-4769-ba39-f4a58257201d",
+      "identifiers": [
+        {
+          "identifier": "1952",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Fareeda Hamidi",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=6&Cat=37"
+        }
+      ]
+    },
+    {
+      "birth_date": "1981-04-19",
+      "gender": "female",
+      "id": "522dff9d-d21d-41b9-a7d5-c2321c819b11",
+      "identifiers": [
+        {
+          "identifier": "1854",
+          "scheme": "everypolitician_legacy"
+        },
+        {
+          "identifier": "Q17305060",
+          "scheme": "wikidata"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/farkhonde-zahra-naderi-m.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/farkhonde-zahra-naderi-m.jpg"
+        },
+        {
+          "url": "https://upload.wikimedia.org/wikipedia/commons/7/75/Portrait_of_Afghan_Parliamentarian_Farkhunda_Zahra_Naderi.jpg"
+        }
+      ],
+      "links": [
+        {
+          "note": "Wikipedia (en)",
+          "url": "https://en.wikipedia.org/wiki/Farkhunda_Zahra_Naderi"
+        },
+        {
+          "note": "Wikipedia (fa)",
+          "url": "https://fa.wikipedia.org/wiki/فرخنده_زهرا_نادری"
+        },
+        {
+          "note": "website",
+          "url": "http://www.fzn.af"
+        }
+      ],
+      "name": "Farkhonda Zahra Nadri",
+      "other_names": [
+        {
+          "name": "Farkhunda Zahra Naderi",
+          "note": "alternate"
+        },
+        {
+          "lang": "de",
+          "name": "Farkhunda Zahra Naderi",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Farkhunda Zahra Naderi",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fa",
+          "name": "فرخنده زهرا نادری",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fr",
+          "name": "Farkhunda Zahra Naderi",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nl",
+          "name": "Farkhunda Zahra Naderi",
+          "note": "multilingual"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=20&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "50116499-b27a-4d82-87f1-7f927ce7f7b5",
+      "identifiers": [
+        {
+          "identifier": "1853",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/fatemah-nazari-m.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/fatemah-nazari-m.JPG"
+        }
+      ],
+      "name": "Fatema- Nazari",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=20&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "ffe823f6-c833-494a-a33c-ea1a2def2359",
+      "identifiers": [
+        {
+          "identifier": "1824",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-fatollah-qesar.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-fatollah-qesar.JPG"
+        }
+      ],
+      "name": "Fathollah Qaisar",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=25&Cat=37"
+        }
+      ]
+    },
+    {
+      "birth_date": "1975",
+      "contact_details": [
+        {
+          "type": "twitter",
+          "value": "FawziaKoofi77"
+        }
+      ],
+      "gender": "female",
+      "id": "626e291b-0801-4b8e-944c-565011cc8587",
+      "identifiers": [
+        {
+          "identifier": "16510179m",
+          "scheme": "bnf"
+        },
+        {
+          "identifier": "1710",
+          "scheme": "everypolitician_legacy"
+        },
+        {
+          "identifier": "1914715",
+          "scheme": "fast"
+        },
+        {
+          "identifier": "/m/0j3g9fl",
+          "scheme": "freebase"
+        },
+        {
+          "identifier": "151606846",
+          "scheme": "sudoc"
+        },
+        {
+          "identifier": "170552138",
+          "scheme": "viaf"
+        },
+        {
+          "identifier": "Q3065252",
+          "scheme": "wikidata"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/fozyah_kofi_badashkhan-m.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/fozyah_kofi_badashkhan-m.JPG"
+        },
+        {
+          "url": "https://upload.wikimedia.org/wikipedia/commons/f/f6/Fauzia_Koofi_of_Afghanistan_in_2011-cropped.jpg"
+        }
+      ],
+      "links": [
+        {
+          "note": "Wikipedia (bg)",
+          "url": "https://bg.wikipedia.org/wiki/Фаузия_Кофи"
+        },
+        {
+          "note": "Wikipedia (en)",
+          "url": "https://en.wikipedia.org/wiki/Fawzia_Koofi"
+        },
+        {
+          "note": "Wikipedia (fa)",
+          "url": "https://fa.wikipedia.org/wiki/فوزیه_کوفی"
+        },
+        {
+          "note": "Wikipedia (fr)",
+          "url": "https://fr.wikipedia.org/wiki/Fawzia_Koofi"
+        },
+        {
+          "note": "Wikipedia (pa)",
+          "url": "https://pa.wikipedia.org/wiki/ਫ਼ਵਜ਼ੀਆ_ਕੂਫ਼ੀ"
+        },
+        {
+          "note": "Wikipedia (pl)",
+          "url": "https://pl.wikipedia.org/wiki/Fawzia_Koofi"
+        },
+        {
+          "note": "Wikipedia (plwikiquote)",
+          "url": "https://plwikiquote.wikipedia.org/wiki/Fawzia_Koofi"
+        },
+        {
+          "note": "Wikipedia (pt)",
+          "url": "https://pt.wikipedia.org/wiki/Fawzia_Koofi"
+        },
+        {
+          "note": "Wikipedia (zh)",
+          "url": "https://zh.wikipedia.org/wiki/法齊婭·古菲"
+        },
+        {
+          "note": "twitter",
+          "url": "https://twitter.com/FawziaKoofi77"
+        }
+      ],
+      "name": "Fawzia Koofi",
+      "other_names": [
+        {
+          "lang": "bg",
+          "name": "Фаузия Кофи",
+          "note": "multilingual"
+        },
+        {
+          "lang": "de",
+          "name": "Fawzia Koofi",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Fawzia Koofi",
+          "note": "multilingual"
+        },
+        {
+          "lang": "es",
+          "name": "Fawzia Koofi",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fa",
+          "name": "فوزیه کوفی",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fr",
+          "name": "Fawzia Koofi",
+          "note": "multilingual"
+        },
+        {
+          "lang": "hu",
+          "name": "Fawzia Koofi",
+          "note": "multilingual"
+        },
+        {
+          "lang": "it",
+          "name": "Fawzia Koofi",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nl",
+          "name": "Fawzia Koofi",
+          "note": "multilingual"
+        },
+        {
+          "lang": "pa",
+          "name": "ਫ਼ਵਜ਼ੀਆ ਕੂਫ਼ੀ",
+          "note": "multilingual"
+        },
+        {
+          "lang": "pl",
+          "name": "Fawzia Koofi",
+          "note": "multilingual"
+        },
+        {
+          "lang": "pt",
+          "name": "Fawzia Koofi",
+          "note": "multilingual"
+        },
+        {
+          "lang": "zh",
+          "name": "法齊婭·古菲",
+          "note": "multilingual"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=42&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "c5de9747-ede6-4e94-89c8-ce3946cc4e83",
+      "identifiers": [
+        {
+          "identifier": "1826",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-fozya-rofi.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-fozya-rofi.JPG"
+        }
+      ],
+      "name": "Fawzia raoofi",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=24&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "1a3ecc90-6a19-4404-9717-1cc15579688c",
+      "identifiers": [
+        {
+          "identifier": "1943",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Fraidon Mohmand",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=7&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "6152bb79-ca17-4ec0-babc-84395a81de81",
+      "identifiers": [
+        {
+          "identifier": "1951",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Freshta Amini",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=6&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "245c5c12-86f7-4b59-9eb3-34b9211ea0d3",
+      "identifiers": [
+        {
+          "identifier": "1948",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Freshta Anwary",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=7&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "3a9ca8da-e0e4-44ee-80ac-5af5acb8b44d",
+      "identifiers": [
+        {
+          "identifier": "2011",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/GHolamhosain-nasiri-s.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/GHolamhosain-nasiri-s.JPG"
+        }
+      ],
+      "name": "GHolam Hosain Nasiri",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "a4fce5e4-e715-425a-acc7-16e472acb2da",
+      "identifiers": [
+        {
+          "identifier": "1961",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/gholamfarogh-majroh.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/gholamfarogh-majroh.JPG"
+        }
+      ],
+      "name": "Gholam Faroqe Majroh",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=5&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "3933aac1-3692-4dcb-bb72-9161a48bc523",
+      "identifiers": [
+        {
+          "identifier": "1963",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Gholam farooq Nazary",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=4&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "e15eb84e-03df-46c3-a595-8ab3fa3bd201",
+      "identifiers": [
+        {
+          "identifier": "1734",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/b-kalali-nor-safi-m.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/b-kalali-nor-safi-m.JPG"
+        }
+      ],
+      "name": "Ghulalai Noor safi",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=39&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "4dfe5e32-ab61-40b0-98e3-35bb17289997",
+      "identifiers": [
+        {
+          "identifier": "1829",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Gul Mohammed",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=24&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "ca29212d-6306-4300-90e1-693248651ff4",
+      "identifiers": [
+        {
+          "identifier": "1974",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-habibeh-sadat.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-habibeh-sadat.jpg"
+        }
+      ],
+      "name": "Habiba Sadat",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=2&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "6b01317d-919c-40c4-ba94-650d0de02bb7",
+      "identifiers": [
+        {
+          "identifier": "1907",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/Copy%20of%20Copy%20of%20habibarahman.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/Copy%20of%20Copy%20of%20habibarahman.jpg"
+        }
+      ],
+      "name": "Habiburahman Afghan",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=12&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "a4c9d18f-3f41-4ef2-8c62-38483fb9dbd9",
+      "identifiers": [
+        {
+          "identifier": "1908",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/hayda-naemzoy.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/hayda-naemzoy.jpg"
+        }
+      ],
+      "name": "Haidar jan naeem zoy",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=12&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "db382198-3b51-4375-90e5-579bef8549a3",
+      "identifiers": [
+        {
+          "identifier": "1941",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/Copy%20of%20abdozaher-qadiri.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/Copy%20of%20abdozaher-qadiri.jpg"
+        }
+      ],
+      "name": "Haji Abdul Zahair Qadeer",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=8&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "fb3690ea-3a66-4727-94ff-d02d260637b2",
+      "identifiers": [
+        {
+          "identifier": "1764",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Haji Abdulwahid Faqeirrzadh",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=35&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "cbfa81df-52b8-4b8d-a0c4-f2e1ed695ab8",
+      "identifiers": [
+        {
+          "identifier": "1871",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/haji-aghajan-m.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/haji-aghajan-m.JPG"
+        }
+      ],
+      "name": "Haji Aghajan sayeedi",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=17&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "e46fed8a-599b-4c72-b0b1-5f9bcbad5cd7",
+      "identifiers": [
+        {
+          "identifier": "1922",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Haji Ali Mohammed",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=10&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "7e0c4486-4bd5-46bd-a289-be125641e078",
+      "identifiers": [
+        {
+          "identifier": "1696",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-gholam-sarvar-fayez.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-gholam-sarvar-fayez.JPG"
+        }
+      ],
+      "name": "Haji Gholam Sarwar Faiez",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=44&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "e43e231b-2d8b-48f6-9d48-d00929f04c46",
+      "identifiers": [
+        {
+          "identifier": "1862",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-mohammad-mohaqqeq.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-mohammad-mohaqqeq.jpg"
+        }
+      ],
+      "name": "Haji Mohammad Maqiq",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=18&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "5e855a80-23a7-448e-979a-4f168d7169ec",
+      "identifiers": [
+        {
+          "identifier": "1914",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Haji Mohammad Nazair Ahmadzai",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=11&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "3f2072f3-3dd3-4397-9132-97a1a6f0ed5f",
+      "identifiers": [
+        {
+          "identifier": "1777",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-mohammad-esmail.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-mohammad-esmail.JPG"
+        }
+      ],
+      "name": "Haji Mohammed Ismail",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=33&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "3fbc4851-d13d-4dd9-a990-df598889cfcb",
+      "identifiers": [
+        {
+          "identifier": "1985",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-mohammad-vali-alizai.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-mohammad-vali-alizai.JPG"
+        }
+      ],
+      "name": "Haji Mohammed Valy Ali zai",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=2&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "d1d013ff-c8d4-4acd-94fd-0acc9fa04593",
+      "identifiers": [
+        {
+          "identifier": "1920",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Haji Naqibullah Mohbut",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=10&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "1783ad09-8640-44a3-adf6-da8d9c434be2",
+      "identifiers": [
+        {
+          "identifier": "3955",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/Hon'ble%20Haji%20Sayed%20Mohammad%20Daud%20Nasiri.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/Hon'ble%20Haji%20Sayed%20Mohammad%20Daud%20Nasiri.jpg"
+        }
+      ],
+      "name": "Haji Sayed Mohammad Daud Nasiri - Daikundi",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "8ef77f06-5cea-4af1-8726-50ba2f69ca82",
+      "identifiers": [
+        {
+          "identifier": "1912",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/hamida-ahmadzai.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/hamida-ahmadzai.jpg"
+        }
+      ],
+      "name": "Hamida ahmadzai",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=11&Cat=37"
+        }
+      ]
+    },
+    {
+      "birth_date": "1964",
+      "gender": "male",
+      "id": "cc000dac-20a0-415f-b673-37b67dc5ef72",
+      "identifiers": [
+        {
+          "identifier": "1937",
+          "scheme": "everypolitician_legacy"
+        },
+        {
+          "identifier": "Q5688389",
+          "scheme": "wikidata"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "links": [
+        {
+          "note": "Wikipedia (en)",
+          "url": "https://en.wikipedia.org/wiki/Hazrat_Ali_(Afghan_politician)"
+        },
+        {
+          "note": "Wikipedia (fa)",
+          "url": "https://fa.wikipedia.org/wiki/حضرت_علی_(سیاستمدار_افغان)"
+        }
+      ],
+      "name": "Hazrat Ali",
+      "other_names": [
+        {
+          "lang": "de",
+          "name": "Hazrat Ali",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Hazrat Ali",
+          "note": "multilingual"
+        },
+        {
+          "lang": "es",
+          "name": "Hazrat Ali",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fa",
+          "name": "حضرت علی",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fr",
+          "name": "Hazrat Ali",
+          "note": "multilingual"
+        },
+        {
+          "lang": "hu",
+          "name": "Hazrat Ali",
+          "note": "multilingual"
+        },
+        {
+          "lang": "it",
+          "name": "Ali",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nl",
+          "name": "Hazrat Ali",
+          "note": "multilingual"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=8&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "e7914d81-cfd7-49fd-87ee-0f05b8e553ab",
+      "identifiers": [
+        {
+          "identifier": "1916",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-heli-ershad.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-heli-ershad.jpg"
+        }
+      ],
+      "name": "Helai Ershad",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=11&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "7d9d69bd-fb66-4904-8e1e-5ded70226399",
+      "identifiers": [
+        {
+          "identifier": "1802",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/homa-soltani-m.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/homa-soltani-m.JPG"
+        }
+      ],
+      "name": "Homa soltani , ghazni",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=28&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "5f5ccec2-d983-45f3-a35e-1ea3eb8dde89",
+      "identifiers": [
+        {
+          "identifier": "1835",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Homaira ayobi",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=23&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "8d962c13-34f0-4c59-ad57-0a77425e6ffd",
+      "identifiers": [
+        {
+          "identifier": "1783",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/homayon-m.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/homayon-m.jpg"
+        }
+      ],
+      "name": "Homayyon Zowihic",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=32&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "87f411ee-cd5c-4bab-8343-8f7cb7e3eff3",
+      "identifiers": [
+        {
+          "identifier": "1840",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "JAFAR MEHDAWEY",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=22&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "given_name": "Khalid",
+      "id": "6a45a6e9-82dd-404f-8765-a60e75dd7812",
+      "identifiers": [
+        {
+          "identifier": "1889",
+          "scheme": "everypolitician_legacy"
+        },
+        {
+          "identifier": "Q6399558",
+          "scheme": "wikidata"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "links": [
+        {
+          "note": "Wikipedia (en)",
+          "url": "https://en.wikipedia.org/wiki/Khalid_Pashtoon"
+        }
+      ],
+      "name": "KHalid Pashton",
+      "other_names": [
+        {
+          "name": "Khalid Pashtoon",
+          "note": "alternate"
+        },
+        {
+          "lang": "de",
+          "name": "Khalid Pashtoon",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Khalid Pashtoon",
+          "note": "multilingual"
+        },
+        {
+          "lang": "es",
+          "name": "Khalid Pashtoon",
+          "note": "multilingual"
+        },
+        {
+          "lang": "hu",
+          "name": "Khalid Pashtoon",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nl",
+          "name": "Khalid Pashtoon",
+          "note": "multilingual"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=15&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "437ef71d-0e0d-4957-8210-8cf358d75425",
+      "identifiers": [
+        {
+          "identifier": "1884",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Kamal safi",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=16&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "9bbe49c2-ce72-4d6e-9dbe-94b7034bf5ee",
+      "identifiers": [
+        {
+          "identifier": "1955",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Khalil Ahmad Shahid Zadah",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=5&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "d339406b-cd11-4ed6-9157-5e89dcf7a984",
+      "identifiers": [
+        {
+          "identifier": "1801",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Khodadad Erfani",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=28&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "7035eef7-76e4-47e7-85e3-2da0df458487",
+      "identifiers": [
+        {
+          "identifier": "1819",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/keramodin-rezazadeh-m.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/keramodin-rezazadeh-m.jpg"
+        }
+      ],
+      "name": "Kiramudden Rezazada",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=26&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "aa6aa7ad-b8c5-40b8-a181-1cdef03c0440",
+      "identifiers": [
+        {
+          "identifier": "1857",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Kobra mostafwey",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=19&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "12989b49-daa0-4629-8737-a50afefb62dc",
+      "identifiers": [
+        {
+          "identifier": "1947",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-layloma-vali-hakimi.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-layloma-vali-hakimi.JPG"
+        }
+      ],
+      "name": "Lailoma- Hakimi",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=7&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "5a4d7ea1-566b-4f11-9217-252fd08d8484",
+      "identifiers": [
+        {
+          "identifier": "1739",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-khaja-sedigh-ahmad-osmani.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-khaja-sedigh-ahmad-osmani.jpg"
+        }
+      ],
+      "name": "Lhowaja sediq ahmad osmani , parwan",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=38&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "59b044bb-a3b9-40a9-a55a-d6e754d249cd",
+      "identifiers": [
+        {
+          "identifier": "1780",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Lyaqatullah babakarkhel , khost",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=32&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "6a21e463-1c32-44cd-b415-26bb81fa3562",
+      "identifiers": [
+        {
+          "identifier": "1897",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "MAHMOOD KHAN",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=13&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "95b36564-77c9-498f-a0d6-eec18d5f43c9",
+      "identifiers": [
+        {
+          "identifier": "1923",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/mohammadakbar-stanekzai.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/mohammadakbar-stanekzai.JPG"
+        }
+      ],
+      "name": "MOHAMMAD AKKBAR STANIKZAI",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=10&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "64c68784-2187-48f1-a1ae-258e19deb4de",
+      "identifiers": [
+        {
+          "identifier": "1860",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/davod-kalakani-m.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/davod-kalakani-m.jpg"
+        }
+      ],
+      "name": "MOHAMMAD Dawood kalakani",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=19&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "c287ae2e-78cd-4d40-9a5c-b80b828220ba",
+      "identifiers": [
+        {
+          "identifier": "1726",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Mahiudden- Mahdi",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=40&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "62408e41-82e5-4a51-89f5-9f6893166a15",
+      "identifiers": [
+        {
+          "identifier": "1798",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/makhdom-moheb-forghani-m.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/makhdom-moheb-forghani-m.JPG"
+        }
+      ],
+      "name": "Makhdom mohibullah forqani , samanghan",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=29&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "0d879896-56d0-4075-989c-6899273ee553",
+      "identifiers": [
+        {
+          "identifier": "1799",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/masome-khavari-m.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/masome-khavari-m.jpg"
+        }
+      ],
+      "name": "Masoma khawari , samanghan",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=29&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "5da8be60-ffd2-4db5-be0a-634622c66033",
+      "identifiers": [
+        {
+          "identifier": "1968",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/masooda.karokhi.ss.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/masooda.karokhi.ss.jpg"
+        }
+      ],
+      "name": "Masooda Karokhi",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=4&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "38fd97e3-747f-45e6-aa59-9eb89336dbd2",
+      "identifiers": [
+        {
+          "identifier": "1864",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Meer Amanullah ghozar",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=18&Cat=37"
+        }
+      ]
+    },
+    {
+      "birth_date": "1962",
+      "gender": "male",
+      "id": "058fa220-a574-4a16-abdd-758c8f42c676",
+      "identifiers": [
+        {
+          "identifier": "1932",
+          "scheme": "everypolitician_legacy"
+        },
+        {
+          "identifier": "Q6874777",
+          "scheme": "wikidata"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        },
+        {
+          "url": "https://upload.wikimedia.org/wikipedia/commons/1/16/Mirwais_Yasini.png"
+        }
+      ],
+      "links": [
+        {
+          "note": "Wikipedia (en)",
+          "url": "https://en.wikipedia.org/wiki/Mirwais_Yasini"
+        },
+        {
+          "note": "Wikipedia (ps)",
+          "url": "https://ps.wikipedia.org/wiki/ميرويس_ياسيني"
+        }
+      ],
+      "name": "Meer wais yasini",
+      "other_names": [
+        {
+          "name": "Mirwais Yasini",
+          "note": "alternate"
+        },
+        {
+          "lang": "de",
+          "name": "Mirwais Yasini",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Mirwais Yasini",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fr",
+          "name": "Mirwais Yasini",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nl",
+          "name": "Mirwais Yasini",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ps",
+          "name": "ميرويس ياسيني",
+          "note": "multilingual"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=9&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "88e92b13-8c22-44da-b8b3-98895f45e71f",
+      "identifiers": [
+        {
+          "identifier": "1874",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-merdadkhan-najrabi.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-merdadkhan-najrabi.jpg"
+        }
+      ],
+      "name": "Mirdad Khan-Nejrabi",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=16&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "a5a48fa8-8c6e-4f56-b4bc-75aa4611d80c",
+      "identifiers": [
+        {
+          "identifier": "1744",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-mirrahman-rahmani.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-mirrahman-rahmani.jpg"
+        }
+      ],
+      "name": "Mirrahaman- Rahamani",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=37&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "2545d4a2-eacf-4358-8fe9-d3c4f31beeee",
+      "identifiers": [
+        {
+          "identifier": "1986",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Moalem Meer wali",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=1&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "da5e3e8a-8074-4f06-b620-c1720e488c8b",
+      "identifiers": [
+        {
+          "identifier": "1858",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-mohammad-ebrahim-ghasmi.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-mohammad-ebrahim-ghasmi.jpg"
+        }
+      ],
+      "name": "Mohammad Abrahim Qasemi",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=19&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "908e7e24-e95b-484b-a589-c8beca8a55d3",
+      "identifiers": [
+        {
+          "identifier": "1820",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/mohamad-ebrahim-malikzadeh-m.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/mohamad-ebrahim-malikzadeh-m.jpg"
+        }
+      ],
+      "name": "Mohammad Abrahim malikzada",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=25&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "54018af0-242e-424d-ba78-693ac35765eb",
+      "identifiers": [
+        {
+          "identifier": "1873",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/mohammad-eghbal-safi-m.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/mohammad-eghbal-safi-m.JPG"
+        }
+      ],
+      "name": "Mohammad Aiqball Sapi",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=17&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "0de56fbf-00bc-4f51-9e66-e266f53592b1",
+      "identifiers": [
+        {
+          "identifier": "1965",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Mohammad Arif Taieb",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=4&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "d185c4dd-9894-4179-95c2-1ea03be2914c",
+      "identifiers": [
+        {
+          "identifier": "1737",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/Copy%20of%20m-farhad-azimi.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/Copy%20of%20m-farhad-azimi.jpg"
+        }
+      ],
+      "name": "Mohammad Farhad Azimi -balkh",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=38&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "dd85729c-4f31-4794-b568-747f14493135",
+      "identifiers": [
+        {
+          "identifier": "1861",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-mohammad-farhad-sedghi.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-mohammad-farhad-sedghi.JPG"
+        }
+      ],
+      "name": "Mohammad Farhad sidiqi",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=19&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "1147e94b-4c9d-4253-b1d5-ba90f9ecbe34",
+      "identifiers": [
+        {
+          "identifier": "1828",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Mohammad Hashim",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=24&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "e2a472fe-003c-4230-a121-6708db9f51fb",
+      "identifiers": [
+        {
+          "identifier": "1919",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/mohammadhasan-mamozay.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/mohammadhasan-mamozay.jpg"
+        }
+      ],
+      "name": "Mohammad Hassain Mamozia",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=10&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "ac166e5c-d4cc-4953-a533-c8deec236547",
+      "identifiers": [
+        {
+          "identifier": "1756",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Mohammad Ibrahim ghakhtalai",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=36&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "911b42c0-d41d-4fbb-9e6d-5d0ad65abdae",
+      "identifiers": [
+        {
+          "identifier": "1898",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/mohammdnaem-lali-hamidzai.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/mohammdnaem-lali-hamidzai.jpg"
+        }
+      ],
+      "name": "Mohammad Naheem Lalai",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=13&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "e5e3a421-86d7-42ea-832a-64c33073a2bd",
+      "identifiers": [
+        {
+          "identifier": "1757",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/navab-mankal-m.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/navab-mankal-m.jpg"
+        }
+      ],
+      "name": "Mohammad Navab Mangal",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=36&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "d9d44204-ddea-4fb2-ab77-63675eca3921",
+      "identifiers": [
+        {
+          "identifier": "1896",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Mohammad Omar Nanghialai",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=14&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "a75f33fc-6ff6-4cc1-ba4c-e3ae307e0606",
+      "identifiers": [
+        {
+          "identifier": "1834",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-mohammad-sarvar-osmani-panahi.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-mohammad-sarvar-osmani-panahi.JPG"
+        }
+      ],
+      "name": "Mohammad Sarwar Osmani",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=23&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "17c7ea8c-e2f2-4104-b847-2ca56a7b4b0d",
+      "identifiers": [
+        {
+          "identifier": "1863",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/mohammad-uonos-ghanoni-m.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/mohammad-uonos-ghanoni-m.jpg"
+        }
+      ],
+      "name": "Mohammad Unos qanoni",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=18&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "d8b321cb-99c0-4186-a8e3-1f352d073247",
+      "identifiers": [
+        {
+          "identifier": "1736",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-mohammad-abdo.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-mohammad-abdo.jpg"
+        }
+      ],
+      "name": "Mohammad abduh",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=38&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "ce23f144-8554-4c68-aa51-ffc02843c2d9",
+      "identifiers": [
+        {
+          "identifier": "1808",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-mohammad-ali-akhlaghi.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-mohammad-ali-akhlaghi.jpg"
+        }
+      ],
+      "name": "Mohammad ali akhlaqi , ghazni",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=27&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "10b86908-461d-4c18-85fb-4e808d78bd4f",
+      "identifiers": [
+        {
+          "identifier": "1809",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-mohammadali-alizadeh.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-mohammadali-alizadeh.jpg"
+        }
+      ],
+      "name": "Mohammad ali alizai , ghazni",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=27&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "given_name": "Mohammad",
+      "id": "6c0e9326-09cf-49c2-aded-0f7a3f7103b1",
+      "identifiers": [
+        {
+          "identifier": "1918",
+          "scheme": "everypolitician_legacy"
+        },
+        {
+          "identifier": "Q6891791",
+          "scheme": "wikidata"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        },
+        {
+          "url": "https://upload.wikimedia.org/wikipedia/commons/a/ac/Mohammad_Alim_Qarar,_Laghman_Province,_Afghanistan.jpg"
+        }
+      ],
+      "links": [
+        {
+          "note": "Wikipedia (en)",
+          "url": "https://en.wikipedia.org/wiki/Mohammad_Alim_Qarar"
+        }
+      ],
+      "name": "Mohammad alim qarar",
+      "other_names": [
+        {
+          "lang": "de",
+          "name": "Mohammad Alim Qarar",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Mohammad Alim Qarar",
+          "note": "multilingual"
+        },
+        {
+          "lang": "es",
+          "name": "Mohammad Alim Qarar",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fr",
+          "name": "Mohammad Alim Qarar",
+          "note": "multilingual"
+        },
+        {
+          "lang": "hu",
+          "name": "Mohammad Alim Qarar",
+          "note": "multilingual"
+        },
+        {
+          "lang": "it",
+          "name": "Mohammad Alim Qarar",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nl",
+          "name": "Mohammad Alim Qarar",
+          "note": "multilingual"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=11&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "cb32a534-b95c-4107-a57e-1fbed4f6b8ff",
+      "identifiers": [
+        {
+          "identifier": "1807",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-mohammad-aref-rahmani.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-mohammad-aref-rahmani.jpg"
+        }
+      ],
+      "name": "Mohammad arif rahmani , ghazni",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=27&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "c7598c20-59b3-4615-af01-4dd9d68b177c",
+      "identifiers": [
+        {
+          "identifier": "1725",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Mohammad azim mohsini , baghlan",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=40&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "e04260a2-f8c6-456f-96fa-d0d45cb7c56d",
+      "identifiers": [
+        {
+          "identifier": "1967",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/mohammadriza-khoshak-watandost.ss.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/mohammadriza-khoshak-watandost.ss.JPG"
+        }
+      ],
+      "name": "Mohammad reza Khoshak Watandost",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=4&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "6f511a87-7026-4a17-9c30-508aeadd1246",
+      "identifiers": [
+        {
+          "identifier": "1915",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Mohammed Yousuf Sabir",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=11&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "62bc5789-0bab-4a52-9ede-a4a4da6d0951",
+      "identifiers": [
+        {
+          "identifier": "1735",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Mohmmad eshaq rahghozar , balkh",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=39&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "90ef74f9-c3c8-4483-a6a6-0d76dd849b8b",
+      "identifiers": [
+        {
+          "identifier": "1795",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/mohammad-hossin-fahime-m.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/mohammad-hossin-fahime-m.jpg"
+        }
+      ],
+      "name": "Mohmmad hosain fahimi , sarpol",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=29&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "88a69adb-5771-4afd-b3aa-e4cc073cd29b",
+      "identifiers": [
+        {
+          "identifier": "1969",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Monwar Shah Bahadory",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=3&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "41dbcf99-41d7-4225-a189-f3f043011ef0",
+      "identifiers": [
+        {
+          "identifier": "1833",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-mosa-nosrat.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-mosa-nosrat.jpg"
+        }
+      ],
+      "name": "Musa khan nasrat",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=23&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "776a6704-9c91-43b6-95c3-7b638b15b241",
+      "identifiers": [
+        {
+          "identifier": "1973",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/naheed.farid.s.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/naheed.farid.s.JPG"
+        }
+      ],
+      "name": "Naheed ahmadi farid",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=3&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "e1e2f2af-6a92-4f4a-b6cd-0bd47ee08a69",
+      "identifiers": [
+        {
+          "identifier": "1971",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/najla-dehqannejat.ss.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/najla-dehqannejat.ss.jpg"
+        }
+      ],
+      "name": "Najla Yousufai Dehqan neZhad",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=3&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "07ea72b7-c538-4f33-af71-9ccc2dbd7a9b",
+      "identifiers": [
+        {
+          "identifier": "2000",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Naseema niazi",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=1&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "6e460578-1537-4842-b5ef-7c50607d7cda",
+      "identifiers": [
+        {
+          "identifier": "1787",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Nassrullah Sadeqi Zahada",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=31&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "6895eaa6-46b0-4a06-aec1-db8ddf8aef7c",
+      "identifiers": [
+        {
+          "identifier": "1887",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Nazari Turkman",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=15&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "9b1a5059-7d85-4b40-bb2c-2d1c9ec3bb68",
+      "identifiers": [
+        {
+          "identifier": "1972",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Nazir Ahmad Hanafi",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=3&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "b38cf287-8d58-4f21-ba74-43eace21591a",
+      "identifiers": [
+        {
+          "identifier": "2001",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/neamatullah-ghafari.ss.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/neamatullah-ghafari.ss.jpg"
+        }
+      ],
+      "name": "Neamatullah GHafari",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=1&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "434ecc44-4dd7-4d44-b383-8b8d99b57ddb",
+      "identifiers": [
+        {
+          "identifier": "1970",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Nesar Ahmad GHoryani",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=3&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "7fc34d52-fc1b-4db0-b414-74e6da5c3f8d",
+      "identifiers": [
+        {
+          "identifier": "1909",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Parvin Dernai",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=12&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "8e614ab7-4f96-4e06-8cf6-d2b238c2fa43",
+      "identifiers": [
+        {
+          "identifier": "1950",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/parveen%20noristani.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/parveen%20noristani.jpg"
+        }
+      ],
+      "name": "Parvine Noorstani",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=6&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "c5a0f13a-44f4-429d-9b63-8c13d1c5f453",
+      "identifiers": [
+        {
+          "identifier": "1934",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Peerbakhsh ghardewal",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=9&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "d761b537-9b3f-4574-9a1b-275e35256f6c",
+      "identifiers": [
+        {
+          "identifier": "1856",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/gheys-hssan-m.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/gheys-hssan-m.jpg"
+        }
+      ],
+      "name": "Qais Hasan",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=19&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "9c8ae26d-8d94-4068-b17a-638ef521b9bc",
+      "identifiers": [
+        {
+          "identifier": "1768",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-ghodratullah-zaki.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-ghodratullah-zaki.jpg"
+        }
+      ],
+      "name": "Qodratullah zaki , Takhar",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=34&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "b34baf37-b604-47b3-8467-55c334ab588c",
+      "identifiers": [
+        {
+          "identifier": "1869",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-ghorbanali-erfani.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-ghorbanali-erfani.jpg"
+        }
+      ],
+      "name": "Querbanali-Erfoni",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=17&Cat=37"
+        }
+      ]
+    },
+    {
+      "birth_date": "1965",
+      "gender": "male",
+      "given_name": "Ramazan",
+      "id": "07866adc-1d1b-40e7-bb81-0499af2676f3",
+      "identifiers": [
+        {
+          "identifier": "1842",
+          "scheme": "everypolitician_legacy"
+        },
+        {
+          "identifier": "/m/03ybf4d",
+          "scheme": "freebase"
+        },
+        {
+          "identifier": "Q203903",
+          "scheme": "wikidata"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/ramazan-m.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/ramazan-m.JPG"
+        }
+      ],
+      "links": [
+        {
+          "note": "Wikipedia (ar)",
+          "url": "https://ar.wikipedia.org/wiki/رمضان_بشردوست"
+        },
+        {
+          "note": "Wikipedia (de)",
+          "url": "https://de.wikipedia.org/wiki/Ramasan_Bashardost"
+        },
+        {
+          "note": "Wikipedia (en)",
+          "url": "https://en.wikipedia.org/wiki/Ramazan_Bashardost"
+        },
+        {
+          "note": "Wikipedia (es)",
+          "url": "https://es.wikipedia.org/wiki/Ramazan_Bashardost"
+        },
+        {
+          "note": "Wikipedia (fa)",
+          "url": "https://fa.wikipedia.org/wiki/رمضان_بشردوست"
+        },
+        {
+          "note": "Wikipedia (fr)",
+          "url": "https://fr.wikipedia.org/wiki/Ramazan_Bashardost"
+        },
+        {
+          "note": "Wikipedia (ps)",
+          "url": "https://ps.wikipedia.org/wiki/رمضان_بشردوست"
+        },
+        {
+          "note": "Wikipedia (zh)",
+          "url": "https://zh.wikipedia.org/wiki/拉马赞·巴沙里德斯特"
+        }
+      ],
+      "name": "RAMAZAN BASHARDOST",
+      "other_names": [
+        {
+          "lang": "ar",
+          "name": "رمضان بشردوست",
+          "note": "multilingual"
+        },
+        {
+          "lang": "de",
+          "name": "Ramasan Bashardost",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Ramazan Bashardost",
+          "note": "multilingual"
+        },
+        {
+          "lang": "es",
+          "name": "Ramazan Bashardost",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fa",
+          "name": "رمضان بشردوست",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fr",
+          "name": "Ramazan Bashardost",
+          "note": "multilingual"
+        },
+        {
+          "lang": "hu",
+          "name": "Ramazan Bashardost",
+          "note": "multilingual"
+        },
+        {
+          "lang": "it",
+          "name": "Ramazan Bashardost",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ja",
+          "name": "ラマザン・バシャルドスト",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nl",
+          "name": "Ramazan Bashardost",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ps",
+          "name": "رمضان بشردوست",
+          "note": "multilingual"
+        },
+        {
+          "lang": "zh",
+          "name": "拉马赞·巴沙里德斯特",
+          "note": "multilingual"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=21&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "98866b8d-5d97-4a0d-9dfe-08e54d0db3a1",
+      "identifiers": [
+        {
+          "identifier": "1956",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Rahima jami",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=5&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "408df264-df61-428f-b30f-b6bd5cf0466e",
+      "identifiers": [
+        {
+          "identifier": "1843",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/ramazan-jomazadah-m.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/ramazan-jomazadah-m.JPG"
+        }
+      ],
+      "name": "Ramazan jomazada",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=21&Cat=37"
+        }
+      ]
+    },
+    {
+      "birth_date": "1985-03-22",
+      "gender": "female",
+      "id": "aac6f415-446d-4070-80d9-195d4f7b77ac",
+      "identifiers": [
+        {
+          "identifier": "1823",
+          "scheme": "everypolitician_legacy"
+        },
+        {
+          "identifier": "Q18637795",
+          "scheme": "wikidata"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/rankinh-karkar-m.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/rankinh-karkar-m.JPG"
+        },
+        {
+          "url": "https://upload.wikimedia.org/wikipedia/commons/6/63/Rangina_Kargar.JPG"
+        }
+      ],
+      "links": [
+        {
+          "note": "Wikipedia (en)",
+          "url": "https://en.wikipedia.org/wiki/Rangina_Kargar"
+        }
+      ],
+      "name": "Ranghena karghar",
+      "other_names": [
+        {
+          "name": "Rangina Kargar",
+          "note": "alternate"
+        },
+        {
+          "lang": "en",
+          "name": "Rangina Kargar",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nl",
+          "name": "Rangina Kargar",
+          "note": "multilingual"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=25&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "0e2a8144-d144-4909-a6da-b689a555ccf6",
+      "identifiers": [
+        {
+          "identifier": "1815",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-roghya-nael.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-roghya-nael.jpg"
+        }
+      ],
+      "name": "Ruqia- Naiel",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=26&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "f3f89ef2-00c8-4d5a-bbf7-7aa4653b00a7",
+      "identifiers": [
+        {
+          "identifier": "1899",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/sakhi.mashwanai.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/sakhi.mashwanai.jpg"
+        }
+      ],
+      "name": "SAKHI MASHWANAI",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=13&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "37ae1de9-8eeb-4459-91f7-90212182fd52",
+      "identifiers": [
+        {
+          "identifier": "1866",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/sharif-allah-kamaval-m.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/sharif-allah-kamaval-m.jpg"
+        }
+      ],
+      "name": "SHarifullah Kamawall",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=18&Cat=37"
+        }
+      ]
+    },
+    {
+      "birth_date": "1972",
+      "gender": "female",
+      "id": "030b25fb-05d6-4acb-809d-c122db9e0f94",
+      "identifiers": [
+        {
+          "identifier": "1847",
+          "scheme": "everypolitician_legacy"
+        },
+        {
+          "identifier": "nm3154418",
+          "scheme": "imdb"
+        },
+        {
+          "identifier": "Q7504854",
+          "scheme": "wikidata"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/shokri-barikzay-m.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/shokri-barikzay-m.jpg"
+        },
+        {
+          "url": "https://upload.wikimedia.org/wikipedia/commons/f/fe/Shukria_Barakzai_in_March_2011-cropped.jpg"
+        }
+      ],
+      "links": [
+        {
+          "note": "Wikipedia (commons)",
+          "url": "https://commons.wikipedia.org/wiki/Category:Shukria_Barakzai"
+        },
+        {
+          "note": "Wikipedia (de)",
+          "url": "https://de.wikipedia.org/wiki/Schukria_Barakzai"
+        },
+        {
+          "note": "Wikipedia (en)",
+          "url": "https://en.wikipedia.org/wiki/Shukria_Barakzai"
+        },
+        {
+          "note": "Wikipedia (fr)",
+          "url": "https://fr.wikipedia.org/wiki/Shukria_Barakzai"
+        },
+        {
+          "note": "Wikipedia (ps)",
+          "url": "https://ps.wikipedia.org/wiki/شکريه_بارکزۍ"
+        },
+        {
+          "note": "Wikipedia (tr)",
+          "url": "https://tr.wikipedia.org/wiki/Şükriye_Barakzai"
+        }
+      ],
+      "name": "SHokria barikzai",
+      "other_names": [
+        {
+          "name": "Shukria Barakzai",
+          "note": "alternate"
+        },
+        {
+          "lang": "de",
+          "name": "Schukria Barakzai",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Shukria Barakzai",
+          "note": "multilingual"
+        },
+        {
+          "lang": "es",
+          "name": "Shukria Barakzai",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fi",
+          "name": "Shukria Barakzai",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fr",
+          "name": "Shukria Barakzai",
+          "note": "multilingual"
+        },
+        {
+          "lang": "hu",
+          "name": "Sukria Barakzai",
+          "note": "multilingual"
+        },
+        {
+          "lang": "it",
+          "name": "Shukria Barakzai",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nl",
+          "name": "Shukria Barakzai",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ps",
+          "name": "شکريه بارکزۍ",
+          "note": "multilingual"
+        },
+        {
+          "lang": "tr",
+          "name": "Şükriye Barakzai",
+          "note": "multilingual"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=21&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "72df1691-fbfa-409d-b7b3-d5ab49aaeefd",
+      "identifiers": [
+        {
+          "identifier": "1939",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Saema khoghyani",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=8&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "5302e469-1084-4bc9-be4a-0ebb786c15d6",
+      "identifiers": [
+        {
+          "identifier": "1926",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Sahib Khan - Logar",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=10&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "818e7c52-16ca-4859-a395-1399a417b1c1",
+      "identifiers": [
+        {
+          "identifier": "1902",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Saleh Mohammad saleh",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=13&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "57ca8a7f-1913-46ca-85ee-cfd8a9c4a5c1",
+      "identifiers": [
+        {
+          "identifier": "1741",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/samea-aziz-sadat-m.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/samea-aziz-sadat-m.jpg"
+        }
+      ],
+      "name": "Samea Azizi Sadaat",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=37&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "ace89f3f-a9ba-4aac-9c6b-2028ca0ccdcf",
+      "identifiers": [
+        {
+          "identifier": "1890",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Sayd Mohammad Akhond",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=15&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "58b196da-40ce-437f-b1e2-73e72b6c0dd2",
+      "identifiers": [
+        {
+          "identifier": "1846",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/dr-kazemi-m.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/dr-kazemi-m.jpg"
+        }
+      ],
+      "name": "Sayed Ali kazimi",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=21&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "754a34ef-5f3f-43ee-93cc-6ca32dd8929e",
+      "identifiers": [
+        {
+          "identifier": "1878",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Sayed Dawood Nadri",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=16&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "da6a02ce-8208-41e1-bef0-ef05186b259e",
+      "identifiers": [
+        {
+          "identifier": "1698",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-fakor-beheshti.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-fakor-beheshti.jpg"
+        }
+      ],
+      "name": "Sayed Jamaludin Fakori Behishti - bamyan",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=44&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "1f75c581-0a97-49c0-9bd4-4c9ea1a62e27",
+      "identifiers": [
+        {
+          "identifier": "1821",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/asefehshadab-m.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/asefehshadab-m.jpg"
+        }
+      ],
+      "name": "Sayydai asifa –shadab",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=25&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "2f91d2af-8a7e-48a8-bd7e-8fc7870e5ef0",
+      "identifiers": [
+        {
+          "identifier": "1792",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Sayyed Anwer Sadaat",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=30&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "b5a68c51-d257-4875-9d11-22fc259ba9a7",
+      "identifiers": [
+        {
+          "identifier": "1793",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-syedmohammad-hasan-sharifi-balkhabi.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-syedmohammad-hasan-sharifi-balkhabi.jpg"
+        }
+      ],
+      "name": "Sayyed Mo- Hassan",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=30&Cat=37"
+        }
+      ]
+    },
+    {
+      "birth_date": "1979",
+      "gender": "female",
+      "id": "10a1ede0-f283-45e7-b10a-0a34e5bb585b",
+      "identifiers": [
+        {
+          "identifier": "1804",
+          "scheme": "everypolitician_legacy"
+        },
+        {
+          "identifier": "Q7461271",
+          "scheme": "wikidata"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-shahkol-rezai.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-shahkol-rezai.JPG"
+        }
+      ],
+      "links": [
+        {
+          "note": "Wikipedia (en)",
+          "url": "https://en.wikipedia.org/wiki/Shah_Gul_Rezai"
+        },
+        {
+          "note": "Wikipedia (fa)",
+          "url": "https://fa.wikipedia.org/wiki/شاه_گل_رضایی"
+        }
+      ],
+      "name": "Shahgul Rezai",
+      "other_names": [
+        {
+          "name": "Shah Gul Rezai",
+          "note": "alternate"
+        },
+        {
+          "lang": "de",
+          "name": "Shah Gul Rezai",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Shah Gul Rezai",
+          "note": "multilingual"
+        },
+        {
+          "lang": "es",
+          "name": "Shah Gul Rezai",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fa",
+          "name": "شاه گل رضایی",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fr",
+          "name": "Shah Gul Rezai",
+          "note": "multilingual"
+        },
+        {
+          "lang": "hu",
+          "name": "Shah Gul Rezai",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nl",
+          "name": "Shah Gul Rezai",
+          "note": "multilingual"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=28&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "ce5b2421-e8f2-4000-9e43-ab2f2082b7a5",
+      "identifiers": [
+        {
+          "identifier": "1957",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-shnaz-hekmati.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-shnaz-hekmati.JPG"
+        }
+      ],
+      "name": "Shahnaz Hemati",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=5&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "4bc6feed-ba3a-421b-8dd2-6200eff6077b",
+      "identifiers": [
+        {
+          "identifier": "1891",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-shakiba-hashemi.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-shakiba-hashemi.jpg"
+        }
+      ],
+      "name": "Shakiba-hashimi",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=14&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "0282b3d6-c7a4-47ab-bcbe-cdc3e2b26437",
+      "identifiers": [
+        {
+          "identifier": "1936",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/shakila-hashmi.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/shakila-hashmi.jpg"
+        }
+      ],
+      "name": "Shakila hashimi",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=8&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "55e382d8-baf1-44f0-9fd3-9529e6fb65a6",
+      "identifiers": [
+        {
+          "identifier": "1785",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-shirin-mohseni.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-shirin-mohseni.jpg"
+        }
+      ],
+      "name": "Shereen- Mohsini",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=31&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "3e2bddb2-badd-43d1-9d73-2ec8734a081a",
+      "identifiers": [
+        {
+          "identifier": "1849",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-shinkayn-zahin-krokhil.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-shinkayn-zahin-krokhil.jpg"
+        }
+      ],
+      "name": "Shinkay Kirokhel",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=21&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "af2a7eba-b0a4-41e4-9839-e59c7046dd50",
+      "identifiers": [
+        {
+          "identifier": "1880",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Shokria payman Ahmadi",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=16&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "738f80ee-0757-4334-8bc6-c047714bf931",
+      "identifiers": [
+        {
+          "identifier": "2008",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/sidiqa-mobariz.s.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/sidiqa-mobariz.s.JPG"
+        }
+      ],
+      "name": "Sidiqa mobarez",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=1&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "4c4f63c3-cb71-4f0a-b8e9-5781187117c1",
+      "identifiers": [
+        {
+          "identifier": "1872",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/tahera-mojjadadi-m.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/tahera-mojjadadi-m.jpg"
+        }
+      ],
+      "name": "Tahera mojadidi",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=17&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "4e0381ea-6b32-47e3-b0b0-7beb81abc057",
+      "identifiers": [
+        {
+          "identifier": "1904",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "Tarakhel Mohammadi",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=12&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "b1e2afa5-7076-4e6b-b37a-154291b86ff6",
+      "identifiers": [
+        {
+          "identifier": "1839",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-torpekay-padman.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-torpekay-padman.JPG"
+        }
+      ],
+      "name": "Torpacki Patman",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=22&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "22c10bac-defd-4ce4-911d-570b43f2c53e",
+      "identifiers": [
+        {
+          "identifier": "1841",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-robabe-parvani.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-robabe-parvani.jpg"
+        }
+      ],
+      "name": "Ustad Robabba Parwani",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=22&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "e44ada34-e146-495e-9f49-9e77e0a495f8",
+      "identifiers": [
+        {
+          "identifier": "1901",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/waghma-sapai.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/waghma-sapai.jpg"
+        }
+      ],
+      "name": "Wagma.Supay",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=13&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "21fbc9db-9a87-47df-bfc7-2fe4ff318b57",
+      "identifiers": [
+        {
+          "identifier": "1789",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/zahra-tokhi-zabli-m-jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/zahra-tokhi-zabli-m-jpg"
+        }
+      ],
+      "name": "Zahra tokhi zabuli , zabul",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=30&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "ac227ae5-8bfd-4fb7-91eb-12f0e8f634ba",
+      "identifiers": [
+        {
+          "identifier": "1740",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-zakya-sankin.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-zakya-sankin.jpg"
+        }
+      ],
+      "name": "Zakia- Sungen",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=38&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "23a52365-0260-4929-a1cc-ab0056f3d201",
+      "identifiers": [
+        {
+          "identifier": "1708",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-abdollatif-pedram.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-abdollatif-pedram.jpg"
+        }
+      ],
+      "name": "abdul lateef pedram,badakhshan",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=42&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "42c3c39d-57b6-40f5-8647-9ee1bd6023ae",
+      "identifiers": [
+        {
+          "identifier": "1790",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/abdullghader-ghallatval-m.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/abdullghader-ghallatval-m.jpg"
+        }
+      ],
+      "name": "abdul qadir qalatwall , zabul",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=30&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "b190b792-1e21-4b3b-ac05-bc0321a239d6",
+      "identifiers": [
+        {
+          "identifier": "1700",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-abdolrahman-shahidani.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-abdolrahman-shahidani.jpg"
+        }
+      ],
+      "name": "abdul rahman shaydani bamyan",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=43&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "ae377616-3a80-4006-a048-140bd37b364f",
+      "identifiers": [
+        {
+          "identifier": "1742",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-abdosatar-khavasi.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-abdosatar-khavasi.jpg"
+        }
+      ],
+      "name": "abdul satar khawasi , parwan",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=37&Cat=37"
+        }
+      ]
+    },
+    {
+      "birth_date": "1957",
+      "death_date": "2012-07-14",
+      "gender": "male",
+      "given_name": "Ahmad",
+      "id": "a2d2c288-499a-4695-964c-5416cb150625",
+      "identifiers": [
+        {
+          "identifier": "1796",
+          "scheme": "everypolitician_legacy"
+        },
+        {
+          "identifier": "Q4695387",
+          "scheme": "wikidata"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "links": [
+        {
+          "note": "Wikipedia (en)",
+          "url": "https://en.wikipedia.org/wiki/Ahmad_Khan_Samangani"
+        }
+      ],
+      "name": "ahmad khan samanghani , samanghan",
+      "other_names": [
+        {
+          "name": "Ahmad Khan Samangani",
+          "note": "alternate"
+        },
+        {
+          "lang": "de",
+          "name": "Ahmad Khan Samangani",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Ahmad Khan Samangani",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fr",
+          "name": "Ahmad Khan Samangani",
+          "note": "multilingual"
+        },
+        {
+          "lang": "ja",
+          "name": "アフマド・カーン・サマンガニ",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nl",
+          "name": "Ahmad Khan Samangani",
+          "note": "multilingual"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=29&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "a89035b5-7aaf-450f-8afa-44b609bd42b1",
+      "identifiers": [
+        {
+          "identifier": "1733",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/b-alam-khan-azadi.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/b-alam-khan-azadi.jpg"
+        }
+      ],
+      "name": "alam khan azadi , balkh",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=39&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "ffe31259-db88-4c85-8a6b-775e570cd00d",
+      "identifiers": [
+        {
+          "identifier": "1702",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/Copy%20of%20amanollah-peyman.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/Copy%20of%20amanollah-peyman.jpg"
+        }
+      ],
+      "name": "amanullah payman , badakhshan",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=43&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "0a8e016b-d6e7-4efa-88fe-72361e34d70f",
+      "identifiers": [
+        {
+          "identifier": "1721",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "ashiqullah , baghlan",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=41&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "31d2d308-04b1-4332-aadd-2bdca0d785e2",
+      "identifiers": [
+        {
+          "identifier": "1729",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-asadullah-sharifi-jpg.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-asadullah-sharifi-jpg.jpg"
+        }
+      ],
+      "name": "assadullah sharifi , balkh",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=40&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "bb1aabfa-923b-422e-be3d-945b921f9332",
+      "identifiers": [
+        {
+          "identifier": "1730",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-breshna-rabi.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-breshna-rabi.JPG"
+        }
+      ],
+      "name": "breshna rabei , balkh",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=40&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "6b615f57-5337-4cf0-8ca3-231319d74cd7",
+      "identifiers": [
+        {
+          "identifier": "1776",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/fahimehsadat-m.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/fahimehsadat-m.jpg"
+        }
+      ],
+      "name": "fahima sadat , jawzjan",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=33&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "3ad2dff4-98e9-426b-837b-ce6f1babfdd6",
+      "identifiers": [
+        {
+          "identifier": "1709",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/zolmay_fazl_azim_mojaddadi_badakhshan(m).jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/zolmay_fazl_azim_mojaddadi_badakhshan(m).jpg"
+        }
+      ],
+      "name": "fazil azim zalmay mojadidi,badakhshan",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=42&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "77a4a90b-26d9-428c-8414-152dd3444c94",
+      "identifiers": [
+        {
+          "identifier": "1746",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-kolbadshah-majidi.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-kolbadshah-majidi.jpg"
+        }
+      ],
+      "name": "ghul padshah majidi , paktia",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=37&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "256dc7c2-dc90-4f8b-bffe-1d0d2f634084",
+      "identifiers": [
+        {
+          "identifier": "1765",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-habibah-danesh.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-habibah-danesh.jpg"
+        }
+      ],
+      "name": "habiba danish , takhar",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=35&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "0067809f-2146-46ee-9249-a0d1be5ecb4f",
+      "identifiers": [
+        {
+          "identifier": "1771",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-abduljabbar.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-abduljabbar.jpg"
+        }
+      ],
+      "name": "haji abdul jabar , Takhar",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=34&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "640ac64a-fb04-4d3d-94e4-b5e3192bf075",
+      "identifiers": [
+        {
+          "identifier": "1743",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "haji mohammad almas zahid , parwan",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=37&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "0675c4af-4bd3-4662-b303-22a9b3ba127e",
+      "identifiers": [
+        {
+          "identifier": "1779",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/kamal-naser-osoli-m.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/kamal-naser-osoli-m.jpg"
+        }
+      ],
+      "name": "kamal nasir osli , khost",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=32&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "c3edba2c-1dec-4572-81ec-d09ba7e42691",
+      "identifiers": [
+        {
+          "identifier": "1791",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-khayrmohammad-aymagh.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-khayrmohammad-aymagh.jpg"
+        }
+      ],
+      "name": "khair mohammad aymaq , sarpol",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=30&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "12dde0af-2c82-49b2-8797-834b6a42a73d",
+      "identifiers": [
+        {
+          "identifier": "1759",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "mahmood khan solaimankhel , paktika",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=36&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "4371fda4-0c09-47a1-b8c4-91d73bd1f049",
+      "identifiers": [
+        {
+          "identifier": "1797",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-abdullah-mohammadi.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-abdullah-mohammadi.jpg"
+        }
+      ],
+      "name": "makhdom abdallulah mohammadi , samanghan",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=29&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "6b7f0a5e-97f8-4ba5-955a-208454a9c308",
+      "identifiers": [
+        {
+          "identifier": "1770",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/maryam-kofi-m.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/maryam-kofi-m.jpg"
+        }
+      ],
+      "name": "maryam kofi , Takhar",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=34&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "e5e7ecc2-f55f-4ab7-af49-ae50fbca0c22",
+      "identifiers": [
+        {
+          "identifier": "1732",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/molavi-abdulrahman.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/molavi-abdulrahman.jpg"
+        }
+      ],
+      "name": "mawlavi abdulrahman rahmani , balkh",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=39&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "15da8b01-c7c9-4ebd-b0c3-b91ba318d755",
+      "identifiers": [
+        {
+          "identifier": "1782",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/merbatkhan-mankal-m.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/merbatkhan-mankal-m.jpg"
+        }
+      ],
+      "name": "merbat khan manghal , khost",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=32&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "7d12c776-9a36-4593-92fa-e5738bd680fb",
+      "identifiers": [
+        {
+          "identifier": "1701",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-mohammad-akbari.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-mohammad-akbari.jpg"
+        }
+      ],
+      "name": "mohammad akbari , bamyan",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=43&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "8de4f06f-571b-45e6-bb4b-216a5ea89c32",
+      "identifiers": [
+        {
+          "identifier": "1786",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-mohammadnoor-akbari.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-mohammadnoor-akbari.jpg"
+        }
+      ],
+      "name": "mohammad noor akbari",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=31&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "ec2aa869-56cb-4a6f-9e4c-a6e84352e99c",
+      "identifiers": [
+        {
+          "identifier": "1711",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/mohammad-zakarya-soda-m.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/mohammad-zakarya-soda-m.JPG"
+        }
+      ],
+      "name": "mohammad zakarya saoda,badakhshan",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=42&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "6aa94db6-1ac2-4308-99e7-c3261de0ed09",
+      "identifiers": [
+        {
+          "identifier": "1788",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "mohammadullah tokhi , zabul",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=31&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "5407ae80-73a4-4b0f-bdb1-b56cefc36603",
+      "identifiers": [
+        {
+          "identifier": "1761",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "nadir khan katwazi , paktika",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=35&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "cc8b1a2f-c04a-48de-a7a9-8c4ebbaa8eee",
+      "identifiers": [
+        {
+          "identifier": "1727",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-najya-aymagh.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-najya-aymagh.jpg"
+        }
+      ],
+      "name": "najia aymaq , baghlan",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=40&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "ab2c99f5-01e8-4932-aded-f1045046b335",
+      "identifiers": [
+        {
+          "identifier": "1760",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/najya-babakarkhel-m.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/najya-babakarkhel-m.jpg"
+        }
+      ],
+      "name": "najia babakar kheel , pakteka",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=36&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "b595f316-0c2d-4357-aa01-e557e728d1f6",
+      "identifiers": [
+        {
+          "identifier": "1722",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-obidullah-ramin.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-obidullah-ramin.jpg"
+        }
+      ],
+      "name": "obaidullah ramin , baghlan",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=41&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "de60878d-37af-40b7-88bf-b7c990122c1f",
+      "identifiers": [
+        {
+          "identifier": "1693",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m,%d8%b9%d8%a8%db%8c%d8%af%d8%a7%d9%84%d9%84%d9%87%20%d8%a8%d8%a7%d8%b1%da%a9%d8%b2%db%8c.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m,%d8%b9%d8%a8%db%8c%d8%af%d8%a7%d9%84%d9%84%d9%87%20%d8%a8%d8%a7%d8%b1%da%a9%d8%b2%db%8c.JPG"
+        }
+      ],
+      "name": "obidullah barekzai orozghan",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=45&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "78130296-fde0-455e-9cef-0e7aa78e29bc",
+      "identifiers": [
+        {
+          "identifier": "1697",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-abdorrahim.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-abdorrahim.jpg"
+        }
+      ],
+      "name": "qazi abdul rahim badgis",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=44&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "1bab8365-515a-44f1-ad76-92588998b66d",
+      "identifiers": [
+        {
+          "identifier": "1766",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/raes-abdolbaghi-m.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/raes-abdolbaghi-m.jpg"
+        }
+      ],
+      "name": "raees abdul baqi malikzada , Takhar",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=34&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "e3dde75d-f0f8-44d5-882e-2f483a4673f4",
+      "identifiers": [
+        {
+          "identifier": "1762",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/rahela-salim-m.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/rahela-salim-m.jpg"
+        }
+      ],
+      "name": "rahela salim , panjsher",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=35&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "ca713ef4-ee58-466b-8daf-cab34bb02176",
+      "identifiers": [
+        {
+          "identifier": "1692",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-reyhaneh-azad.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-reyhaneh-azad.jpg"
+        }
+      ],
+      "name": "raihana azad orozghan",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=45&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "58305464-889f-4524-a416-4166b5374dd1",
+      "identifiers": [
+        {
+          "identifier": "1695",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/%d8%b5%d9%81%db%8c%d9%87%20%d8%a7%db%8c%d9%85%d8%a7%d9%82.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/%d8%b5%d9%81%db%8c%d9%87%20%d8%a7%db%8c%d9%85%d8%a7%d9%82.JPG"
+        }
+      ],
+      "name": "safia aymaq badgis",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=44&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "8d860110-b4f3-40f9-aee7-bee7f0c19145",
+      "identifiers": [
+        {
+          "identifier": "1706",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-safiullah-moslem.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-safiullah-moslem.jpg"
+        }
+      ],
+      "name": "safiullah moslim badakhshan",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=43&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "cd5d494c-25a7-4bdd-b91b-faa52a675930",
+      "identifiers": [
+        {
+          "identifier": "1699",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-safora-elkhani.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-safora-elkhani.jpg"
+        }
+      ],
+      "name": "safora elkhni bamyan",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=44&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "given_name": "Sahira",
+      "id": "bdd3bb05-a3c4-42d7-8a90-2ad1040ba942",
+      "identifiers": [
+        {
+          "identifier": "1778",
+          "scheme": "everypolitician_legacy"
+        },
+        {
+          "identifier": "Q7399652",
+          "scheme": "wikidata"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/sahera-sharif-m.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/sahera-sharif-m.jpg"
+        }
+      ],
+      "links": [
+        {
+          "note": "Wikipedia (en)",
+          "url": "https://en.wikipedia.org/wiki/Sahira_Sharif"
+        }
+      ],
+      "name": "sahira sharif , khost",
+      "other_names": [
+        {
+          "name": "Sahira Sharif",
+          "note": "alternate"
+        },
+        {
+          "lang": "de",
+          "name": "Sahira Sharif",
+          "note": "multilingual"
+        },
+        {
+          "lang": "en",
+          "name": "Sahira Sharif",
+          "note": "multilingual"
+        },
+        {
+          "lang": "es",
+          "name": "Sahira Sharif",
+          "note": "multilingual"
+        },
+        {
+          "lang": "fr",
+          "name": "Sahira Sharif",
+          "note": "multilingual"
+        },
+        {
+          "lang": "hu",
+          "name": "Sahira Sharif",
+          "note": "multilingual"
+        },
+        {
+          "lang": "it",
+          "name": "Sahira Sharif",
+          "note": "multilingual"
+        },
+        {
+          "lang": "nl",
+          "name": "Sahira Sharif",
+          "note": "multilingual"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=32&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "0d9a28b7-a6f2-410f-a60f-7530874d14dc",
+      "identifiers": [
+        {
+          "identifier": "1731",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-sefora-nyazi.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-sefora-nyazi.jpg"
+        }
+      ],
+      "name": "saifora niazi , balkh",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=39&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "9abe4b2b-1b4a-4403-ba5e-259dd6d6cb71",
+      "identifiers": [
+        {
+          "identifier": "1831",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/sameallah-samim-m.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/sameallah-samim-m.jpg"
+        }
+      ],
+      "name": "samiullah samim",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=23&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "0fc1743c-6aee-45e4-9489-7c64a5c6f6ed",
+      "identifiers": [
+        {
+          "identifier": "1769",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "sayed ekramuden masomi , Takhar",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=34&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "male",
+      "id": "7ef674e5-be8c-447f-ae28-35e6f8957ca5",
+      "identifiers": [
+        {
+          "identifier": "1719",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/m-syed-mansor-nader.jpg",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/m-syed-mansor-nader.jpg"
+        }
+      ],
+      "name": "sayed mansoor nadery , baghlan",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=41&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "161ed6c3-1fd2-4aed-b14b-8deb8620e195",
+      "identifiers": [
+        {
+          "identifier": "1816",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "sayed nadir shah bahr ghor",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=26&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "330bb0f1-f405-486a-b9c6-79f19206b359",
+      "identifiers": [
+        {
+          "identifier": "1694",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/syedmosa-jenab.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/syedmosa-jenab.JPG"
+        }
+      ],
+      "name": "sayyed mohmmad mosa jenab saheb badgis",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=45&Cat=37"
+        }
+      ]
+    },
+    {
+      "gender": "female",
+      "id": "ef199185-fce5-4e8c-9497-a4c4850a9270",
+      "identifiers": [
+        {
+          "identifier": "1817",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/sema-joyandh-m.JPG",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/sema-joyandh-m.JPG"
+        }
+      ],
+      "name": "sema joyenda",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=26&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "30fd9092-b6eb-4d04-9984-4ee144e1b037",
+      "identifiers": [
+        {
+          "identifier": "1705",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "shah abdul ahad afzali , badakhshan",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=43&Cat=37"
+        }
+      ]
+    },
+    {
+      "id": "df1095cf-6640-4e65-ac44-ac337560eef7",
+      "identifiers": [
+        {
+          "identifier": "1803",
+          "scheme": "everypolitician_legacy"
+        }
+      ],
+      "image": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png",
+      "images": [
+        {
+          "url": "http://www.wolesi.website/Media/Images/mine/no-pic-vak.png"
+        }
+      ],
+      "name": "shah jahan , ghazni",
+      "sources": [
+        {
+          "url": "http://wolesi.website/pve/document.aspx?Page=28&Cat=37"
+        }
+      ]
+    }
+  ],
+  "organizations": [
+    {
+      "classification": "legislature",
+      "id": "legislature",
+      "identifiers": [
+        {
+          "identifier": "Q2108181",
+          "scheme": "wikidata"
+        }
+      ],
+      "name": "Wolesi Jirga",
+      "seats": 249
+    },
+    {
+      "classification": "party",
+      "id": "party/unknown",
+      "name": "unknown"
+    }
+  ],
+  "meta": {
+    "sources": [
+      "http://wolesi.website",
+      "http://wikidata.org/"
+    ]
+  },
+  "memberships": [
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "0067809f-2146-46ee-9249-a0d1be5ecb4f",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "0282b3d6-c7a4-47ab-bcbe-cdc3e2b26437",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "030b25fb-05d6-4acb-809d-c122db9e0f94",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "058fa220-a574-4a16-abdd-758c8f42c676",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "0675c4af-4bd3-4662-b303-22a9b3ba127e",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "07866adc-1d1b-40e7-bb81-0499af2676f3",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "07ea72b7-c538-4f33-af71-9ccc2dbd7a9b",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "08501fa8-ab5d-48a9-b669-8123e6235748",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "0968d7bf-61ee-4deb-bb56-242feed3415f",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "0a8e016b-d6e7-4efa-88fe-72361e34d70f",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "0d879896-56d0-4075-989c-6899273ee553",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "0d9a28b7-a6f2-410f-a60f-7530874d14dc",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "0de56fbf-00bc-4f51-9e66-e266f53592b1",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "0e2a8144-d144-4909-a6da-b689a555ccf6",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "0fc1743c-6aee-45e4-9489-7c64a5c6f6ed",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "10a1ede0-f283-45e7-b10a-0a34e5bb585b",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "10b86908-461d-4c18-85fb-4e808d78bd4f",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "10e4fc18-18b6-4397-a4db-0ce100dcca02",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "1147e94b-4c9d-4253-b1d5-ba90f9ecbe34",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "12989b49-daa0-4629-8737-a50afefb62dc",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "12dde0af-2c82-49b2-8797-834b6a42a73d",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "15da8b01-c7c9-4ebd-b0c3-b91ba318d755",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "161ed6c3-1fd2-4aed-b14b-8deb8620e195",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "1783ad09-8640-44a3-adf6-da8d9c434be2",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "17c7ea8c-e2f2-4104-b847-2ca56a7b4b0d",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "19915231-0be5-42a6-95f8-d2e8504544be",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "1a3ecc90-6a19-4404-9717-1cc15579688c",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "1bab8365-515a-44f1-ad76-92588998b66d",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "1e890b59-bd79-4f5b-8afa-066af7bc8d45",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "1f75c581-0a97-49c0-9bd4-4c9ea1a62e27",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "21fbc9db-9a87-47df-bfc7-2fe4ff318b57",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "22c10bac-defd-4ce4-911d-570b43f2c53e",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "232322d9-e229-4207-a48c-4c1ad43ec948",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "23a52365-0260-4929-a1cc-ab0056f3d201",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "245c5c12-86f7-4b59-9eb3-34b9211ea0d3",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "24b0e8dd-2b3a-445f-9271-56028d627a17",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "2545d4a2-eacf-4358-8fe9-d3c4f31beeee",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "256dc7c2-dc90-4f8b-bffe-1d0d2f634084",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "25d7c071-785c-4dd0-95c3-1773a6fc619c",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "29403f9b-587a-401d-b0ea-6b20ad64b401",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "2dc3c971-fa70-4264-b674-c8d0ce818e4a",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "2f91d2af-8a7e-48a8-bd7e-8fc7870e5ef0",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "30fd9092-b6eb-4d04-9984-4ee144e1b037",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "31d2d308-04b1-4332-aadd-2bdca0d785e2",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "3300b50f-ab92-4f8f-b62d-1e9cb4ee42fa",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "330bb0f1-f405-486a-b9c6-79f19206b359",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "37ae1de9-8eeb-4459-91f7-90212182fd52",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "38ef2d81-58d2-4389-b185-9aa1de10f110",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "38fd97e3-747f-45e6-aa59-9eb89336dbd2",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "3933aac1-3692-4dcb-bb72-9161a48bc523",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "39b3e3e2-4f1c-4913-8e23-6fbdec0c97c8",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "3a9ca8da-e0e4-44ee-80ac-5af5acb8b44d",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "3ad2dff4-98e9-426b-837b-ce6f1babfdd6",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "3e2bddb2-badd-43d1-9d73-2ec8734a081a",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "3f2072f3-3dd3-4397-9132-97a1a6f0ed5f",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "3f6253b7-9be7-42e3-8651-f41a4446b9c7",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "3fbc4851-d13d-4dd9-a990-df598889cfcb",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "408df264-df61-428f-b30f-b6bd5cf0466e",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "41dbcf99-41d7-4225-a189-f3f043011ef0",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "42c3c39d-57b6-40f5-8647-9ee1bd6023ae",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "434ecc44-4dd7-4d44-b383-8b8d99b57ddb",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "4371fda4-0c09-47a1-b8c4-91d73bd1f049",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "437ef71d-0e0d-4957-8210-8cf358d75425",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "4bc6feed-ba3a-421b-8dd2-6200eff6077b",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "4c4f63c3-cb71-4f0a-b8e9-5781187117c1",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "4dfe5e32-ab61-40b0-98e3-35bb17289997",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "4e0381ea-6b32-47e3-b0b0-7beb81abc057",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "4e74aa84-39df-4a3e-a210-1e205d0d1107",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "50116499-b27a-4d82-87f1-7f927ce7f7b5",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "522dff9d-d21d-41b9-a7d5-c2321c819b11",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "52457972-cd7c-4871-af30-ed21d050d5cb",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "5302e469-1084-4bc9-be4a-0ebb786c15d6",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "54018af0-242e-424d-ba78-693ac35765eb",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "5407ae80-73a4-4b0f-bdb1-b56cefc36603",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "55e382d8-baf1-44f0-9fd3-9529e6fb65a6",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "5784b757-9bfe-472c-9633-67d088b73cab",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "57ca8a7f-1913-46ca-85ee-cfd8a9c4a5c1",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "58305464-889f-4524-a416-4166b5374dd1",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "58b196da-40ce-437f-b1e2-73e72b6c0dd2",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "59b044bb-a3b9-40a9-a55a-d6e754d249cd",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "5a4d7ea1-566b-4f11-9217-252fd08d8484",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "5da8be60-ffd2-4db5-be0a-634622c66033",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "5e855a80-23a7-448e-979a-4f168d7169ec",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "5f5ccec2-d983-45f3-a35e-1ea3eb8dde89",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "6152bb79-ca17-4ec0-babc-84395a81de81",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "62408e41-82e5-4a51-89f5-9f6893166a15",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "626e291b-0801-4b8e-944c-565011cc8587",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "62bc5789-0bab-4a52-9ede-a4a4da6d0951",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "640ac64a-fb04-4d3d-94e4-b5e3192bf075",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "64c68784-2187-48f1-a1ae-258e19deb4de",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "671dd348-c48b-4ce0-b0aa-9f7df4b8da4e",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "6895eaa6-46b0-4a06-aec1-db8ddf8aef7c",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "69e8a01d-18ad-4fac-8742-b030e1d161f4",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "6a21e463-1c32-44cd-b415-26bb81fa3562",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "6a45a6e9-82dd-404f-8765-a60e75dd7812",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "6aa94db6-1ac2-4308-99e7-c3261de0ed09",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "6b01317d-919c-40c4-ba94-650d0de02bb7",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "6b615f57-5337-4cf0-8ca3-231319d74cd7",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "6b7f0a5e-97f8-4ba5-955a-208454a9c308",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "6c0e9326-09cf-49c2-aded-0f7a3f7103b1",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "6dec5eb4-db61-4f95-97d7-8710a50b5e8d",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "6e460578-1537-4842-b5ef-7c50607d7cda",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "6f511a87-7026-4a17-9c30-508aeadd1246",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "7035eef7-76e4-47e7-85e3-2da0df458487",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "7092d108-ac19-49a7-b38a-2c9e00d5dac6",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "720abc9a-c17e-4b96-9c5a-afddf79df213",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "72df1691-fbfa-409d-b7b3-d5ab49aaeefd",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "738f80ee-0757-4334-8bc6-c047714bf931",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "754a34ef-5f3f-43ee-93cc-6ca32dd8929e",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "776a6704-9c91-43b6-95c3-7b638b15b241",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "77a4a90b-26d9-428c-8414-152dd3444c94",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "78130296-fde0-455e-9cef-0e7aa78e29bc",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "7d12c776-9a36-4593-92fa-e5738bd680fb",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "7d9d69bd-fb66-4904-8e1e-5ded70226399",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "7e0c4486-4bd5-46bd-a289-be125641e078",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "7ef674e5-be8c-447f-ae28-35e6f8957ca5",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "7fc34d52-fc1b-4db0-b414-74e6da5c3f8d",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "818e7c52-16ca-4859-a395-1399a417b1c1",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "82a9881d-751c-4d8c-8d16-990db11032e2",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "84672f50-6a66-4244-9005-6d99bca88922",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "872197b7-0a66-4d89-8fbe-a093fac8fcf6",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "87f411ee-cd5c-4bab-8343-8f7cb7e3eff3",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "88a69adb-5771-4afd-b3aa-e4cc073cd29b",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "88e92b13-8c22-44da-b8b3-98895f45e71f",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "8d860110-b4f3-40f9-aee7-bee7f0c19145",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "8d962c13-34f0-4c59-ad57-0a77425e6ffd",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "8de38d62-6768-423e-a677-3248709cebc7",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "8de4f06f-571b-45e6-bb4b-216a5ea89c32",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "8e614ab7-4f96-4e06-8cf6-d2b238c2fa43",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "8ef77f06-5cea-4af1-8726-50ba2f69ca82",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "908e7e24-e95b-484b-a589-c8beca8a55d3",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "90ef74f9-c3c8-4483-a6a6-0d76dd849b8b",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "9101c9ce-9b7f-4669-8b59-4b8a97890091",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "911b42c0-d41d-4fbb-9e6d-5d0ad65abdae",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "92308bfc-a99c-4ec8-b96a-75952429890d",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "9246439e-3b92-4806-8c30-278749c666b5",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "95b36564-77c9-498f-a0d6-eec18d5f43c9",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "98866b8d-5d97-4a0d-9dfe-08e54d0db3a1",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "9abe4b2b-1b4a-4403-ba5e-259dd6d6cb71",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "9b1a5059-7d85-4b40-bb2c-2d1c9ec3bb68",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "9bbe49c2-ce72-4d6e-9dbe-94b7034bf5ee",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "9c8ae26d-8d94-4068-b17a-638ef521b9bc",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "a2d2c288-499a-4695-964c-5416cb150625",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "a3015c20-f9bb-413e-823d-40488d1e9e17",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "a4c9d18f-3f41-4ef2-8c62-38483fb9dbd9",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "a4fce5e4-e715-425a-acc7-16e472acb2da",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "a5a48fa8-8c6e-4f56-b4bc-75aa4611d80c",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "a75f33fc-6ff6-4cc1-ba4c-e3ae307e0606",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "a825541a-3658-4aed-84e6-81335901008d",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "a88e5420-e689-456e-b1c3-aac6194a8d71",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "a89035b5-7aaf-450f-8afa-44b609bd42b1",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "aa6aa7ad-b8c5-40b8-a181-1cdef03c0440",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "aac6f415-446d-4070-80d9-195d4f7b77ac",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "ab2c99f5-01e8-4932-aded-f1045046b335",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "ac166e5c-d4cc-4953-a533-c8deec236547",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "ac227ae5-8bfd-4fb7-91eb-12f0e8f634ba",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "ace89f3f-a9ba-4aac-9c6b-2028ca0ccdcf",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "ae377616-3a80-4006-a048-140bd37b364f",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "af2a7eba-b0a4-41e4-9839-e59c7046dd50",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "b190b792-1e21-4b3b-ac05-bc0321a239d6",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "b1a2cf91-2d42-4995-8e31-4ab589630246",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "b1e2afa5-7076-4e6b-b37a-154291b86ff6",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "b34baf37-b604-47b3-8467-55c334ab588c",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "b38cf287-8d58-4f21-ba74-43eace21591a",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "b4a823f1-4912-4704-8228-018e6237697f",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "b595f316-0c2d-4357-aa01-e557e728d1f6",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "b5a68c51-d257-4875-9d11-22fc259ba9a7",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "b6e17eb7-75a2-495a-8a38-f21442a66eee",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "b712d0d7-0ef2-4bfd-8277-e87740e3cf6b",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "b79f4c80-1d4d-4a96-aeda-47260efbb0b9",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "bb1aabfa-923b-422e-be3d-945b921f9332",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "bd587a92-a390-46d5-8d82-65b9e2d08418",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "bdd3bb05-a3c4-42d7-8a90-2ad1040ba942",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "bf76811e-0a03-4769-ba39-f4a58257201d",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "bf9341bf-d027-46f4-b4e2-51d48ec374a2",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "bfdb3455-0930-4a36-80df-fa8c72a89781",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "c287ae2e-78cd-4d40-9a5c-b80b828220ba",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "c3edba2c-1dec-4572-81ec-d09ba7e42691",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "c5a0f13a-44f4-429d-9b63-8c13d1c5f453",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "c5de9747-ede6-4e94-89c8-ce3946cc4e83",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "c7598c20-59b3-4615-af01-4dd9d68b177c",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "ca29212d-6306-4300-90e1-693248651ff4",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "ca713ef4-ee58-466b-8daf-cab34bb02176",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "cad39770-2a15-4547-8e3e-ca882957da63",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "cb32a534-b95c-4107-a57e-1fbed4f6b8ff",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "cbfa81df-52b8-4b8d-a0c4-f2e1ed695ab8",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "cc000dac-20a0-415f-b673-37b67dc5ef72",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "cc8b1a2f-c04a-48de-a7a9-8c4ebbaa8eee",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "cd5d494c-25a7-4bdd-b91b-faa52a675930",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "cd736630-a4da-463f-abbf-120b868bcecd",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "ce23f144-8554-4c68-aa51-ffc02843c2d9",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "ce5b2421-e8f2-4000-9e43-ab2f2082b7a5",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "d185c4dd-9894-4179-95c2-1ea03be2914c",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "d1d013ff-c8d4-4acd-94fd-0acc9fa04593",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "d339406b-cd11-4ed6-9157-5e89dcf7a984",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "d4e3003a-72c4-46c4-9457-3757617823af",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "d7118bdf-99fb-4bd1-9260-24bceaca8963",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "d761b537-9b3f-4574-9a1b-275e35256f6c",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "d8b321cb-99c0-4186-a8e3-1f352d073247",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "d8deefe3-e8c1-4037-9c3c-5600eea57823",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "d9d44204-ddea-4fb2-ab77-63675eca3921",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "da5e3e8a-8074-4f06-b620-c1720e488c8b",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "da6a02ce-8208-41e1-bef0-ef05186b259e",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "db382198-3b51-4375-90e5-579bef8549a3",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "dd85729c-4f31-4794-b568-747f14493135",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "de60878d-37af-40b7-88bf-b7c990122c1f",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "df0701e5-1e2c-4853-8cbb-8cce0fc17120",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "df1095cf-6640-4e65-ac44-ac337560eef7",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "e04260a2-f8c6-456f-96fa-d0d45cb7c56d",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "e15eb84e-03df-46c3-a595-8ab3fa3bd201",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "e1e2f2af-6a92-4f4a-b6cd-0bd47ee08a69",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "e2a472fe-003c-4230-a121-6708db9f51fb",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "e3dde75d-f0f8-44d5-882e-2f483a4673f4",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "e43e231b-2d8b-48f6-9d48-d00929f04c46",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "e44ada34-e146-495e-9f49-9e77e0a495f8",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "e46fed8a-599b-4c72-b0b1-5f9bcbad5cd7",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "e5e3a421-86d7-42ea-832a-64c33073a2bd",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "e5e7ecc2-f55f-4ab7-af49-ae50fbca0c22",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "e7914d81-cfd7-49fd-87ee-0f05b8e553ab",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "e9a790e6-0e5c-4b2c-8f17-66668d49a2e8",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "eba294a0-2c03-4528-8ae3-25920b0061c0",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "ec0d7dc6-e87a-48b8-8f5b-505d32d7e18c",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "ec2aa869-56cb-4a6f-9e4c-a6e84352e99c",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "ef199185-fce5-4e8c-9497-a4c4850a9270",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "f3f89ef2-00c8-4d5a-bbf7-7aa4653b00a7",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "fb3690ea-3a66-4727-94ff-d02d260637b2",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "ffe31259-db88-4c85-8a6b-775e570cd00d",
+      "role": "member"
+    },
+    {
+      "legislative_period_id": "term/2010",
+      "on_behalf_of_id": "party/unknown",
+      "organization_id": "legislature",
+      "person_id": "ffe823f6-c833-494a-a33c-ea1a2def2359",
+      "role": "member"
+    }
+  ],
+  "events": [
+    {
+      "classification": "general election",
+      "end_date": "1961",
+      "id": "Q24045328",
+      "name": "Afghan parliamentary election, 1961",
+      "start_date": "1961"
+    },
+    {
+      "classification": "general election",
+      "end_date": "1965-09-07",
+      "id": "Q4689129",
+      "name": "Afghan parliamentary election, 1965",
+      "start_date": "1965-09-07"
+    },
+    {
+      "classification": "general election",
+      "end_date": "1969",
+      "id": "Q4689130",
+      "name": "Afghan parliamentary election, 1969",
+      "start_date": "1969"
+    },
+    {
+      "classification": "general election",
+      "end_date": "1988",
+      "id": "Q4689131",
+      "name": "Afghan parliamentary election, 1988",
+      "start_date": "1988"
+    },
+    {
+      "classification": "general election",
+      "end_date": "2005-09-18",
+      "id": "Q1193119",
+      "name": "Afghan parliamentary election, 2005",
+      "start_date": "2005-09-18"
+    },
+    {
+      "classification": "general election",
+      "end_date": "2010-09-18",
+      "id": "Q1754798",
+      "name": "Afghan parliamentary election, 2010",
+      "start_date": "2010-09-18"
+    },
+    {
+      "classification": "legislative period",
+      "end_date": "2015-06-22",
+      "id": "term/2010",
+      "name": "2010–2015",
+      "organization_id": "legislature",
+      "start_date": "2011-01-26"
+    },
+    {
+      "classification": "general election",
+      "end_date": "2016-10-15",
+      "id": "Q20003457",
+      "name": "Afghan parliamentary election, 2016",
+      "start_date": "2016-10-15"
+    }
+  ],
+  "areas": [
+
+  ]
+}


### PR DESCRIPTION
Methods return group and area for a given member.

TermTable currently uses `#org_lookup` and `#area_lookup` to get the area and group for a given member. The intention is for the class to use the extension methods instead.