### PR TITLE
Make the order of people and identifiers more stable

### DIFF
--- a/lib/page/term_table.rb
+++ b/lib/page/term_table.rb
@@ -56,7 +56,7 @@ module Page
     end
 
     def people
-      @people ||= people_for_current_term.sort_by(&:sort_name).map do |person|
+      @people ||= people_for_current_term.sort_by { |e| [e.sort_name, e.name] }.map do |person|
         PersonCard.new(
           person:          person,
           proxy_image:     image_proxy_url(person.id),
@@ -88,7 +88,7 @@ module Page
                 .flatten
                 .reject { |i| i[:scheme] == 'everypolitician_legacy' }
                 .group_by { |i| i[:scheme] }
-                .sort_by { |_s, ids| -ids.size }
+                .sort_by { |s, ids| [-ids.size, s] }
                 .map { |s, _ids| s }
     end
 


### PR DESCRIPTION
Depending on how the list of people to display on the term page is
generated, the displayed order of the people and the top identifiers may
be different. This is because before rendering the page, people are
sorted just on their sort_name attribute, and identifiers are sorted
by the number of identifiers of that scheme found in the term: if two
people have the same sort name (e.g. e.g. Octavio Jara Wolff and Sergio
Jara Catalán have the same sort_name, 'Jara') or if there are two
identifiers which occur the same number of times (often the case for
IDs schemes that occur only once or twice in a term) the items may
appear in different orders in the page between versions of the code even
though the same people with the same associated data are used for both.

This change makes the sorting of people and identifiers more stable
between versions, by adding the full name as a secondary sort key for
people and the scheme as a secondary sort key for identifiers. (Note
that I've only said "more stable": there might be people with exactly
the same sort_name and name, but this commit should address the bulk of
this problem, and we can add additional data to the sort key if we come
across such a case.)