### PR TITLE
[WIP] Everypolitician::Positions prototype

### DIFF
--- a/lib/everypolitician_extensions.rb
+++ b/lib/everypolitician_extensions.rb
@@ -11,6 +11,71 @@ module EveryPolitician
   end
 
   module LegislatureExtension
+    class Position
+      def initialize(row)
+        @row = row
+      end
+
+      def id
+        row[:id]
+      end
+
+      def name
+        row[:name]
+      end
+
+      def position
+        row[:position]
+      end
+
+      def start_date
+        parse_date(row[:start_date])
+      end
+
+      def end_date
+        parse_date(row[:end_date])
+      end
+
+      def type
+        row[:type]
+      end
+
+      private
+
+      attr_reader :row
+
+      def parse_date(date)
+        Date.new(*date.split('-').map(&:to_i))
+      end
+    end
+
+    class Positions
+      def initialize(csv_url:)
+        @csv_url = csv_url
+      end
+
+      def positions
+        csv.map { |row| Position.new(row) }
+      end
+
+      private
+
+      attr_reader :csv_url
+
+      def csv
+        CSV.parse(
+          csv_data,
+          converters:        nil,
+          headers:           true,
+          header_converters: :symbol
+        )
+      end
+
+      def csv_data
+        @csv_data ||= open(csv_url).read
+      end
+    end
+
     # UK.legislature('Commons').term(65)
     def term(termid)
       after, current, before = [nil, legislative_periods, nil]
@@ -22,6 +87,16 @@ module EveryPolitician
       current.define_singleton_method(:prev) { before }
       current.define_singleton_method(:next) { after }
       current
+    end
+
+    def positions
+      @positions ||= Positions.new(csv_url: positions_csv_url).positions
+    end
+
+    private
+
+    def positions_csv_url
+      names_url.gsub(/names\.csv$/, 'unstable/positions.csv')
     end
   end
 

--- a/t/everypolitician_extensions/legislature_extensions.rb
+++ b/t/everypolitician_extensions/legislature_extensions.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+describe 'Everypolitician::LegislatureExtension' do
+  describe 'accessing positions data' do
+    before do
+      stub_popolo('f88ce37', 'Estonia/Riigikogu')
+      stub_everypolitician_data_request('f88ce37/data/Estonia/Riigikogu/unstable/positions.csv')
+    end
+
+    let(:riigikogu) { index_at_known_sha.country('estonia').legislature('riigikogu') }
+
+    subject { riigikogu.positions.find { |p| p.id == 'e28a42b5-395d-4993-9025-f5b417edd583' } }
+
+    it 'returns the expected number of positions' do
+      riigikogu.positions.size.must_equal 110
+    end
+
+    it 'returns Position instances' do
+      subject.name.must_equal 'Andres Anvelt'
+      subject.position.must_equal 'Minister of Justice'
+      subject.start_date.must_equal Date.new(2014, 3, 26)
+      subject.end_date.must_equal Date.new(2015, 4, 9)
+    end
+  end
+end

