### PR TITLE
Return objects from membership.area and group

### DIFF
--- a/lib/page/term_table.rb
+++ b/lib/page/term_table.rb
@@ -93,13 +93,7 @@ module Page
     end
 
     def person_memberships(person)
-      membership_lookup[person.id].each do |mem|
-        group = org_lookup[mem.on_behalf_of_id].first.name if mem.on_behalf_of_id
-        group = '' if group.to_s.downcase == 'unknown'
-        area = area_lookup[mem.area_id].first.name if mem.area_id
-        mem.define_singleton_method(:group) { group || '' }
-        mem.define_singleton_method(:area)  { area  || '' }
-      end
+      membership_lookup[person.id]
     end
 
     def image_proxy_url(id)

--- a/t/page/term_table.rb
+++ b/t/page/term_table.rb
@@ -91,8 +91,8 @@ describe 'TermTable' do
         af.memberships.count.must_equal 1
         af.memberships.first.start_date.must_equal '2013-10-29'
         af.memberships.first.end_date.must_equal nil
-        af.memberships.first.group.must_equal 'ÖVP'
-        af.memberships.first.area.must_equal 'Wahlkreis: 3B – Waldviertel'
+        af.memberships.first.group.name.must_equal 'ÖVP'
+        af.memberships.first.area.name.must_equal 'Wahlkreis: 3B – Waldviertel'
       end
 
       it 'has two entries on bio card' do

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -151,7 +151,7 @@
                           <% person.memberships.each do |mem| %>
                             <p class="person-card__politics">
 
-                              <%= [mem.group, mem.area].reject(&:empty?).join(" — ") %>
+                              <%= [mem.group, mem.area].reject(&:nil?).map(&:name).join(" — ") %>
 
                               <% if mem.start_date && mem.end_date %>
                                 <span class="person-card__politics__date">(<%= mem.start_date.to_s %> to <%= mem.end_date.to_s %>)</span>


### PR DESCRIPTION
We currently have two conflicting places injecting methods into Membership objects for 'area' and 'group' — MembershipExtension, which returns the relevant objects of Area or Organization; and
`person_memberships` in the TermTable page, which then overrides these to be strings. This leads to all manner of odd and inconsistent behaviour.

Change this to use objects throughout by simply falling back on the version from the MembershipExtension.

(NB: This should also remove a *lot* of the test warnings, per https://github.com/everypolitician/viewer-sinatra/issues/15572)