### PR TITLE
Check for supported version of html-tidy in tests

### DIFF
--- a/t/test_helper.rb
+++ b/t/test_helper.rb
@@ -57,12 +57,19 @@ module Minitest
     end
 
     def last_response_must_be_valid
-      skip if `which tidy`.empty?
+      skip unless supported_html_tidy_version?
       validation = PageValidations::HTMLValidation.new.validation(last_response.body, last_request.url)
       assert validation.valid?, validation.exceptions
     end
 
     private
+
+    # If an old version of html-tidy is installed then this HTML string will
+    # cause `tidy(1)` to exit with a non-zero status, which will cause `system`
+    # to return `false`.
+    def supported_html_tidy_version?
+      system("echo '<!DOCTYPE html><title>Test</title><body><header>Test</header>' | tidy -eq > /dev/null 2>&1")
+    end
 
     def ep_repo
       'https://github.com/everypolitician/everypolitician-data'


### PR DESCRIPTION
# What does this do?

This change adds a more robust check for a supported version of html-tidy.

# Why was this needed?


Previously we were only checking that html-tidy was installed, however this meant that the user might have a very old version of html-tidy installed, which doesn't support HTML5. This new check now ensures that the user's version of html-tidy actually supports HTML5.

# Relevant Issue(s)

Closes https://github.com/everypolitician/viewer-sinatra/issues/15573

# Implementation notes

I've extracted the check for a supported version of html-tidy into it's own helper method to make it clearer what the check is actually doing.