### PR TITLE
Use tidy-html5 to validate the countries page

### DIFF
--- a/t/web/countries.rb
+++ b/t/web/countries.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+require 'test_helper'
+require_relative '../../app'
+
+describe 'Countries' do
+  describe 'HTML validation' do
+    it 'has no errors in the countries page' do
+      get '/countries.html'
+      last_response_must_be_valid
+    end
+  end
+end


### PR DESCRIPTION
# What does this do?

HTML-validates the countries page

# Why was this needed?

HTML could be broken, turns out it wasn't, but the detection is now in place

# Relevant Issue(s)

https://github.com/everypolitician/everypolitician/issues/505

# Implementation notes

None

# Screenshots

None

# Notes to Reviewer

Errors corrected:
- No errors

# Notes to Merger

There was no test file for the countries page, so I created it from scratch.