### PR TITLE
Update README docs for unstable cabinet memberships

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,7 @@ directory to display cabinet memberships on the website. Because this data
 is unstable there currently aren't methods in [the `everypolitician`
 gem](https://github.com/everypolitician/everypolitician-ruby) for
 interacting with it, so viewer-sinatra has some of its own classes for
-dealing with it. These classes live in the
-`lib/everypolitician_extensions.rb` file and are documented below.
+dealing with it.
 
 #### Get all cabinet memberships for a person
 
@@ -128,8 +127,9 @@ To print all of the known cabinet memberships for a person, you can do the
 following:
 
 ```ruby
-house_of_commons = Everypolitician::Index.new.country('UK').legislature('Commons')
-person = house_of_commons.popolo.persons.find_by(name: 'Gordon Brown')
+term = Everypolitician::Index.new.country('UK').legislature('Commons').term('term/54')
+term_table = TermTable.new(term: term)
+person = term_table.people.find { |p| p.name == 'Gordon Brown' }
 
 person.cabinet_memberships.each do |membership|
   puts "#{person.name} was #{membership.label} #{membership.start_date} - #{membership.end_date}"


### PR DESCRIPTION
# What does this do?

Updates the README with a new interface for accessing the cabinet positions for a person.

# Why was this needed?

Trying to handle unstable cabinet memberships directly in the Popolo classes wasn't working because the Popolo classes (understandably) don't know anything about the world outside Popolo.

So to fix this we're going to move the logic for looking up cabinet memberships into the `TermTable` and `PersonCard` classes for now. Then once we've found a stable place for the cabinet memberships to live we can then move more of the logic into the Popolo classes or wherever makes sense.

# Relevant Issue(s)

Part of #15606 

The original pull request where I added the README for this was https://github.com/everypolitician/viewer-sinatra/pull/15609