### PR TITLE
 Update to the new signature of term_table_url

### DIFF
--- a/views/house.erb
+++ b/views/house.erb
@@ -19,7 +19,7 @@
       <ul class="grid-list grid-list--vertically-center" id="terms-<%= @page.house.slug.downcase %>">
         <% @page.legislative_periods.each do |term| %>
         <li>
-          <a class="avatar-unit" href="<%= term_table_url(@page.country, @page.house, term) %>">
+          <a class="avatar-unit" href="<%= term_table_url(term) %>">
             <span class="avatar"><i class="fa fa-university"></i></span>
             <h3><%= term.name %></h3>
             <% if term.start_date || term.end_date %>


### PR DESCRIPTION
After rebasing master onto this branch and running the tests, some were failing due to the recent simplification of the signature of the term_table_url method. This commit updates the template to use the new signature.