### PR TITLE
Legislature tabs

### DIFF
--- a/t/web/tab_component.rb
+++ b/t/web/tab_component.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require 'test_helper'
+require_relative '../../app'
+
+describe 'Tab component in term table' do
+  subject { Nokogiri::HTML(last_response.body) }
+
+  before do
+    stub_everypolitician_data_request('6139efe/data/Australia/Representatives/ep-popolo-v1.0.json')
+    get '/australia/representatives/term-table/44.html'
+  end
+
+  it 'should have as many tabs as houses' do
+    subject.css('.house-tab').count.must_equal 2
+  end
+
+  describe 'active tab' do
+    it 'should be the House of Representatives' do
+      subject.css('.house-tab--active').text.strip.must_equal 'House of Representatives'
+    end
+  end
+
+  describe 'tab links' do
+    let(:tabs) { subject.css('.house-tab/@href') }
+
+    it 'links to first term in House of Representatives' do
+      tabs.first.text.must_equal '/australia/representatives/term-table/44.html'
+    end
+
+    it 'links to first term in Senate' do
+      tabs.last.text.must_equal '/australia/senate/term-table/44.html'
+    end
+  end
+end

--- a/views/sass/_components.scss
+++ b/views/sass/_components.scss
@@ -498,12 +498,43 @@ p.lead {
 
 // Little round social icons for membership tables
 .person-link {
-  display: inline-block;
-  width: 24px;
-  padding-top: 24px;
-  height: 0;
-  overflow: hidden;
-  vertical-align: middle;
-  border-radius: 100%;
-  margin-right: 0.3em;
+    display: inline-block;
+    width: 24px;
+    padding-top: 24px;
+    height: 0;
+    overflow: hidden;
+    vertical-align: middle;
+    border-radius: 100%;
+    margin-right: 0.3em;
+}
+
+.house-tabs {
+    @extend .unstyled-list;
+    @extend .inline-list;
+    padding-top: 1em;
+
+    @media (min-width: $medium_screen) and (min-height: 600px) {
+        padding-top: 1.5em;
+    }
+}
+
+.house-tab {
+    display: inline-block;
+    padding: 0.5em 1em;
+    border-radius: 5px 5px 0 0;
+    background-color: mix($colour_green, #fff, 25%);
+    background: linear-gradient(180deg, mix($colour_green, #fff, 20%), 50%, mix($colour_green, #fff, 30%));
+    color: darken($colour_green, 10%) !important;
+
+    &:hover,
+    &:focus {
+        background-color: mix($colour_green, #fff, 15%);
+        background: linear-gradient(180deg, mix($colour_green, #fff, 10%), 50%, mix($colour_green, #fff, 20%));
+    }
+}
+
+.house-tab--active,
+.house-tab--active:hover,
+.house-tab--active:focus {
+background: #fff;
 }

--- a/views/sass/_components.scss
+++ b/views/sass/_components.scss
@@ -513,7 +513,18 @@ p.lead {
     @extend .inline-list;
     padding-top: 1em;
 
-    @media (min-width: $medium_screen) and (min-height: 600px) {
+    // Make the tabs scroll horizontally on small screens.
+    // TODO: Make this not suck when the currently selected tab is
+    // hidden off to the far right of the line.
+    @media (max-width: $small_screen_max) {
+        text-align: left;
+        white-space: nowrap;
+        overflow: auto;
+        margin: 0 -1em;
+        padding: 1em 0.5em 0 0.5em;
+   }
+
+   @media (min-width: $medium_screen) and (min-height: 600px) {
         padding-top: 1.5em;
     }
 }
@@ -537,4 +548,8 @@ p.lead {
 .house-tab--active:hover,
 .house-tab--active:focus {
 background: #fff;
+}
+
+.source-credits a {
+    @extend .break-word;
 }

--- a/views/sass/_mixins.scss
+++ b/views/sass/_mixins.scss
@@ -121,3 +121,18 @@
         }
     }
 }
+
+.break-word {
+    // https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+
+    -ms-word-break: break-all;
+    word-break: break-all;
+    word-break: break-word;
+
+    -ms-hyphens: auto;
+    -moz-hyphens: auto;
+    -webkit-hyphens: auto;
+    hyphens: auto;
+}

--- a/views/sass/_typography.scss
+++ b/views/sass/_typography.scss
@@ -171,6 +171,10 @@ textarea {
     -webkit-appearance: none;
 }
 
+select {
+    max-width: 100%;
+}
+
 fieldset {
     padding: 0;
     border: 0;

--- a/views/sass/_variables.scss
+++ b/views/sass/_variables.scss
@@ -34,6 +34,7 @@ $high_dpi_screen: '-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi
 
 $large_screen_max: $giant_screen - (1em * (1px / $size_font-base));
 $medium_screen_max: $large_screen - (1em * (1px / $size_font-base));
+$small_screen_max: $medium_screen - (1em * (1px / $size_font-base));
 
 $animation-short: 0.2s ease-out;
 

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -1,3 +1,19 @@
+<div class="page-section page-section--green page-section--no-padding">
+    <div class="container text-center">
+        <ul class="house-tabs">
+          <% @page.country.legislatures.each do |house| %>
+            <li>
+                <a
+                  class="house-tab <% if @page.house == house %>house-tab--active<% end %>"
+                  href="<%= term_table_url(house.legislative_periods.first) %>">
+                    <%= house.name %>
+                </a>
+            </li>
+          <% end %>
+        </ul>
+    </div>
+</div>
+
 <div class="page-section" id="term">
     <div class="container text-center">
         <h1><span class="avatar"><i class="fa fa-university"></i></span> <%= @page.current_term.name %></h1>


### PR DESCRIPTION
This PR was superseeded by #15451 

## What does this do?

This PR rescues the work of @zarino adding a tab component in PR #13598

## Why was this needed?

After merging the house/download page, it was clear that either a reword of the bottom of that page was needed (#15259) or either to go for the tab component integration directly (#15240). The latter was chosen and so this PR integrates Zarino's work in #13598 to the term table page instead.

## Relevant Issue(s)

This is part of issue #15259 regarding the reword the house download page, which was part of issue #15240 to link between legislature download pages in the same country. It is also the last point in the first section of the workflow described in todo list #15256

## Implementation notes

I took the two first commits made by Zarino, added the changes from his fixup commit, and updated the variables used in the template to use the page object passed to the template. Then I added his two commits to this branch. Finally, I made my changes on top of those two commits.

Adds:
* A new tabbed component in the `term_table.erb` template and related styles.
* Styles for smaller screens.
* Tests to check that the tabs are displayed correctly and with the right information

## Screenshots
**Country with more than one legislature:**

![screen shot 2016-07-25 at 14 15 11](https://cloud.githubusercontent.com/assets/739624/17102580/35573708-5272-11e6-906e-4ba6b93cb55f.png)

![screen shot 2016-07-25 at 15 09 39](https://cloud.githubusercontent.com/assets/739624/17104220/d6b33c4e-5279-11e6-84b6-091e446264d6.png)


**Country with only one legislature:**

![screen shot 2016-07-25 at 15 08 09](https://cloud.githubusercontent.com/assets/739624/17104192/b59a1f14-5279-11e6-8b9f-48e3c37475c5.png)

![screen shot 2016-07-25 at 15 09 14](https://cloud.githubusercontent.com/assets/739624/17104209/c8c6c57e-5279-11e6-8546-8371ec4578cd.png)

## Notes to Reviewer

If the tab component is added to more pages, it's probably better to extract it to it's own erb partial.
But for now, since this is the first page where the component is integrated, I decided to leave it in the template.

Some candidates for tab component integration:
* /country/house/
* /country/house/download.html
* /country/house/wikidata ?
* ...?

![layouts](https://cloud.githubusercontent.com/assets/2157089/18202368/829ea0c4-7107-11e6-9eb2-fa9d1efad258.png)

## Notes to Merger

This PR should finish section 1 of #15256 :tada: :balloon: 

