### PR TITLE
Vagrant provision.sh will now install Ruby 2.3.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,7 +144,7 @@ DEPENDENCIES
   yard
 
 RUBY VERSION
-   ruby 2.0.0p481
+   ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.5
+   1.13.2

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -10,7 +10,7 @@ sudo apt-get update
 
 # Install required packages
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
-  ruby2.0 ruby2.0-dev git build-essential libxslt1-dev zlib1g-dev
+  ruby2.3 ruby2.3-dev git build-essential libxslt1-dev zlib1g-dev
 
 # Add cd /vagrant to ~/.bashrc
 grep -qG "cd /vagrant" "$HOME/.bashrc" || echo "cd /vagrant" >> "$HOME/.bashrc"


### PR DESCRIPTION
# What does this do?

Installs Ruby 2.3.x as part of the Vagrant provisioning process.

# Why was this needed?

The Gemfile required version 2.3.1 of Ruby.

# Relevant Issue(s)

–

# Implementation notes

–

# Screenshots

–

# Notes to Reviewer

–

# Notes to Merger

–


