### PR TITLE
Link to other houses in the house/download page

### DIFF
--- a/lib/page/house_download.rb
+++ b/lib/page/house_download.rb
@@ -25,6 +25,14 @@ module Page
       index.index_url
     end
 
+    def more_houses?
+      country.legislatures.count > 1
+    end
+
+    def other_houses
+      country.legislatures.reject { |legislature| legislature.slug == house.slug }
+    end
+
     private
 
     attr_reader :index

--- a/t/page/house_download.rb
+++ b/t/page/house_download.rb
@@ -45,4 +45,14 @@ describe 'HouseDownload' do
       subject.download_url.must_include 'd8a4682f'
     end
   end
+
+  describe 'other houses' do
+    it 'knows that there is more than one house' do
+      subject.more_houses?.must_equal true
+    end
+
+    it 'knows of House of Representatives from Senate' do
+      subject.other_houses.first.name.must_equal 'House of Representatives'
+    end
+  end
 end

--- a/t/web/house_download.rb
+++ b/t/web/house_download.rb
@@ -50,11 +50,11 @@ describe 'house download template' do
 
   describe 'other houses' do
     it 'shows a link to the other legislature' do
-      subject.css('.page-section .button--quarternary').first.text.strip.must_include 'House of Representatives'
+      subject.css('.page-section--green .button--secondary').first.text.must_include 'House of Representatives'
     end
 
     it 'links to the other legislature' do
-      subject.css('.page-section .button--quarternary/@href').first.text.strip.must_equal '/united-states-of-america/house/'
+      subject.css('.page-section--green .button--secondary/@href').first.text.must_include '/united-states-of-america/house/'
     end
   end
 end

--- a/t/web/house_download.rb
+++ b/t/web/house_download.rb
@@ -47,4 +47,14 @@ describe 'house download template' do
       last_response_must_be_valid
     end
   end
+
+  describe 'other houses' do
+    it 'shows a link to the other legislature' do
+      subject.css('.page-section .button--quarternary').first.text.strip.must_include 'House of Representatives'
+    end
+
+    it 'links to the other legislature' do
+      subject.css('.page-section .button--quarternary/@href').first.text.strip.must_equal '/united-states-of-america/house/'
+    end
+  end
 end

--- a/views/house_download.erb
+++ b/views/house_download.erb
@@ -85,6 +85,22 @@
   </div>
 
 <div class="page-section">
+
+  <% if @page.more_houses? %>
+  <div class="container">
+    <h3>Other legislatures</h3>
+    <p>We have more data available for this country:</p>
+    <% @page.other_houses.each do |house| %>
+    <p>
+      <a class="button button--quarternary" href="/<%= @page.country.slug.downcase %>/<%= house.slug.downcase %>/">
+        <i class="fa fa-globe"></i>
+        <span class="large-screen-only">View</span> <%= house.name %>
+      </a>
+    </p>
+    <% end %>
+  </div>
+  <% end %>
+
   <div class="container">
     <h3>Other countries</h3>
     <div class="layout-equal-columns">

--- a/views/house_download.erb
+++ b/views/house_download.erb
@@ -1,23 +1,23 @@
 <div class="page-section page-section--grey text-center">
   <div class="container">
-    <h3>Download data for politicians in this legislature.</h3>
+    <h2>Download data for politicians in this legislature.</h2>
+    <p>
+      Read more about
+      <a href="http://docs.everypolitician.org/data_summary.html">what’s in the data</a>
+      and how we use
+      <a href="http://docs.everypolitician.org/technical.html">CSV and JSON formats</a>.
+      If you’re a programmer, see our notes on
+      <a href="http://docs.everypolitician.org/use_the_data.html">how to use the data</a>.
+    </p>
   </div>
 </div>
 
   <div class="page-section">
     <div class="container">
       <div class="country__legislature" id="legislature-<%= @page.house.slug.downcase %>" data-house="<%= @page.house.slug.downcase %>">
-        <p>
-          Read more about
-          <a href="http://docs.everypolitician.org/data_summary.html">what’s in the data</a>
-          and how we use
-          <a href="http://docs.everypolitician.org/technical.html">CSV and JSON formats</a>.
-          If you’re a programmer, see our notes on
-          <a href="http://docs.everypolitician.org/use_the_data.html">how to use the data</a>.
-        </p>
         <div class="layout-equal-columns">
           <div class="first-column">
-            <h4>Data for the whole legislature</h4>
+            <h3>Data for the whole legislature</h3>
             <p>
               <em>All</em> the data we have for this legislature is available
               in a single JSON file (using the Popolo open standard).
@@ -34,7 +34,7 @@
             </p>
           </div>
           <div class="second-column">
