### PR TITLE
Simplify the instantiation of PersonCard objects

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
 GIT
   remote: https://github.com/everypolitician/everypolitician-popolo.git
-  revision: 4e6e75ddfece32889243595e7305ba9007e3c8b4
+  revision: 40dc460d8340df9ae78469b755ce73b4fd074ce3
   specs:
-    everypolitician-popolo (0.5.0)
+    everypolitician-popolo (0.8.0)
+      require_all
 
 GIT
   remote: https://github.com/everypolitician/everypolitician-ruby.git

--- a/lib/everypolitician_extensions.rb
+++ b/lib/everypolitician_extensions.rb
@@ -38,14 +38,8 @@ module EveryPolitician
       end
     end
 
-    def people_ids
-      @people_ids ||= Set.new(memberships.map(&:person_id))
-    end
-
     def people
-      @people ||= legislature.popolo.persons.select do |p|
-        people_ids.include?(p.id)
-      end
+      @people ||= memberships.map(&:person).uniq(&:id)
     end
 
     def top_identifiers

--- a/lib/everypolitician_extensions.rb
+++ b/lib/everypolitician_extensions.rb
@@ -37,6 +37,27 @@ module EveryPolitician
         mem.end_date.to_s.empty? || mem.end_date == end_date
       end
     end
+
+    def people_ids
+      @people_ids ||= Set.new(memberships.map(&:person_id))
+    end
+
+    def people
+      @people ||= legislature.popolo.persons.select do |p|
+        people_ids.include?(p.id)
+      end
+    end
+
+    def top_identifiers
+      @top_identifiers ||= people
+                           .map(&:identifiers)
+                           .compact
+                           .flatten
+                           .reject { |i| i[:scheme] == 'everypolitician_legacy' }
+                           .group_by { |i| i[:scheme] }
+                           .sort_by { |s, ids| [-ids.size, s] }
+                           .map { |s, _ids| s }
+    end
   end
 
   module MembershipExtension

--- a/lib/page/term_table.rb
+++ b/lib/page/term_table.rb
@@ -59,7 +59,6 @@ module Page
       @people ||= people_for_current_term.sort_by { |e| [e.sort_name, e.name] }.map do |person|
         PersonCard.new(
           person:          person,
-          proxy_image:     image_proxy_url(person.id),
           term:            term,
           top_identifiers: top_identifiers
         )
@@ -90,11 +89,6 @@ module Page
                 .group_by { |i| i[:scheme] }
                 .sort_by { |s, ids| [-ids.size, s] }
                 .map { |s, _ids| s }
-    end
-
-    def image_proxy_url(id)
-      'https://mysociety.github.io/politician-image-proxy' \
-      "/#{country.slug}/#{house.slug}/#{id}/140x140.jpeg"
     end
 
     # Caches for faster lookup

--- a/lib/page/term_table.rb
+++ b/lib/page/term_table.rb
@@ -60,7 +60,7 @@ module Page
         PersonCard.new(
           person:          person,
           proxy_image:     image_proxy_url(person.id),
-          memberships:     person_memberships(person),
+          term:            term,
           top_identifiers: top_identifiers
         )
       end
@@ -92,20 +92,12 @@ module Page
                 .map { |s, _ids| s }
     end
 
-    def person_memberships(person)
-      membership_lookup[person.id]
-    end
-
     def image_proxy_url(id)
       'https://mysociety.github.io/politician-image-proxy' \
       "/#{country.slug}/#{house.slug}/#{id}/140x140.jpeg"
     end
 
     # Caches for faster lookup
-    def membership_lookup
-      @membership_lookup ||= current_term_memberships.group_by(&:person_id)
-    end
-
     def area_lookup
       @area_lookup ||= popolo.areas.group_by(&:id)
     end

--- a/lib/page/term_table.rb
+++ b/lib/page/term_table.rb
@@ -60,7 +60,6 @@ module Page
         PersonCard.new(
           person:          person,
           term:            term,
-          top_identifiers: top_identifiers
         )
       end
     end

--- a/lib/page/term_table.rb
+++ b/lib/page/term_table.rb
@@ -56,7 +56,7 @@ module Page
     end
 
     def people
