### PR TITLE
Read DATASOURCE from an environment variable rather than a file

### DIFF
--- a/DATASOURCE
+++ b/DATASOURCE
@@ -1,1 +1,0 @@
-https://cdn.rawgit.com/everypolitician/everypolitician-data/6eba76491ba558c52ba521947116b602297cfa33/countries.json

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This `viewer-sinatra` app dynamically generates the data pages of
 the [EveryPolitician website](http://everypolitician.org).
 
 It's a small Sinatra app that loads data on a per-request basis
-using a `countries.json` file specified by the URL in the `DATASOURCE` file.
+using a `countries.json` file specified by the URL in the `DATASOURCE`
+environment variable.
 
 Typically, we use this with `DATASOURCE` pointing at a specific version
 (often the *most recent version*) of `countries.json`, which is the

--- a/app.rb
+++ b/app.rb
@@ -19,7 +19,8 @@ helpers Popolo::Helper
 
 set :erb, trim: '-'
 set :docs_url, 'http://docs.everypolitician.org'
-set :index, EveryPolitician::Index.new(index_url: File.read('DATASOURCE').chomp)
+set :datasource, ENV.fetch('DATASOURCE', 'https://github.com/everypolitician/everypolitician-data/raw/master/countries.json')
+set :index, EveryPolitician::Index.new(index_url: settings.datasource)
 
 get '/' do
   @page = Page::Home.new(index: settings.index)

--- a/t/page/download.rb
+++ b/t/page/download.rb
@@ -21,10 +21,6 @@ describe 'Download' do
       it 'should be at the correct SHA' do
         subject.download_url.must_include 'd8a4682f'
       end
-
-      it 'should be at rawgit' do
-        subject.download_url.must_equal index_at_known_sha.index_url
-      end
     end
   end
 end

--- a/t/page/download.rb
+++ b/t/page/download.rb
@@ -23,7 +23,7 @@ describe 'Download' do
       end
 
       it 'should be at rawgit' do
-        subject.download_url.must_include 'cdn.rawgit.com'
+        subject.download_url.must_equal index_at_known_sha.index_url
       end
     end
   end

--- a/t/page/house_download.rb
+++ b/t/page/house_download.rb
@@ -44,9 +44,5 @@ describe 'HouseDownload' do
     it 'should be at the correct SHA' do
       subject.download_url.must_include 'd8a4682f'
     end
-
-    it 'should be at rawgit' do
-      subject.download_url.must_equal index_at_known_sha.index_url
-    end
   end
 end

--- a/t/page/house_download.rb
+++ b/t/page/house_download.rb
@@ -46,7 +46,7 @@ describe 'HouseDownload' do
     end
 
     it 'should be at rawgit' do
-      subject.download_url.must_include 'cdn.rawgit.com'
+      subject.download_url.must_equal index_at_known_sha.index_url
     end
   end
 end

--- a/t/test_helper.rb
+++ b/t/test_helper.rb
@@ -26,7 +26,7 @@ module Minitest
     end
 
     before do
-      cj_file = %r{#{cdn}/#{ep_repo}/\w+/countries.json}
+      cj_file = %r{#{cdn}/#{ep_repo}/raw/\w+/countries.json}
       fixture = Pathname.new('t/fixtures/d8a4682f-countries.json')
       stub_request(:get, cj_file).to_return(body: fixture.read)
     end
@@ -58,7 +58,7 @@ module Minitest
     private
 
     def cdn
-      'https://cdn.rawgit.com'
+      'https://github.com'
     end
 
     def ep_repo
@@ -66,7 +66,7 @@ module Minitest
     end
 
     def countries_json_url
-      URI.join(cdn, ep_repo + '/', 'd8a4682f/countries.json').to_s
+      URI.join(cdn, ep_repo + '/', 'raw/d8a4682f/countries.json').to_s
     end
   end
 end

--- a/t/test_helper.rb
+++ b/t/test_helper.rb
@@ -26,7 +26,7 @@ module Minitest
     end
 
     before do
-      cj_file = %r{#{cdn}/#{ep_repo}/raw/\w+/countries.json}
+      cj_file = %r{#{ep_repo}/raw/\w+/countries.json}
       fixture = Pathname.new('t/fixtures/d8a4682f-countries.json')
       stub_request(:get, cj_file).to_return(body: fixture.read)
     end
@@ -57,16 +57,12 @@ module Minitest
 
     private
 
-    def cdn
-      'https://github.com'
-    end
-
     def ep_repo
-      'everypolitician/everypolitician-data'
+      'https://github.com/everypolitician/everypolitician-data'
     end
 
     def countries_json_url
-      URI.join(cdn, ep_repo + '/', 'raw/d8a4682f/countries.json').to_s
+      URI.join(ep_repo + '/', 'raw/d8a4682f/countries.json').to_s
     end
   end
 end


### PR DESCRIPTION
This changes viewer-sinatra to read the `DATASOURCE`, which is a url pointing to the `countries.json` file to use to get the data for the site, from an environment variable instead of a file.

As part of [changing the way everypolitician.org is deployed](https://github.com/everypolitician/everypolitician/projects/2) we want to be able to have a site builder gem that when invoked uses viewer-sinatra to build everypolitician.org using a specific version of `countries.json`. This pull request means that we can specify which version of `countries.json` we want to use without having to make a commit to viewer-sinatra.

Fixes https://github.com/everypolitician/everypolitician/issues/503