-            <h4>Just politicians’ names</h4>
+            <h3>Just politicians’ names</h3>
             <p>
               We’ve also separated just the names into a CSV file. Note there
               may be multiple names for a single politician (for example, this
@@ -52,7 +52,7 @@
           </div>
         </div>
       </div>
-      <h4>Data for specific terms</h4>
+      <h3>Data for specific terms</h3>
       <p>
         CSV files for individual terms have <em>simplified</em> data for each
         member. This might be all you need if you’re looking for the core
@@ -84,53 +84,51 @@
     </div>
   </div>
 
-<div class="page-section">
 
-  <% if @page.more_houses? %>
-  <div class="container">
-    <h3>Other legislatures</h3>
-    <p>We have more data available for this country:</p>
-    <% @page.other_houses.each do |house| %>
-    <p>
-      <a class="button button--quarternary" href="/<%= @page.country.slug.downcase %>/<%= house.slug.downcase %>/">
-        <i class="fa fa-globe"></i>
-        <span class="large-screen-only">View</span> <%= house.name %>
-      </a>
-    </p>
-    <% end %>
-  </div>
-  <% end %>
-
-  <div class="container">
-    <h3>Other countries</h3>
-    <div class="layout-equal-columns">
-      <div class="first-column">
-        <p>
-          Want politicians who aren’t from <%= @page.country.name %>?
-          No problem: we’ve got the world covered.
-        </p>
-        <p>
-          <a class="button button--quarternary" href="/countries.html">
+<% if @page.more_houses? %>
+  <div class="page-section page-section--green text-center">
+    <div class="container">
+      <h2>Other legislatures</h2>
+      <p>We have more data available for this country:</p>
+      <p>
+        <% @page.other_houses.each do |house| %>
+          <a class="button button--secondary" href="/<%= @page.country.slug.downcase %>/<%= house.slug.downcase %>/">
             <i class="fa fa-globe"></i>
-            <span class="large-screen-only">View</span> all countries
+            <span class="large-screen-only">View</span> <%= house.name %>
           </a>
-        </p>
-      </div>
-      <div class="second-column">
-        <p>
-          The file <code>countries.json</code> is the machine-readable index of
-          all the countries (and their legislatures) we’ve got data for. This
-          is especially useful if you’re interested in coding a way to
-          automatically
-          <a href="http://docs.everypolitician.org/repo_structure.html">read our data</a>.
-        </p>
-        <p>
-          <a href="<%= @page.download_url %>" class="button button--download">
-            <i class="fa fa-download"></i>
-            <span class="large-screen-only">Download</span> countries.json
-          </a>
-        </p>
-      </div>
+        <% end %>
+      </p>
+    </div>
+  </div>
+<% end %>
+
+<div class="page-section <% unless @page.more_houses? %>page-section--grey<% end %> text-center">
+
+  <div class="container">
+    <h2>Other countries</h2>
+    <div style="max-width: 26em; margin: 0 auto;">
+      <p>
+        Want politicians who aren’t from <%= @page.country.name %>?
+        No problem: we’ve got the world covered.
+      </p>
+      <p>
+        <a class="button button--secondary" href="/countries.html">
+          <i class="fa fa-globe"></i>
+          <span class="large-screen-only">View</span> all countries
+        </a>
+      </p>
+      <p style="margin-top: 2em;">
+        Looking for a way to automatically
+        <a href="http://docs.everypolitician.org/repo_structure.html">read our data</a>?
+        Download a machine-readable index of all the countries (and
+        their legislatures) we’ve got data for.
+      </p>
+      <p>
+        <a href="<%= @page.download_url %>" class="button button--download">
+          <i class="fa fa-download"></i>
+          <span class="large-screen-only">Download</span> countries.json
+        </a>
+      </p>
     </div>
   </div>
 </div>

--- a/views/sass/_components.scss
+++ b/views/sass/_components.scss
@@ -71,6 +71,7 @@ p.lead {
     font-weight: $body_typeface_bold;
     padding: 0.75em 1.5em;
     @include vendor-prefix(transition, all $animation-short);
+
     &:hover,
     &:active,
     &:focus {
@@ -78,6 +79,10 @@ p.lead {
         border-color: darken($colour_green, 5%);
         color: $colour_white;
         @include vendor-prefix(transition, all $animation-short);
+    }
+
+    & + .button {
+        margin-left: 1em;
     }
 }
 


### PR DESCRIPTION
## What does this do?

Links to other houses in the same country in the house/download page, because at the moment that section links to other countries only.

## Why was this needed?

After merging the house/download page, it was clear that either a reword of the bottom of that page was needed (#15259) or either to go for the tab component integration directly (#15240). We changed our mind and went for the first one instead.

## Relevant Issue(s)

* Closes #15259 (Reword the house download page). 
* Last point in the first section of the workflow described in todo list #15256.

## Implementation notes

Adds:
* New method in the House/download page to check if there are other houses
* New method in the House/download page to get the other houses
* Tests to check that the link to other houses are displayed correctly and with the right information
* Updates the template.

At the moment there are no countries with more than two houses. If there were more than two, the links would just been added after each other.

## Screenshots

**Country with more than one legislature:**

Australia. Go to [http://localhost:5000/australia/representatives/download.html](http://localhost:5000/australia/representatives/download.html)

![australia](https://cloud.githubusercontent.com/assets/739624/19036229/7b764e7e-8966-11e6-9edf-75eaafce80ad.png)

**Country with only one legislature:**

Panama. Go to [http://localhost:5000/panama/assembly/download.html](http://localhost:5000/panama/assembly/download.html)

![panama](https://cloud.githubusercontent.com/assets/739624/19036278/c1050fa2-8966-11e6-83ff-5ac20d92989e.png)

**Country with three legislatures:**

A country like this doesn’t exist yet. But if it did, the “Other legislatures” section would look like this:

![screen shot 2016-10-03 at 12 45 12](https://cloud.githubusercontent.com/assets/739624/19036345/45be6de2-8967-11e6-874e-423f7d4e44f4.png)

## Notes to Reviewer

None

## Notes to Merger

NONE :tada: :balloon: 

## Related legacy links

This PR replaces #15426