### PR TITLE
Use the bundler github shortcut in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,11 @@ source 'https://rubygems.org'
 
 ruby '2.3.1'
 
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
+
 gem 'dotenv'
-gem 'everypolitician', '~> 0.18.0', git: 'https://github.com/everypolitician/everypolitician-ruby.git'
-gem 'everypolitician-popolo', git: 'https://github.com/everypolitician/everypolitician-popolo.git'
+gem 'everypolitician', '~> 0.18.0', github: 'everypolitician/everypolitician-ruby'
+gem 'everypolitician-popolo', github: 'everypolitician/everypolitician-popolo'
 gem 'iso_country_codes'
 gem 'json'
 gem 'nokogiri', '>= 1.6.7'


### PR DESCRIPTION
# What does this do?

Uses the `github:` shortcut in the `Gemfile` for gems that are not in Rubygems and we have to link to their repos.

# Why was this needed?

For security reasons as described in http://bundler.io/git.html#security

# Relevant Issue(s)

Part of https://github.com/everypolitician/everypolitician/issues/518

# Implementation notes

* I ran `bundle exec rake bundle:audit` and got:
```bash
:) bundle exec rake bundle:audit
Updating ruby-advisory-db ...
De https://github.com/rubysec/ruby-advisory-db
 * branch            master     -> FETCH_HEAD
Already up-to-date.
Updated ruby-advisory-db
ruby-advisory-db: 273 advisories
No vulnerabilities found
```

# Screenshots

None

# Notes to Reviewer

None

# Notes to Merger

None