-      @people ||= people_for_current_term.sort_by { |e| [e.sort_name, e.name] }.map do |person|
+      @people ||= term.people.sort_by { |e| [e.sort_name, e.name] }.map do |person|
         PersonCard.new(
           person:          person,
           term:            term,
@@ -80,17 +80,6 @@ module Page
       @popolo ||= house.popolo
     end
 
-    def top_identifiers
-      @tidx ||= people_for_current_term
-                .map(&:identifiers)
-                .compact
-                .flatten
-                .reject { |i| i[:scheme] == 'everypolitician_legacy' }
-                .group_by { |i| i[:scheme] }
-                .sort_by { |s, ids| [-ids.size, s] }
-                .map { |s, _ids| s }
-    end
-
     # Caches for faster lookup
     def area_lookup
       @area_lookup ||= popolo.areas.group_by(&:id)
@@ -98,18 +87,6 @@ module Page
 
     def org_lookup
       @org_lookup ||= popolo.organizations.group_by(&:id)
-    end
-
-    def current_term_memberships
-      @ctm ||= term.memberships
-    end
-
-    def current_term_people_ids
-      @ctpids ||= Set.new(current_term_memberships.map(&:person_id))
-    end
-
-    def people_for_current_term
-      @pct ||= popolo.persons.select { |p| current_term_people_ids.include?(p.id) }
     end
   end
 end

--- a/lib/page/term_table.rb
+++ b/lib/page/term_table.rb
@@ -58,8 +58,8 @@ module Page
     def people
       @people ||= term.people.sort_by { |e| [e.sort_name, e.name] }.map do |person|
         PersonCard.new(
-          person:          person,
-          term:            term,
+          person: person,
+          term:   term
         )
       end
     end

--- a/lib/person_cards.rb
+++ b/lib/person_cards.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
 class PersonCard
-
-  # TODO: pass fewer arguments!
-  def initialize(person:, term:, top_identifiers:)
+  def initialize(person:, term:)
     @person          = person
     @term            = term
-    @top_identifiers = top_identifiers # get from Legislature
   end
 
   def proxy_image
@@ -48,7 +45,11 @@ class PersonCard
 
   private
 
-  attr_reader :person, :term, :top_identifiers
+  attr_reader :person, :term
+
+  def top_identifiers
+    term.top_identifiers
+  end
 
   def legislature
     term.legislature

--- a/lib/person_cards.rb
+++ b/lib/person_cards.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 class PersonCard
-  attr_reader :proxy_image, :memberships
+  attr_reader :proxy_image
 
   # TODO: pass fewer arguments!
-  def initialize(person:, proxy_image:, memberships:, top_identifiers:)
+  def initialize(person:, proxy_image:, term:, top_identifiers:)
     @person          = person
-    @memberships     = memberships # should be able to get from Person
     @proxy_image     = proxy_image # get from Legislature
+    @term            = term
     @top_identifiers = top_identifiers # get from Legislature
   end
 
@@ -39,9 +39,17 @@ class PersonCard
     Section::Identifiers.new(person, top_identifiers: top_identifiers).data
   end
 
+  def memberships
+    person.memberships.where(legislative_period_id: term.id)
+  end
+
   private
 
-  attr_reader :person, :top_identifiers
+  attr_reader :person, :term, :top_identifiers
+
+  def legislature
+    term.legislature
+  end
 
   class Section
     CardLine = Struct.new(:type, :value, :link)

--- a/lib/person_cards.rb
+++ b/lib/person_cards.rb
@@ -1,14 +1,17 @@
 # frozen_string_literal: true
 
 class PersonCard
-  attr_reader :proxy_image
 
   # TODO: pass fewer arguments!
-  def initialize(person:, proxy_image:, term:, top_identifiers:)
+  def initialize(person:, term:, top_identifiers:)
     @person          = person
-    @proxy_image     = proxy_image # get from Legislature
     @term            = term
     @top_identifiers = top_identifiers # get from Legislature
+  end
+
+  def proxy_image
+    'https://mysociety.github.io/politician-image-proxy' \
+    "/#{legislature.country.slug}/#{legislature.slug}/#{id}/140x140.jpeg"
   end
 
   def id


### PR DESCRIPTION
# What does this do?

This pull request simplifies the dependencies of the `PersonCard` class,
so that it only needs to take a `Person` and a `LegislativePeriod` when
instantiating. It also moves some functionality from `TermTable` to
`LegislativePeriod` ~~(by monkey-patching the latter class).~~

# Why was this needed?

In the future we would like to reuse these models in other projects, and
these changes make that reuse easier.

# Relevant Issue(s)

I couldn't find one, but some of these changes were suggested by "TODO"
comments in the existing source.

# Implementation notes

~~I'm not 100% sure if the monkey-patching of `LegislativePeriod` is sensible
or not - maybe similar changes in the original class in `everypolitician-ruby`
would be more useful in the long run, but I thought this was OK.~~

# Screenshots

The appearance of the site should be unchanged by these.

# Notes to Reviewer

I've run the recursive `wget` on the site before and after this change, and
the results are identical (according to `diff -r`) so I don't think this has
broken anything.

~~I'm not sure if the upgrade of everypolitician-popolo is actually required
any more (I've gone through several variants of this change) but it seems
like a good idea in any case.~~

# Notes to Merger

None.