### PR TITLE
Add README for unstable position data interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,38 @@ bundle exec rake test:all
 bundle exec rake
 ```
 
+## Internal documentation
+
+### Interacting with unstable data
+
+We use data from the `unstable/positions.csv` file in a legislature's
+directory to display cabinet memberships on the website. Because this data
+is unstable there currently aren't methods in [the `everypolitician`
+gem](https://github.com/everypolitician/everypolitician-ruby) for
+interacting with it, so viewer-sinatra has some of its own classes for
+dealing with it. These classes live in the
+`lib/everypolitician_extensions.rb` file and are documented below.
+
+#### Get all cabinet memberships for a person
+
+To print all of the known cabinet memberships for a person, you can do the
+following:
+
+```ruby
+house_of_commons = Everypolitician::Index.new.country('UK').legislature('Commons')
+person = house_of_commons.popolo.persons.find_by(name: 'Gordon Brown')
+
+person.cabinet_memberships.each do |membership|
+  puts "#{person.name} was #{membership.label} #{membership.start_date} - #{membership.end_date}"
+end
+```
+
+Which will output something like this:
+
+```
+Gordon Brown was Prime Minister of the United Kingdom 2007-06-27 - 2010-05-11
+Gordon Brown was Chancellor of the Exchequer 1997-05-02 - 2007-06-27
+```
 
 ## Sinatra, SASS, styling
 


### PR DESCRIPTION
# What does this do?

This adds a section to the README with details on the expected interface for using the unstable position data.

# Why was this needed?

We want to add an interface for interacting with unstable position data to viewer-sinatra. This interface is an extension to the `EveryPolitician::Popolo::Person` class, which operates on the
`unstable/positions.csv` file in a legislature's directory in everypolitician-data.

# Relevant Issue(s)

Part of https://github.com/everypolitician/viewer-sinatra/issues/15606

- High level issue: Executive memberships https://github.com/everypolitician/viewer-sinatra/issues/24

# Implementation notes

I was originally going to add the `positions` method to the `Legislature`, but that doesn't really make sense, as it's people that hold positions, so that's where I've ended up putting the method.

In the (very near) future we'll be adding methods for filtering positions to just those that fall between two dates, so that we can show positions for a particular term. But for now this interface should give us enough to get off the ground.