### PR TITLE
Do a shallow clone of viewer-static in release.sh

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -12,7 +12,7 @@ build_viewer_static() {
 }
 
 deploy_viewer_static() {
-  git clone https://github.com/everypolitician/viewer-static.git
+  git clone --depth=1 https://github.com/everypolitician/viewer-static.git
   cd viewer-static
   git checkout gh-pages
   cp -R ../localhost:4567/* .


### PR DESCRIPTION
When deploying the site we don't need to do a full ~700MB clone of
viewer-static as we're not using the history in the repository. This
should help speed up the deploy process a bit.

Related to https://github.com/everypolitician/everypolitician-data/pull/17407 where I made a similar change to that script.