### PR TITLE
Use tidy-html5 to validate the house page

### DIFF
--- a/t/test_helper.rb
+++ b/t/test_helper.rb
@@ -57,6 +57,7 @@ module Minitest
     end
 
     def last_response_must_be_valid
+      skip if `which tidy`.empty?
       validation = PageValidations::HTMLValidation.new.validation(last_response.body, last_request.url)
       assert validation.valid?, validation.exceptions
     end

--- a/t/web/country.rb
+++ b/t/web/country.rb
@@ -45,7 +45,6 @@ describe 'Country Page' do
 
   describe 'HTML validation' do
     it 'has no errors in the country page' do
-      skip if `which tidy`.empty?
       get '/estonia/'
       last_response_must_be_valid
     end

--- a/t/web/house.rb
+++ b/t/web/house.rb
@@ -22,7 +22,6 @@ describe 'House Page' do
 
   describe 'HTML validation' do
     it 'has no errors in the house page' do
-      skip if `which tidy`.empty?
       last_response_must_be_valid
     end
   end

--- a/t/web/house.rb
+++ b/t/web/house.rb
@@ -19,4 +19,11 @@ describe 'House Page' do
       subject.css('.avatar-unit p').last.text.must_equal '1981-01-06 - 1983-01-03'
     end
   end
+
+  describe 'HTML validation' do
+    it 'has no errors in the house page' do
+      skip if `which tidy`.empty?
+      last_response_must_be_valid
+    end
+  end
 end

--- a/views/house.erb
+++ b/views/house.erb
@@ -48,10 +48,10 @@
 
       <a href="http://gender-balance.org" class="gender-balance-promo__demo">
         <div class="screenshot-wrapper">
-          <img src="/images/screencast.gif" width="232" height="330">
+          <img src="/images/screencast.gif" width="232" height="330" alt="Gender-Balance app preview">
         </div>
-      </div>
-    </a>
+      </a>
+    </div>
 
   </div>
 </div>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -64,7 +64,7 @@
                         <a href="/"><span class="header-logo">EveryPolitician</span></a>
                       <% end %>
                     </h2>
-                    <% if @house %><h3><a href="/<%= @country.slug.downcase %>/<%= @house.slug.downcase %>/"><%= @house.name %></h3><% end %>
+                    <% if @house %><h3><a href="/<%= @country.slug.downcase %>/<%= @house.slug.downcase %>/"><%= @house.name %></a></h3><% end %>
                 </div>
                 <div class="site-header__navigation site-header__navigation--primary">
                     <nav role="navigation">


### PR DESCRIPTION
# What does this do?

HTML-validates the house page and removes skip duplication

# Why was this needed?

The HTML was broken and the skip was duplicated

# Relevant Issue(s)

https://github.com/everypolitician/everypolitician/issues/505

# Implementation notes

None

# Screenshots

None

# Notes to Reviewer

Errors corrected:
- An "img" element must have an "alt" attribute, except under certain
conditions. For details, consult guidance on providing text alternatives
for images. At line 254, column 69.
- End tag "div" seen, but there were open elements. At line 256, column 12.
- Unclosed element "a". At line 252, column 77.

# Notes to Merger

None