### PR TITLE
Link to house in the headings of house/download.html

### DIFF
--- a/t/web/basic.rb
+++ b/t/web/basic.rb
@@ -25,6 +25,14 @@ describe 'Viewer' do
     end
   end
 
+  describe 'when viewing a house/download page' do
+    before { get '/finland/eduskunta/download.html' }
+
+    it 'should link back to the house' do
+      subject.css('.site-header__logo h3 a/@href').text.must_equal '/finland/eduskunta/'
+    end
+  end
+
   describe 'unknown house of known country' do
     before { get '/finland/upper' }
 

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -64,7 +64,7 @@
                         <a href="/"><span class="header-logo">EveryPolitician</span></a>
                       <% end %>
                     </h2>
-                    <% if @house %><h3><%= @house.name %></h3><% end %>
+                    <% if @house %><h3><a href="/<%= @country.slug.downcase %>/<%= @house.slug.downcase %>/"><%= @house.name %></h3><% end %>
                 </div>
                 <div class="site-header__navigation site-header__navigation--primary">
                     <nav role="navigation">

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -1,5 +1,5 @@
-<% @country    = @page.country if (@page and @page.respond_to? :country) %>
-<% @house      = @page.house   if (@page and @page.respond_to? :house) %>
+<% @country = @page.country if (@page and @page.respond_to? :country) %>
+<% @house   = @page.house   if (@page and @page.respond_to? :house) %>
 
 <!DOCTYPE html>
 <html class="no-js">


### PR DESCRIPTION
This PR addresses the point "_Ensure house/download links to House page_" in the mamma-issue #15256.

* It adds a test against the main layout to document the existence of a link to the house in house/download pages
* It adds a link to the house in the header of the main layout file.

It also corrects misalignment of the top variables in the layout template at the top
