### PR TITLE
Use tidy-html5 to validate the term-table page

### DIFF
--- a/t/web/term_table/nz.rb
+++ b/t/web/term_table/nz.rb
@@ -17,4 +17,13 @@ describe 'Per Country Tests' do
       subject.css('#term h1').text.must_include '51st Parliament'
     end
   end
+
+  describe 'HTML validation' do
+    before { get '/new-zealand/house/term-table/51.html' }
+
+    it 'has no errors in the term-table page' do
+      skip if `which tidy`.empty?
+      last_response_must_be_valid
+    end
+  end
 end

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -140,10 +140,13 @@
                             <img src="/images/person-placeholder-108px.png"
                                  data-src="<%= person.proxy_image %>"
                                  style="display: none"
-                                 class="person-card__image">
-                            <noscript><img src="<%= person.proxy_image %>" class="person-card__image"></noscript>
+                                 class="person-card__image"
+                                 alt="Member headshot">
+                            <noscript><img src="<%= person.proxy_image %>" class="person-card__image"
+                            alt="Member headshot"></noscript>
                           <% else %>
-                            <img src="/images/person-placeholder-108px.png" class="person-card__image">
+                            <img src="/images/person-placeholder-108px.png" class="person-card__image"
+                            alt="Placeholder image">
                           <% end %>
 
                             <h3 class="person-card__name"><%= person.name %></h3>


### PR DESCRIPTION
# What does this do?

HTML-validates the term table page

# Why was this needed?

The HTML was broken

# Relevant Issue(s)

https://github.com/everypolitician/everypolitician/issues/505

# Implementation notes

None

# Screenshots

None

# Notes to Reviewer

Errors corrected:
- An "img" element must have an "alt" attribute, except under certain
conditions. For details, consult guidance on providing text alternatives
for images. (All occurrences)

# Notes to Merger

None