### PR TITLE
Use tidy-html5 to validate the term-table page

### DIFF
--- a/t/web/term_table/ni.rb
+++ b/t/web/term_table/ni.rb
@@ -35,5 +35,23 @@ describe 'Northern Ireland' do
       img.attr('src').text.must_equal '/images/person-placeholder-108px.png'
       img.attr('data-src').text.must_include 'politician-image-proxy'
     end
+
+    describe 'alt attribute on avatars' do
+      it 'has the person name in a placeholder image' do
+        img = mcquillan.css('img.person-card__image')
+        img.attr('alt').text.must_equal 'Placeholder image for Adrian McQuillan'
+      end
+
+      it 'has the person name in a normal image' do
+        img = annalo.css('img.person-card__image')
+        img.attr('alt').text.must_equal 'Member headshot for Anna Lo'
+      end
+    end
+
+    describe 'HTML validation' do
+      it 'has no errors in the term-table page' do
+        last_response_must_be_valid
+      end
+    end
   end
 end

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -140,10 +140,13 @@
                             <img src="/images/person-placeholder-108px.png"
                                  data-src="<%= person.proxy_image %>"
                                  style="display: none"
-                                 class="person-card__image">
-                            <noscript><img src="<%= person.proxy_image %>" class="person-card__image"></noscript>
+                                 class="person-card__image"
+                                 alt="Member headshot for <%= person.name %>">
+                            <noscript><img src="<%= person.proxy_image %>" class="person-card__image"
+                            alt="Member headshot for <%= person.name %>"></noscript>
                           <% else %>
-                            <img src="/images/person-placeholder-108px.png" class="person-card__image">
+                            <img src="/images/person-placeholder-108px.png" class="person-card__image"
+                            alt="Placeholder image for <%= person.name %>">
                           <% end %>
 
                             <h3 class="person-card__name"><%= person.name %></h3>


### PR DESCRIPTION
# What does this do?

HTML-validates the term-table page and in doing so addresses [this comments](https://github.com/everypolitician/viewer-sinatra/pull/15433#discussion_r80199278)

# Why was this needed?

HTML was broken

# Relevant Issue(s)

https://github.com/everypolitician/everypolitician/issues/505

# Implementation notes

None

# Screenshots

None

# Notes to Reviewer

Errors corrected:
- An "img" element must have an "alt" attribute, except under certain
conditions. For details, consult guidance on providing text alternatives
for images. (All occurrences)

# Notes to Merger

None
