### PR TITLE
Fix @head_tags warning

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -1,5 +1,6 @@
 <% @country = @page.country if (@page and @page.respond_to? :country) %>
 <% @house   = @page.house   if (@page and @page.respond_to? :house) %>
+<% @head_tags = @head_tags ||= "" %>
 
 <!DOCTYPE html>
 <html class="no-js">

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -1,12 +1,11 @@
 <% @country = @page.country if (@page and @page.respond_to? :country) %>
 <% @house   = @page.house   if (@page and @page.respond_to? :house) %>
-<% @head_tags = @head_tags ||= "" %>
 
 <!DOCTYPE html>
 <html class="no-js">
 <head>
     <meta charset="utf-8">
-    <%= @head_tags %>
+    <%= @head_tags ||= "" %>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
     <link rel="stylesheet" type="text/css" href="/javascript/jquery-ui-1.11.4.custom/jquery-ui.css">


### PR DESCRIPTION
I made a very tiny fix that removes the `@head_tags` warnings, after dabbling with the possibility of just making a dedicated erb template for this intermediate page (`redirect.erb`) that didn't use the main `layout.erb` page and discarding it.

The warnings were appearing when running a single test file separately, but not when running the rake tasks that run several test files. When setting the warning flags to `true` in the Rakefile, a lot of other warnings appear but those may be investigated and fixed in a different pull request.

Closes #14817

Fixup commits must be autosquashed before merging.
