### PR TITLE
Test redirect

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -133,10 +133,10 @@ end
 # spider the site to generate the contents of everypolitician/viewer-static.
 # See scripts/release.sh (update_viewer_static).
 def docs_redirect(path, page_title)
-  url = URI.join(settings.docs_url, path)
+  @url = URI.join(settings.docs_url, path)
   @head_tags = [
-    %(<meta http-equiv="refresh" content="0; url=#{url}">),
-    %(<link rel="canonical" href="#{url}"/>),
+    %(<meta http-equiv="refresh" content="0; url=#{@url}">),
+    %(<link rel="canonical" href="#{@url}"/>),
   ].join("\n\t")
   @page_title = page_title
   erb :redirect

--- a/t/web/redirect.rb
+++ b/t/web/redirect.rb
@@ -3,12 +3,13 @@ require 'test_helper'
 require_relative '../../app'
 
 describe 'when hitting a docs page' do
-  subject { Nokogiri::HTML(last_response.body) }
-  before { get '/contribute.html' }
+  let(:url) { 'http://docs.everypolitician.org/contribute.html' }
+  subject   { Nokogiri::HTML(last_response.body) }
+  before    { get '/contribute.html' }
 
   it 'should redirect to the right url' do
-    subject.css('meta/@content').first.text.must_equal '0; url=http://docs.everypolitician.org/contribute.html'
-    subject.css('link/@href').first.text.must_equal 'http://docs.everypolitician.org/contribute.html'
+    subject.css('meta/@content').first.text.must_equal "0; url=#{url}"
+    subject.css('link/@href').first.text.must_equal url
   end
 
   it 'should show the page title' do
@@ -16,7 +17,7 @@ describe 'when hitting a docs page' do
   end
 
   it 'should link to the right page' do
-    subject.css('.lead a/@href').text.must_equal 'http://docs.everypolitician.org/contribute.html'
-    subject.css('.button--secondary/@href').text.must_equal 'http://docs.everypolitician.org/contribute.html'
+    subject.css('.lead a/@href').text.must_equal url
+    subject.css('.button--secondary/@href').text.must_equal url
   end
 end

--- a/t/web/redirect.rb
+++ b/t/web/redirect.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'test_helper'
+require_relative '../../app'
+
+describe 'when hitting a docs page' do
+  subject { Nokogiri::HTML(last_response.body) }
+  before { get '/contribute.html' }
+
+  it 'should redirect to the right url' do
+    subject.css('meta/@content').first.text.must_equal '0; url=http://docs.everypolitician.org/contribute.html'
+    subject.css('link/@href').first.text.must_equal 'http://docs.everypolitician.org/contribute.html'
+  end
+
+  it 'should show the page title' do
+    subject.css('.hero--jazzy h1').text.must_equal 'How to contribute'
+  end
+
+  it 'should link to the right page' do
+    subject.css('.lead a/@href').text.must_equal 'http://docs.everypolitician.org/contribute.html'
+    subject.css('.button--secondary/@href').text.must_equal 'http://docs.everypolitician.org/contribute.html'
+  end
+end

--- a/views/redirect.erb
+++ b/views/redirect.erb
@@ -6,11 +6,11 @@
 
 <div class="page-section">
     <div class="container centered">
-        <p class="lead">Redirecting to <a href="http://docs.everypolitician.org/<%= @filename %>">docs.everypolitician.org</a></p>
+        <p class="lead">Redirecting to <a href="<%= @url %>"><%= @url %></a></p>
         <p class="fourohfour-suggestions">
             <a href="/" class="button button--primary">Go home</a>
             <span class="fourohfour-suggestions__or">or</span>
-            <a href="http://docs.everypolitician.org/<%= @filename %>" class="button button--secondary">Load page</a>
+            <a href="<%= @url %>" class="button button--secondary">Load page</a>
         </p>
     </div>
 </div>


### PR DESCRIPTION
This PR supersedes [Country download redirect #15261](#15261)

## What does this do?

This PR is the first part of splitting [Country download redirect #15261](#15261) in two. Second part here: #15466

It adds tests for the existing redirecting code (and which make the change at hand easy), leaving the second part of that PR as the part that can be the subsequent easy change.

## Why was this needed?

[Country download redirect #15261](#15261) was a little too large, especially as it had a dependency on other PRs that weren't merged at the moment of its creation.

## Relevant Issue(s)

This is part of issue [release house and house/download pages #15256](#15256) regarding the post-live clean-up, and TO-DO list [TODO w/c 2016-08-30 #492](https://github.com/everypolitician/everypolitician/issues/492)

## Implementation notes

* Since the url of the host was hardcoded in the view, it is now passed as a variable to it [1].

* New tests were added to ensure that the redirection to the docs pages is working properly (`/t/web/redirect.rb`).

---------------------------
[1] Passing `@url` to the view also allowed to get rid of the non-existing `@filename` variable referenced in said template. The tests were showing that when hitting a documents route (for example, `everypolitician.org/contribute.html`), the presence of this non-existing variable was causing a redirection to `docs.everypolitician.org` instead of `docs.everypolitician.org/contribute.html`.

## Screenshots

Not needed

## Notes to Reviewer

Nope

## Notes to Merger

This PR should be merged before #15466