--- a/t/fixtures/everypolitician-data/f88ce37/data/Estonia/Riigikogu/unstable/positions.csv
+++ b/t/fixtures/everypolitician-data/f88ce37/data/Estonia/Riigikogu/unstable/positions.csv
@@ -1,0 +1,111 @@
+id,name,position,start_date,end_date
+480df40f-359a-4238-b179-332d47dd1611,Aivar Sõerd,Minister of Finance,2005-04-13,2007-04-05
+e28a42b5-395d-4993-9025-f5b417edd583,Andres Anvelt,Minister of Justice,2014-03-26,2015-04-09
+062854b4-591c-4c47-83e4-bf0c20c64ef3,Andrus Ansip,Mayor of Tartu,1998-09-10,2004-09-23
+062854b4-591c-4c47-83e4-bf0c20c64ef3,Andrus Ansip,member of the European Parliament,2014-07-01,2014-10-31
+062854b4-591c-4c47-83e4-bf0c20c64ef3,Andrus Ansip,Prime Minister of Estonia,2005-04-12,2014-03-26
+062854b4-591c-4c47-83e4-bf0c20c64ef3,Andrus Ansip,European Commissioner for Digital Agenda,2014-11-01,
+062854b4-591c-4c47-83e4-bf0c20c64ef3,Andrus Ansip,Minister of Economic Affairs and Communications,2004-09-13,2005-04-13
+ca220e41-2833-436b-b94c-91273c29b73a,Anne Sulling,Minister of Foreign Trade and Entrepreneurship,2014-03-26,2015-04-09
+4ab03025-d72c-4b06-94b9-e23ec9d32e3a,Arto Aas,Minister of Public Administration,2015-04-09,
+bfbf9f5e-8ccc-44f8-ac89-700922daa181,Edgar Savisaar,Prime Minister of Estonia,1991-08-20,1992-01-29
+bfbf9f5e-8ccc-44f8-ac89-700922daa181,Edgar Savisaar,Mayor of Tallinn,2001-12,2004-10
+bfbf9f5e-8ccc-44f8-ac89-700922daa181,Edgar Savisaar,Mayor of Tallinn,2007-04-09,
+bfbf9f5e-8ccc-44f8-ac89-700922daa181,Edgar Savisaar,Minister of the Interior,2005-04-12,2005-10-10
+bfbf9f5e-8ccc-44f8-ac89-700922daa181,Edgar Savisaar,Minister of Economic Affairs and Communications,2005-04-13,2007-04-05
+32f14e80-cf5b-407c-a6a6-95fbd7f2851c,Eiki Nestor,Minister of Social Affairs,1999-03-25,2002-01-28
+6274ade3-5a81-4510-a353-bd701af44228,Eldar Efendijev,Minister of Population and Ethnic Affairs,2002-01-28,2003-04-10
+e4d2b6ca-4dbc-41d6-92cf-431d405ac4ab,Ester Tuiksoo,Minister of Agriculture,2004-04-05,2007-04-05
+03d7b8ee-b3b7-4548-a696-fd243ef706d3,Hannes Hanso,Minister of Defence,2015-09-14,
+3783663b-a6e2-4da0-abdb-ad5d5fc2d6e5,Hanno Pevkur,Minister of Justice,2012-12-10,2014-03-26
+3783663b-a6e2-4da0-abdb-ad5d5fc2d6e5,Hanno Pevkur,Minister of the Interior,2014-03-26,
+3783663b-a6e2-4da0-abdb-ad5d5fc2d6e5,Hanno Pevkur,Minister of Social Affairs,2009-02-23,2012-12-10
+134ff404-8a56-436f-8f6b-c287dc8892ce,Helir-Valdor Seeder,Minister of Agriculture,2007-04-06,2014-03-26
+134ff404-8a56-436f-8f6b-c287dc8892ce,Helir-Valdor Seeder,Minister of Finance,2009,2009
+f9e8ab84-eba2-493c-a246-e3ba6665578a,Helmen Kütt,Minister of Social Protection,2014-03-26,2015-03-30
+10ddfe8e-def5-46e9-a15f-5a76a6eb6d1b,Indrek Saar,Minister of Culture,2015-04-09,
+72e3aa88-8434-4da2-9760-0177ab88f56b,Ivari Padar,member of the European Parliament,,
+72e3aa88-8434-4da2-9760-0177ab88f56b,Ivari Padar,Minister of Agriculture,2014-04-07,
+72e3aa88-8434-4da2-9760-0177ab88f56b,Ivari Padar,Minister of Finance,2007-04-05,2009-05-21
+72e3aa88-8434-4da2-9760-0177ab88f56b,Ivari Padar,Minister of Agriculture,1999-03-25,2002-01-28
+dcab809b-7a75-4fe3-a4cf-488e510d07b9,Jaak Aaviksoo,Minister of Culture and Education,1995-11-06,1995-12-31
+dcab809b-7a75-4fe3-a4cf-488e510d07b9,Jaak Aaviksoo,Minister of Education and Research,2011-04-06,2014-03-26
+dcab809b-7a75-4fe3-a4cf-488e510d07b9,Jaak Aaviksoo,Minister of Defence,2007-04-05,2011-04-06
+dcab809b-7a75-4fe3-a4cf-488e510d07b9,Jaak Aaviksoo,Minister of Education and Research,1996-01-01,1996-11-30
+0f616bd9-0e2d-4993-bee3-c7b3a6a82708,Jaak Allik,Minister of Culture,1996-01-01,1999-03-25
+0f616bd9-0e2d-4993-bee3-c7b3a6a82708,Jaak Allik,minister without portfolio,1995-11-06,1996-01-01
+93c9f00c-5a92-45a1-bbc4-2c7899a33557,Jaan Õunapuu,Minister of Regional Affairs,2003-04-10,2007-04-05
+3fad94a9-bdd1-4fd4-bcf8-30cdf745516c,Jaanus Marrandi,Minister of Agriculture,2002-01-28,2003-04-10
+89da6035-2917-4ebe-9fcf-c927aa576942,Jaanus Tamkivi,Minister of the Environment,2007-04-05,2011-04-05
+fb7fe98f-f304-44d4-b055-24a94ba7b0c0,Jevgeni Ossinovski,Minister of Education and Research,2014-03-26,2015-04-09
+fb7fe98f-f304-44d4-b055-24a94ba7b0c0,Jevgeni Ossinovski,Minister of Health and Labour,2015-09-14,
+8288a3ee-f554-42a8-b98d-8f0f1e11bd86,Juhan Parts,Prime Minister of Estonia,2003-04-10,2005-04-12
+8288a3ee-f554-42a8-b98d-8f0f1e11bd86,Juhan Parts,Minister of Economic Affairs and Communications,2007-04-06,2014-03-26
+508adc11-672e-401d-bf60-7912e9ebf6fc,Jürgen Ligi,Minister of Finance,2009-06-04,2014-11-03
+508adc11-672e-401d-bf60-7912e9ebf6fc,Jürgen Ligi,Minister of Education and Research,2015-04-09,
+508adc11-672e-401d-bf60-7912e9ebf6fc,Jürgen Ligi,Minister of Defence,2005-10-10,2007-04-05
+3fd0711e-db41-48c3-a04c-d3128ab80066,Jüri Adams,Minister of Justice,1994-11-08,1995-04-17
+228ba218-43db-4b81-9a34-44ec36b98b24,Kaja Kallas,member of the European Parliament,2014-07-01,
+c4a5d205-2d51-495f-9c8a-36afdbf2549c,Kalle Laanet,Minister of the Interior,2005-04-13,2007-04-05
+ed651195-2f16-4074-86d0-ba81c2581f36,Keit Pentus-Rosimannus,Minister of Foreign Affairs,2014-11-17,2015-07-01
+ed651195-2f16-4074-86d0-ba81c2581f36,Keit Pentus-Rosimannus,Minister of the Environment,2011-04-06,2014-11-17
+dd71454a-fb2f-4ec4-9c51-ef0956e0d39f,Ken-Marti Vaher,Minister of Justice,2003-04-10,2005-04-13
+dd71454a-fb2f-4ec4-9c51-ef0956e0d39f,Ken-Marti Vaher,Minister of the Interior,2011-04-06,2014-03-26
+e6279173-c122-46a0-a4e1-0155c8df817c,Kristen Michal,Minister of Justice,2011-04-05,2012-12-10
+e6279173-c122-46a0-a4e1-0155c8df817c,Kristen Michal,Minister of Economic Affairs and Infrastructure,2015-04-09,
+6c6e3b63-d1ac-4744-affe-e8545737a830,Kristiina Ojuland,member of the European Parliament,,
+6c6e3b63-d1ac-4744-affe-e8545737a830,Kristiina Ojuland,Minister of Foreign Affairs,2002-01-28,2005-02-10
+f04fbe53-d4e9-4fc2-b210-d181afcac9b7,Laine Randjärv,Minister of Culture,2007-04-05,2011-04-06
+f04fbe53-d4e9-4fc2-b210-d181afcac9b7,Laine Randjärv,Mayor of Tartu,2004-09-23,2007-04-05
+12bfe340-4e98-4e45-afa2-75b4a87c373f,Mailis Reps,Minister of Education and Research,2005-04-13,2007-04-05
+12bfe340-4e98-4e45-afa2-75b4a87c373f,Mailis Reps,Minister of Education and Research,2002-01-28,2003-04-10
+8b23cd8f-fe08-4f63-a321-3aa53ae9940e,Maret Maripuu,Minister of Social Affairs,2007-04-05,2009-02-23
+a7cf5ead-b4dd-4113-bc14-62dc4990b416,Margus Hanson,Minister of Defence,2003-04-10,2004-11-22
+ac4cc87b-1de2-418e-b92d-799fce699e48,Margus Tsahkna,Minister of Social Protection,2015-04-09,
+d88222df-a90a-4cbe-ad0a-317c4556c07b,Marianne Mikko,member of the European Parliament,,
+e8cd9094-5cf9-4b4e-89bb-b1b60119cef3,Maris Lauri,Minister of Finance,2014-11-03,2015-03-30
+0259486a-0410-49f3-aef9-8b79c15741a7,Marko Pomerants,Minister of the Interior,2009-07-03,2011-04-05
+0259486a-0410-49f3-aef9-8b79c15741a7,Marko Pomerants,Minister of Social Affairs,2003-04-10,2005-04-13
+0259486a-0410-49f3-aef9-8b79c15741a7,Marko Pomerants,Minister of the Environment,2015-04-09,
+fb57a6ab-7353-4608-a7e8-6c7e8adf9997,Mart Laar,Minister of Defence,2011-04-06,2012-05-11
+fb57a6ab-7353-4608-a7e8-6c7e8adf9997,Mart Laar,member of the European Parliament,2003-04-24,2004-07-19
+fb57a6ab-7353-4608-a7e8-6c7e8adf9997,Mart Laar,Prime Minister of Estonia,1992-10-21,1994-11-08
+fb57a6ab-7353-4608-a7e8-6c7e8adf9997,Mart Laar,Prime Minister of Estonia,1999-03-25,2002-01-28
+24727280-679e-4ca3-ae34-15051aa40bcf,Mati Raidma,Minister of the Environment,2014-11-17,2015-04-09
+4abfac12-b57f-40f8-831c-15f0786e0e03,Paul-Eerik Rummo,Minister of Culture and Education,1992,1994
+4abfac12-b57f-40f8-831c-15f0786e0e03,Paul-Eerik Rummo,Minister of Education and Research,1992-10-21,1994-06-21
+4abfac12-b57f-40f8-831c-15f0786e0e03,Paul-Eerik Rummo,Minister of Population and Ethnic Affairs,2003-04-10,2007-04-05
+37157edd-5b83-4193-ba8b-7636a9b92788,Peep Aru,Minister of Regional Affairs,1997,1999
+37157edd-5b83-4193-ba8b-7636a9b92788,Peep Aru,minister without portfolio,1997-04-07,1999-03-25
+5db703d7-bdb8-4d14-b2dd-1100aa9c1671,Peeter Kreitzberg,Minister of Culture and Education,1995-04-18,1995-11-05
+fde979c9-f1b8-48c6-85e5-7448e1815ad3,Rannar Vassiljev,Minister of Health and Labour,2015-04-09,2015-09-14
+4b060a08-805e-45c3-8477-f770d4e52c1a,Rein Lang,Minister of Culture,2011-04-06,2013-12-04
+4b060a08-805e-45c3-8477-f770d4e52c1a,Rein Lang,Minister of Justice,2005-04-12,2011-04-06
+4b060a08-805e-45c3-8477-f770d4e52c1a,Rein Lang,Minister of Foreign Affairs,2005-02-21,2005-04-13
+acdfe7cf-1b7c-49c6-b3f2-46cacc8d1d24,Rein Randver,Minister of the Environment,2006-10-11,2007-04-05
+51ff72fb-c6e8-4200-984e-471441cdcc6b,Siim Valmar Kiisler,Minister of Regional Affairs,2008-01-23,2014-03-26
+fa8a4384-62a5-4d09-9b6e-1a93c6cc8ef0,Sven Mikser,Minister of Defence,2014-03-26,2015-09-14
+fa8a4384-62a5-4d09-9b6e-1a93c6cc8ef0,Sven Mikser,Minister of Defence,2002-01-28,2003-04-10
+fadf4b85-2782-4159-8a94-457448957956,Sven Sester,Minister of Finance,2015-04-09,
+6b71eefc-413d-4db6-88f0-d7ff845ebaf1,Taavi Rõivas,Prime Minister of Estonia,2014-03-26,
+6b71eefc-413d-4db6-88f0-d7ff845ebaf1,Taavi Rõivas,Minister of Social Affairs,2012-12-11,2014-03-26
+660009df-70d6-41db-9c62-a2f4b3954649,Tiit Tammsaar,Minister of Agriculture,2003-04-10,2004-04-02
+3d3d1918-5637-49e1-ae01-14a1358ad702,Tõnis Lukas,Minister of Education and Research,1999-03-25,2002-01-28
+3d3d1918-5637-49e1-ae01-14a1358ad702,Tõnis Lukas,Minister of Education and Research,2007-04-05,2011-04-05
+3d3d1918-5637-49e1-ae01-14a1358ad702,Tõnis Lukas,Mayor of Tartu,1996-10-31,1997-04-03
+06c667e1-ad6e-4d82-8881-baeeb6311493,Tõnis Palts,Minister of Finance,2003-04-10,2003-10-06
+1a8c0540-64fd-4d50-b33b-a4c37ef596a3,Urmas Klaas,Mayor of Tartu,2014-04-08,
+173df2d0-3584-4a91-bd88-abd1799f83d6,Urmas Kruuse,Minister of Health and Labour,2014-03-26,2015-03-30
+173df2d0-3584-4a91-bd88-abd1799f83d6,Urmas Kruuse,Mayor of Tartu,2007-04-26,2014-03-26
+173df2d0-3584-4a91-bd88-abd1799f83d6,Urmas Kruuse,Minister of Rural Affairs,2015-04-09,
+22d0ca41-c8a6-4475-9cad-6b932a909a48,Urmas Paet,member of the European Parliament,2014-11-03,
+22d0ca41-c8a6-4475-9cad-6b932a909a48,Urmas Paet,Minister of Culture,2003-04-10,2005-04-12
+22d0ca41-c8a6-4475-9cad-6b932a909a48,Urmas Paet,Minister of Foreign Affairs,2005-04-13,2014-11-03
+75a1da0b-ed40-418a-b412-0595bb0f617e,Urmas Reinsalu,Minister of Justice,2015-04-09,
+75a1da0b-ed40-418a-b412-0595bb0f617e,Urmas Reinsalu,Minister of Defence,2012-05-11,2014-03-26
+cdb00a6d-65c7-4f22-a8d5-57dd296b30a3,Urve Palo,Minister of Economic Affairs and Infrastructure,2014-03-26,2015-04-09
+cdb00a6d-65c7-4f22-a8d5-57dd296b30a3,Urve Palo,Minister of Entrepreneurship,2015-04-09,2015-08-30
+cdb00a6d-65c7-4f22-a8d5-57dd296b30a3,Urve Palo,Minister of Population and Ethnic Affairs,2007-04-05,2009-05-21
+13d18bf2-db98-4bda-b8b5-cf2f09c00ae9,Urve Tiidus,Minister of Culture,2013-12-04,2015-04-09
+2cced9a3-4f1c-4266-af00-a73dd22a47f9,Vilja Savisaar-Toomast,member of the European Parliament,,
+77605932-0f05-461e-8a0d-a5618f0fe6b8,Yana Toom,member of the European Parliament,2014,


### PR DESCRIPTION
# What does this do?

This pull request is a prototype of an `Everypolitician::Positions` class for interacting with position data.

# Why was this needed?

We want to add cabinet data to the term pages and in order to do this we need to interact with the position data from everypolitician-data. This data is currently in the `unstable` directory of each legislature, and therefore isn't available from the everypolitician gem yet.

# Relevant Issue(s)

- Add method for accessing legislature position data https://github.com/everypolitician/viewer-sinatra/issues/15606

# Implementation notes

I think I've actually got two changes going on here:

- Adding classes for interacting with position data
- Adding a class for getting position data from a CSV

So I think I probably want to end up with one pull request which adds the `Position` and `Positions` classes, and then a separate one that adds the `UnstablePositionCSV` class which can then return an instance of `Positions`. Then when we decide on where we want the CSVs to live we can just switch out `UnstablePositionCSV` for something else.

# Notes to Merger

⚠️  Not ready for merging