### PR TITLE
Use tidy-html5 to validate the home page

### DIFF
--- a/public/javascript/main.js
+++ b/public/javascript/main.js
@@ -305,15 +305,23 @@ $(function(){
   });
 
   // http://baymard.com/labs/country-selector
-  $('.js-select-to-autocomplete').selectToAutocomplete().on('change', function(){
-    var v = $(this).val();
-    if (v) {
-      // Assumes the <option>'s `value` attribute is a URL slug for the country
-      window.location.href = '/' + v + '/';
-    }
-  }).on('focus', function(){
-    $(this).next().trigger("focus");
-  });
+  $('.js-select-to-autocomplete')
+    .attr({
+      placeholder:  'Search by country name',
+      autocorrect:  'off',
+      autocomplete: 'off'
+    })
+    .selectToAutocomplete()
+    .on('change', function(){
+      var v = $(this).val();
+      if (v) {
+        // Assumes the <option>'s `value` attribute is a URL slug for the country
+        window.location.href = '/' + v + '/';
+      }
+    })
+    .on('focus', function(){
+      $(this).next().trigger("focus");
+    });
 
   // Fix the incorrect default autocomplete width, which meant that
   // autocomplete menu was longer than the search input it's linked to.

--- a/t/web/basic.rb
+++ b/t/web/basic.rb
@@ -66,4 +66,12 @@ describe 'Viewer' do
       last_response.status.must_equal 404
     end
   end
+
+  describe 'HTML validation' do
+    before { get '/' }
+
+    it 'has no errors in the home page' do
+      last_response_must_be_valid
+    end
+  end
 end

--- a/views/country_selector.erb
+++ b/views/country_selector.erb
@@ -1,4 +1,4 @@
-<select class="field js-select-to-autocomplete" placeholder="Search by country name" name="Country" id="country-selector" autofocus="autofocus" autocorrect="off" autocomplete="off">
+<select class="field js-select-to-autocomplete" name="Country" id="country-selector" autofocus="autofocus">
     <option value="" selected="selected">Select Country</option>
   <% @page.all_countries.each do |country| %>
     <option value="<%= country.slug %>" data-alternative-spellings="<%= country.names %>" title="<%= commify(country.total_people) %> <% if country.total_people == 1 %>person<% else %>people<% end %>"><%= country.name %></option>


### PR DESCRIPTION
# What does this do?

HTML-validates the home page

# Why was this needed?

HTML was broken

# Relevant Issue(s)

https://github.com/everypolitician/everypolitician/issues/505
Closes #15562

# Implementation notes

The attributes removed to make the validation pass where added back with JavaScript.

# Screenshots

![screen shot 2016-09-20 at 17 24 35](https://cloud.githubusercontent.com/assets/739624/18679352/2d4ae9f8-7f57-11e6-8362-b1737459fcec.png)

(Image by @zarino )

# Notes to Reviewer

Errors corrected:
- Attribute "placeholder" not allowed on element "select" at this point. At line 86, column 189
- Attribute "autocorrect" not allowed on element "select" at this point. At line 86, column 189
- Attribute "autocomplete" not allowed on element "select" at this point. At line 86, column 189

# Notes to Merger

None
