### PR TITLE
Use 'travis_wait' to avoid timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ addons:
     - cmake
 script:
   - bundle exec rake
-  - scripts/release.sh
+  - travis_wait 30 scripts/release.sh
 sudo: false
 rvm:
   - 2.3.1


### PR DESCRIPTION
Travis is currently timing out before completion.

https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received suggests this.