### PR TITLE
Fix behaviour descriptions

### DIFF
--- a/t/everypolitician_extensions/membership_extension.rb
+++ b/t/everypolitician_extensions/membership_extension.rb
@@ -39,11 +39,11 @@ describe 'MembershipExtensions -- memberships with no known groups or area names
                       .first
   end
 
-  it 'should return nil if a membership has no group data' do
+  it 'should return nil if a membership has no area data' do
     subject.area.must_be_nil
   end
 
-  it 'should return "unkown" if membership’s area name is unknown' do
+  it 'should return "unkown" if membership’s group name is unknown' do
     subject.group.name.must_equal 'unknown'
   end
 end


### PR DESCRIPTION
Descriptions were named wrong. One was testing the area but described as testing the group and vice versa.