### PR TITLE
Update to rubocop 0.46

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,12 +22,12 @@ gem 'sinatra'
 gem 'yajl-ruby', require: 'yajl'
 
 group :test do
+  gem 'bundler-audit'
+  gem 'html_validation'
   gem 'minitest'
   gem 'pry'
   gem 'rack-test'
   gem 'webmock'
-  gem 'bundler-audit'
-  gem 'html_validation'
 end
 
 group :quality do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
       pkg-config (~> 1.1.7)
     octokit (3.8.0)
       sawyer (~> 0.6.0, >= 0.5.3)
-    parser (2.3.1.2)
+    parser (2.3.3.1)
       ast (~> 2.2)
     path_expander (1.0.0)
     pkg-config (1.1.7)
@@ -69,7 +69,7 @@ GEM
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
-    rainbow (2.1.0)
+    rainbow (2.2.1)
     rake (10.4.2)
     redcarpet (3.2.3)
     reek (4.4.0)
@@ -77,7 +77,7 @@ GEM
       parser (~> 2.3.1, >= 2.3.1.2)
       rainbow (~> 2.0)
     require_all (1.3.3)
-    rubocop (0.42.0)
+    rubocop (0.46.0)
       parser (>= 2.3.1.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
@@ -100,7 +100,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
-    unicode-display_width (1.1.0)
+    unicode-display_width (1.1.2)
     virtus (1.0.5)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
@@ -147,4 +147,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.2
+   1.13.4


### PR DESCRIPTION
This silences the "Warning: unrecognized cop Metrics/BlockLength found"
warnings