### PR TITLE
Remove duplicate before_install section in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,11 @@ language: ruby
 cache: bundler
 before_install:
   - echo -e "machine github.com\n  login $GITHUB_ACCESS_TOKEN" >> ~/.netrc
+  - scripts/install_tidy.sh
 addons:
   apt:
     packages:
     - cmake
-before_install:
-  - scripts/install_tidy.sh
 script:
   - bundle exec rake test:all
   - bundle exec rake rubocop


### PR DESCRIPTION
# What does this do?

This removes a duplicate `before_install` section from `.travis.yml` that I accidentally added in #15573.

# Why was this needed?

Deploys of everypolitician.org were failing because I'd overwritten the `before_install` section that was adding credentials to `.netrc`, so git didn't have the correct credentials available to push to viewer-static.

# Relevant Issue(s)

#15573 was the pull request that introduced the problem.