### PR TITLE
Rake default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,7 @@ addons:
 before_install:
   - scripts/install_tidy.sh
 script:
-  - bundle exec rake test:all
-  - bundle exec rake rubocop
-  - bundle exec rake bundle:audit
+  - bundle exec rake
   - scripts/release.sh
 sudo: false
 rvm:

--- a/README.md
+++ b/README.md
@@ -104,7 +104,13 @@ bundle exec rake test:extensions
 bundle exec rake test:all
 ```
 
-It is recommended to run the last command at least once right before pushing.
+### Run absolutely all the tests plus rubocop and bundle audit
+
+```bash
+bundle exec rake
+```
+
+It is recommended to run the last command at least once right before pushing. Also, running this command assures you that what you get locally is the same that you will get in Travis.
 
 ## Sinatra, SASS, styling
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ bundle exec rake test:all
 bundle exec rake
 ```
 
-It is recommended to run the last command at least once right before pushing. Also, running this command assures you that what you get locally is the same that you will get in Travis.
 
 ## Sinatra, SASS, styling
 

--- a/Rakefile
+++ b/Rakefile
@@ -54,3 +54,5 @@ end
 
 require 'bundler/audit/task'
 Bundler::Audit::Task.new
+
+task default: ['test:all', 'rubocop', 'bundle:audit']


### PR DESCRIPTION
# What does this do?

It adds a new default task to Travis, so that running `bundle exec rake` runs everything and all the things: tests, syntax checks and security checks

# Why was this needed?

Because it was easy to forget to manually run all the things before pushing, and get different results from Travis. Now we only have to run a single command.

# Relevant Issue(s)

"_Use default rake tasks to configure what runs on Travis_" https://github.com/everypolitician/everypolitician/issues/516

# Implementation notes

None

# Screenshots

None

# Notes to Reviewer

None

# Notes to Merger

None