### PR TITLE
Add YARD documentation the PersonCard class

### DIFF
--- a/lib/person_cards.rb
+++ b/lib/person_cards.rb
@@ -1,44 +1,65 @@
 # frozen_string_literal: true
 
+# A single person card on the term table page
 class PersonCard
+  # @param person [Everypolitician::Popolo::Person] the person this card represents
+  # @param term [Everypolitician::LegislativePeriod] the term the card is for
   def initialize(person:, term:)
     @person          = person
     @term            = term
   end
 
+  # URL for a proxied version of the person's image
+  # @return [String]
   def proxy_image
     'https://mysociety.github.io/politician-image-proxy' \
     "/#{legislature.country.slug}/#{legislature.slug}/#{id}/140x140.jpeg"
   end
 
+  # EveryPolitician UUID for this person
+  # @return [String]
   def id
     person.id
   end
 
+  # Primary display name for this person
+  # @return [String]
   def name
     person.name
   end
 
+  # URL for the unproxied version of the person's image
+  # @return [String]
   def image
     person.image
   end
 
+  # Social media information about this person
+  # @return [Array<PersonCard::Section::CardLine>]
   def social
     Section::Social.new(person).data
   end
 
+  # Biographical information about this person
+  # @return [Array<PersonCard::Section::CardLine>]
   def bio
     Section::Bio.new(person).data
   end
 
+  # Contact details for this person
+  # @return [Array<PersonCard::Section::CardLine>]
   def contacts
     Section::Contacts.new(person).data
   end
 
+  # Identifiers for this person
+  # @return [Array<PersonCard::Section::CardLine>]
   def identifiers
     Section::Identifiers.new(person, top_identifiers: top_identifiers).data
   end
 
+  # List of memberships this person holds in the current term
+  # @return [Array<EveryPolitician::Popolo::Membership>]
   def memberships
     person.memberships.where(legislative_period_id: term.id)
   end

--- a/lib/person_cards.rb
+++ b/lib/person_cards.rb
@@ -58,7 +58,7 @@ class PersonCard
     Section::Identifiers.new(person, top_identifiers: top_identifiers).data
   end
 
-  # List of memberships this person holds in the current term
+  # List of memberships this person held in this term
   # @return [Array<EveryPolitician::Popolo::Membership>]
   def memberships
     person.memberships.where(legislative_period_id: term.id)


### PR DESCRIPTION
# What does this do?

Adds YARD documentation to the `PersonCard` class.

# Why was this needed?

We want to document all the classes in this app as part of https://github.com/everypolitician/viewer-sinatra/issues/15310.

More specifically I want to properly document the new methods I'm adding for cabinet memberships, so documenting the rest of this class first means I'm not changing the whole world at once when adding docs for that.

# Relevant Issue(s)

Part of https://github.com/everypolitician/viewer-sinatra/issues/15310

Should make https://github.com/everypolitician/viewer-sinatra/issues/15606 easier to document…

# Screenshots

![person-card-yard](https://cloud.githubusercontent.com/assets/22996/23262623/ae66c256-f9db-11e6-99f3-90e9c13655e3.png)
