### PR TITLE
Document that person image can show if JS is disabled

### DIFF
--- a/t/web/term_table/ni.rb
+++ b/t/web/term_table/ni.rb
@@ -31,9 +31,21 @@ describe 'Northern Ireland' do
     end
 
     it 'should start with a placeholder image, but have proxy set' do
-      img = annalo.css('img.person-card__image')
+      img = annalo.css('img.person-card__image')[0]
+      img.attr('src').must_equal '/images/person-placeholder-108px.png'
+      img.attr('data-src').must_include 'politician-image-proxy'
+    end
+
+    it 'should have an image if JavaScript is disabled' do
+      img = annalo.css('img.person-card__image')[1]
+      img.attr('src').must_include 'politician-image-proxy'
+      img.attr('data-src').must_be_nil
+    end
+
+    it 'has only a placeholder image if the person has no image' do
+      img = mcquillan.css('img.person-card__image')
+      img.size.must_equal 1
       img.attr('src').text.must_equal '/images/person-placeholder-108px.png'
-      img.attr('data-src').text.must_include 'politician-image-proxy'
     end
   end
 end


### PR DESCRIPTION
# What does this do?

It improves the image tests in the term-table page tests for Northern Ireland, documenting the fact that a person with an image shows it both when JS is and is not disabled.

It also documents that when there is no image available for a person, a placeholder image will be shown.
# Why was this needed?

Because there were no tests for it.
# Relevant Issue(s)

None
# Implementation notes

None
# Screenshots

None
# Notes to Reviewer

None
# Notes to Merger

None
