### PR TITLE
Use tidy-html5 to validate the house/download page

### DIFF
--- a/t/web/house_download.rb
+++ b/t/web/house_download.rb
@@ -41,4 +41,10 @@ describe 'house download template' do
       subject.css('#term-senate-113 p').text.strip.must_include '2013-01-06 - 2015-01-03'
     end
   end
+
+  describe 'HTML validation' do
+    it 'has no errors in the house/download page' do
+      last_response_must_be_valid
+    end
+  end
 end


### PR DESCRIPTION
# What does this do?

HTML-validates the house/download page

# Why was this needed?

HTML could be broken, turns out it wasn't for this particular page, but the automated detection is now in place

# Relevant Issue(s)

https://github.com/everypolitician/everypolitician/issues/505

# Implementation notes

None

# Screenshots

None

# Notes to Reviewer

None

# Notes to Merger

None
Errors corrected:
- No errors