### PR TITLE
Include top 5 identifiers per person

### DIFF
--- a/lib/page/term_table.rb
+++ b/lib/page/term_table.rb
@@ -90,7 +90,7 @@ module Page
                 .group_by { |i| i[:scheme] }
                 .sort_by { |_s, ids| -ids.size }
                 .map { |s, _ids| s }
-                .take(3)
+                .take(5)
     end
 
     def person_memberships(person)

--- a/lib/page/term_table.rb
+++ b/lib/page/term_table.rb
@@ -90,7 +90,6 @@ module Page
                 .group_by { |i| i[:scheme] }
                 .sort_by { |_s, ids| -ids.size }
                 .map { |s, _ids| s }
-                .take(5)
     end
 
     def person_memberships(person)

--- a/lib/person_cards.rb
+++ b/lib/person_cards.rb
@@ -106,7 +106,7 @@ class PersonCard
       end
 
       def info
-        extras[:top_identifiers].select { |s| person.identifier(s) }.map do |scheme|
+        extras[:top_identifiers].select { |s| person.identifier(s) }.take(5).map do |scheme|
           id = person.identifier(scheme)
           {
             type:  scheme,

--- a/t/page/term_table.rb
+++ b/t/page/term_table.rb
@@ -125,32 +125,48 @@ describe 'TermTable' do
         af.contacts.first.link.must_equal 'mailto:angela.fichtinger@parlament.gv.at'
       end
 
-      describe 'identifiers' do
-        let(:maria) { subject.people.find { |p| p.name == 'Mag. Dr. Maria Theresia Fekter' } }
+      it 'has two identifiers' do
+        af.identifiers.count.must_equal 2
+      end
 
-        it 'shows up to 5' do
-          maria.identifiers.size.must_equal 5
-        end
+      it 'has Wikidata' do
+        af.identifiers.first.type.must_equal 'wikidata'
+        af.identifiers.first.value.must_equal 'Q15783437'
+        af.identifiers.first.link.must_equal 'https://www.wikidata.org/wiki/Q15783437'
+      end
 
-        it 'shows them ordered by their frequency in the term' do
-          maria.identifiers[0].type.must_equal 'wikidata'
-          maria.identifiers[1].type.must_equal 'parlaments_at'
-          maria.identifiers[2].type.must_equal 'viaf'
-          maria.identifiers[3].type.must_equal 'gnd'
-          maria.identifiers[4].type.must_equal 'munzinger'
-        end
+      it 'has a parliament identifier' do
+        af.identifiers.last.type.must_equal 'parlaments_at'
+        af.identifiers.last.value.must_equal '83146'
+        af.identifiers.last.link.must_equal nil
+      end
+    end
 
-        it 'has Wikidata' do
-          maria.identifiers.first.type.must_equal 'wikidata'
-          maria.identifiers.first.value.must_equal 'Q85362'
-          maria.identifiers.first.link.must_equal 'https://www.wikidata.org/wiki/Q85362'
-        end
+    describe 'identifiers' do
+      let(:maria) { subject.people.find { |p| p.name == 'Mag. Dr. Maria Theresia Fekter' } }
 
-        it 'has a munzinger id' do
-          maria.identifiers.last.type.must_equal 'munzinger'
-          maria.identifiers.last.value.must_equal '00000026847'
-          maria.identifiers.last.link.must_equal nil
-        end
+      it 'shows up to 5' do
+        maria.identifiers.size.must_equal 5
+      end
+
+      it 'shows them ordered by their frequency in the term' do
+        maria.identifiers[0].type.must_equal 'wikidata'
+        maria.identifiers[1].type.must_equal 'parlaments_at'
+        maria.identifiers[2].type.must_equal 'viaf'
+        maria.identifiers[3].type.must_equal 'gnd'
+        maria.identifiers[4].type.must_equal 'munzinger'
+      end
+
+      it 'has Wikidata' do
+        maria.identifiers.first.type.must_equal 'wikidata'
+        maria.identifiers.first.value.must_equal 'Q85362'
+        maria.identifiers.first.link.must_equal 'https://www.wikidata.org/wiki/Q85362'
+      end
+
+      it 'has a munzinger id' do
+        maria.identifiers.last.type.must_equal 'munzinger'
+        maria.identifiers.last.value.must_equal '00000026847'
+        maria.identifiers.last.link.must_equal nil
       end
     end
 

--- a/t/page/term_table.rb
+++ b/t/page/term_table.rb
@@ -125,34 +125,32 @@ describe 'TermTable' do
         af.contacts.first.link.must_equal 'mailto:angela.fichtinger@parlament.gv.at'
       end
 
-      it 'has two identifiers' do
-        af.identifiers.count.must_equal 2
-      end
+      describe 'identifiers' do
+        let(:maria) { subject.people.find { |p| p.name == 'Mag. Dr. Maria Theresia Fekter' } }
 
-      it 'has Wikidata' do
-        af.identifiers.first.type.must_equal 'wikidata'
-        af.identifiers.first.value.must_equal 'Q15783437'
-        af.identifiers.first.link.must_equal 'https://www.wikidata.org/wiki/Q15783437'
-      end
+        it 'shows up to 5' do
+          maria.identifiers.size.must_equal 5
+        end
 
-      it 'has a parliament identifier' do
-        af.identifiers.last.type.must_equal 'parlaments_at'
-        af.identifiers.last.value.must_equal '83146'
-        af.identifiers.last.link.must_equal nil
-      end
+        it 'shows them ordered by their frequency in the term' do
+          maria.identifiers[0].type.must_equal 'wikidata'
+          maria.identifiers[1].type.must_equal 'parlaments_at'
+          maria.identifiers[2].type.must_equal 'viaf'
+          maria.identifiers[3].type.must_equal 'gnd'
+          maria.identifiers[4].type.must_equal 'munzinger'
+        end
 
-      it 'has up to 5 identifiers' do
-        harald = subject.people.find { |p| p.name == 'Dr. Harald Walser' }
-        harald.identifiers.size.must_equal 5
-      end
+        it 'has Wikidata' do
+          maria.identifiers.first.type.must_equal 'wikidata'
+          maria.identifiers.first.value.must_equal 'Q85362'
+          maria.identifiers.first.link.must_equal 'https://www.wikidata.org/wiki/Q85362'
+        end
 
-      it 'has identifiers ordered by term frequency' do
-        harald = subject.people.find { |p| p.name == 'Dr. Harald Walser' }
-        harald.identifiers[0].type.must_equal 'wikidata'
-        harald.identifiers[1].type.must_equal 'parlaments_at'
-        harald.identifiers[2].type.must_equal 'viaf'
-        harald.identifiers[3].type.must_equal 'gnd'
-        harald.identifiers[4].type.must_equal 'lcauth'
+        it 'has a munzinger id' do
+          maria.identifiers.last.type.must_equal 'munzinger'
+          maria.identifiers.last.value.must_equal '00000026847'
+          maria.identifiers.last.link.must_equal nil
+        end
       end
     end
 

--- a/t/page/term_table.rb
+++ b/t/page/term_table.rb
@@ -140,6 +140,20 @@ describe 'TermTable' do
         af.identifiers.last.value.must_equal '83146'
         af.identifiers.last.link.must_equal nil
       end
+
+      it 'has up to 5 identifiers' do
+        harald = subject.people.find { |p| p.name == 'Dr. Harald Walser' }
+        harald.identifiers.size.must_equal 5
+      end
+
+      it 'has identifiers ordered by term frequency' do
+        harald = subject.people.find { |p| p.name == 'Dr. Harald Walser' }
+        harald.identifiers[0].type.must_equal 'wikidata'
+        harald.identifiers[1].type.must_equal 'parlaments_at'
+        harald.identifiers[2].type.must_equal 'viaf'
+        harald.identifiers[3].type.must_equal 'gnd'
+        harald.identifiers[4].type.must_equal 'lcauth'
+      end
     end
 
     it 'knows percentage of people that have special data' do


### PR DESCRIPTION
Currently we find the Top identifiers across a legislature, and then
include those for each person who has them. This commit changes
that behaviour to include up to 5 identifiers per person, ordered by
how common those are across that legislature.

I chose Harald for the tests because he has more than 5 identifiers.

![harald](https://cloud.githubusercontent.com/assets/2157089/18756327/70552268-80e7-11e6-843e-0eca3b925094.png)

Closes #6332