### PR TITLE
Add documentation for Page::TermTable class

### DIFF
--- a/lib/page/term_table.rb
+++ b/lib/page/term_table.rb
@@ -77,7 +77,7 @@ module Page
       @group_data
     end
 
-    # A list of people that held a memberships at some point during this term
+    # A list of people that held a membership at some point during this term
     # @return [Array<PersonCard>]
     def people
       @people ||= term.people.sort_by { |e| [e.sort_name, e.name] }.map do |person|

--- a/lib/page/term_table.rb
+++ b/lib/page/term_table.rb
@@ -4,45 +4,67 @@ require_relative '../everypolitician_extensions'
 require_relative '../person_cards'
 
 module Page
+  # Page showing members for an individual term of a legislature.
   class TermTable
+    # @param term [EveryPolitician::LegislativePeriod]
     def initialize(term:)
       @term = term
     end
 
+    # The Page title
+    # @return [String]
     def title
       parts = [country.name, house.name, current_term.name]
       "EveryPolitician: #{parts.join(' - ')}"
     end
 
+    # A list of URLs where the data for this term came from.
+    # @return [Array<String>]
     def data_sources
       popolo.popolo[:meta][:sources]
     end
 
+    # The country that this term relates to
+    # @return [EveryPolitician::Country]
     def country
       house.country
     end
 
+    # The legislature that this term relates to
+    # @return [EveryPolitician::Legislature]
     def house
       term.legislature
     end
 
+    # Other terms for the legislature the current term relates to
+    # @return [Array<EveryPolitician::LegislativePeriod>]
     def terms
       house.legislative_periods
     end
 
+    # The next (newer) term for the current legislature
+    # @return [EveryPolitician::LegislativePeriod]
     def next_term
       term.next
     end
 
+    # The previous (older) term for the current legislature
+    # @return [EveryPolitician::LegislativePeriod]
     def prev_term
       term.prev
     end
 
+    # The current term that this class is wrapping
+    # @return [EveryPolitician::LegislativePeriod]
     def current_term
       term
     end
 
+    # Represents a count of seats/members for a given group.
     SeatCount = Struct.new(:group_id, :name, :member_count)
+
+    # A list of groups that we know about and their seat/member counts
+    # @return [Array<SeatCount>]
     def group_data
       @group_data ||= term
                       .memberships_at_end
@@ -55,6 +77,8 @@ module Page
       @group_data
     end
 
+    # A list of people that held a memberships at some point during this term
+    # @return [Array<PersonCard>]
     def people
       @people ||= term.people.sort_by { |e| [e.sort_name, e.name] }.map do |person|
         PersonCard.new(
@@ -64,8 +88,14 @@ module Page
       end
     end
 
+    # A list of symbols representing the cards we show for a person.
     CARDS = %i(social bio contacts identifiers).freeze
+
+    # Represents the percentages of information we have for each card type.
     Percentages = Struct.new(*CARDS)
+
+    # The known percentages for the various types of data we display on the site.
+    # @return [Percentages]
     def percentages
       pc = ->(card) { ((people.count { |p| p.send(card.to_s).any? } / people.count.to_f) * 100).floor }
       Percentages.new(*CARDS.map { |card| pc.call(card) })


### PR DESCRIPTION
# What does this do?

Adds YARD documentation for the `Page::TermTable` class.


# Why was this needed?

This is part of the bigger effort to document all classes in this app (https://github.com/everypolitician/viewer-sinatra/issues/15310).

# Relevant Issue(s)

Part of https://github.com/everypolitician/viewer-sinatra/issues/15310

This change should make #15606 a bit easier to document.

# Screenshots

![page-term-table-yard](https://cloud.githubusercontent.com/assets/22996/23259075/a002597e-f9cb-11e6-88e9-2aa2c0308b37.png)
