### PR TITLE
Add cabinet memberships to term table

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,39 +110,6 @@ bundle exec rake test:all
 bundle exec rake
 ```
 
-## Internal documentation
-
-### Interacting with unstable data
-
-We use data from the `unstable/positions.csv` file in a legislature's
-directory to display cabinet memberships on the website. Because this data
-is unstable there currently aren't methods in [the `everypolitician`
-gem](https://github.com/everypolitician/everypolitician-ruby) for
-interacting with it, so viewer-sinatra has some of its own classes for
-dealing with it. These classes live in the
-`lib/everypolitician_extensions.rb` file and are documented below.
-
-#### Get all cabinet memberships for a person
-
-To print all of the known cabinet memberships for a person, you can do the
-following:
-
-```ruby
-house_of_commons = Everypolitician::Index.new.country('UK').legislature('Commons')
-person = house_of_commons.popolo.persons.find_by(name: 'Gordon Brown')
-
-person.cabinet_memberships.each do |membership|
-  puts "#{person.name} was #{membership.label} #{membership.start_date} - #{membership.end_date}"
-end
-```
-
-Which will output something like this:
-
-```
-Gordon Brown was Prime Minister of the United Kingdom 2007-06-27 - 2010-05-11
-Gordon Brown was Chancellor of the Exchequer 1997-05-02 - 2007-06-27
-```
-
 ## Sinatra, SASS, styling
 
 The project uses [Sinatra](http://www.sinatrarb.com), an ultra-minimal Ruby MVC web app framework.

--- a/lib/everypolitician_extensions.rb
+++ b/lib/everypolitician_extensions.rb
@@ -60,6 +60,12 @@ module EveryPolitician
       end
     end
 
+    def cabinet_memberships
+      @cabinet_memberships ||= legislature.cabinet_memberships.select do |m|
+        m.start_date >= start_date.to_s && (m.end_date.nil? || m.end_date <= end_date.to_s)
+      end
+    end
+
     def people
       @people ||= memberships.map(&:person).uniq(&:id)
     end

--- a/lib/everypolitician_extensions.rb
+++ b/lib/everypolitician_extensions.rb
@@ -23,6 +23,28 @@ module EveryPolitician
       current.define_singleton_method(:next) { after }
       current
     end
+
+    CabinetMembership = Struct.new(:person_id, :label, :start_date, :end_date)
+
+    def cabinet_memberships
+      unstable_positions.reject { |p| p[:start_date].nil? }.map do |p|
+        CabinetMembership.new(p[:id], p[:position], p[:start_date], p[:end_date])
+      end
+    end
+
+    private
+
+    def unstable_positions
+      CSV.parse(unstable_positions_csv, converters: nil, headers: true, header_converters: :symbol)
+    end
+
+    def unstable_positions_csv
+      open(unstable_positions_csv_url).read
+    end
+
+    def unstable_positions_csv_url
+      names_url.gsub(/names\.csv$/, 'unstable/positions.csv')
+    end
   end
 
   module LegislativePeriodExtension

--- a/lib/person_cards.rb
+++ b/lib/person_cards.rb
@@ -58,11 +58,25 @@ class PersonCard
     Section::Identifiers.new(person, top_identifiers: top_identifiers).data
   end
 
-  # List of memberships this person held in this term
+  # List of cabinet memberships this person held in this term
+  #
+  # @example Iterating through cabinet memberships for a {PersonCard} instance.
+  #   person_card.cabinet_memberships.each do |membership|
+  #     puts "#{person_card.name} was #{membership.label} #{membership.start_date} - #{membership.end_date}"
+  #   end
+  #
   # @return [Array<EveryPolitician::Popolo::Membership>]
-  def memberships
+  def cabinet_memberships
+    []
+  end
+
+  # List of legislative memberships this person held in this term
+  # @return [Array<EveryPolitician::Popolo::Membership>]
+  def legislative_memberships
     person.memberships.where(legislative_period_id: term.id)
   end
+
+  alias memberships legislative_memberships
 
   private
 

--- a/lib/person_cards.rb
+++ b/lib/person_cards.rb
@@ -67,7 +67,7 @@ class PersonCard
   #
   # @return [Array<EveryPolitician::Popolo::Membership>]
   def cabinet_memberships
-    []
+    term.cabinet_memberships.select { |membership| membership.person_id == id }
   end
 
   # List of legislative memberships this person held in this term

--- a/lib/person_cards.rb
+++ b/lib/person_cards.rb
@@ -65,7 +65,7 @@ class PersonCard
   #     puts "#{person_card.name} was #{membership.label} #{membership.start_date} - #{membership.end_date}"
   #   end
   #
-  # @return [Array<EveryPolitician::Popolo::Membership>]
+  # @return [Array<Everypolitician::LegislatureExtension::CabinetMembership>]
   def cabinet_memberships
     term.cabinet_memberships.select { |membership| membership.person_id == id }
   end

--- a/t/everypolitician_extensions/legislative_period_extension_test.rb
+++ b/t/everypolitician_extensions/legislative_period_extension_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+describe 'Everypolitician::LegislativePeriodExtension' do
+  describe 'getting cabinet positions' do
+    before do
+      stub_everypolitician_data_request('f88ce37/data/Estonia/Riigikogu/unstable/positions.csv')
+    end
+
+    subject { index_at_known_sha.country('Estonia').legislature('Riigikogu').term('13') }
+
+    it 'only returns cabinet positions for the legislative period' do
+      mem = subject.cabinet_memberships.first
+      mem.start_date.must_be :>=, subject.start_date.to_s
+    end
+  end
+end

--- a/t/everypolitician_extensions/legislature_extension_test.rb
+++ b/t/everypolitician_extensions/legislature_extension_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+describe 'EveryPolitician::LegislatureExtension' do
+  describe 'getting cabinet positions' do
+    before do
+      stub_everypolitician_data_request('f88ce37/data/Estonia/Riigikogu/unstable/positions.csv')
+    end
+
+    subject { index_at_known_sha.country('Estonia').legislature('Riigikogu') }
+
+    it 'has a list of cabinet memberships' do
+      subject.cabinet_memberships.size.wont_equal 0
+    end
+
+    it 'has membership instances in the list of cabinet positions' do
+      mem = subject.cabinet_memberships.first
+      mem.class.must_equal EveryPolitician::LegislatureExtension::CabinetMembership
+      mem.person_id.must_equal '480df40f-359a-4238-b179-332d47dd1611'
+      mem.start_date.must_equal '2005-04-13'
+    end
+  end
+end

--- a/t/fixtures/everypolitician-data/1a17862/data/Northern_Ireland/Assembly/unstable/positions.csv
+++ b/t/fixtures/everypolitician-data/1a17862/data/Northern_Ireland/Assembly/unstable/positions.csv
@@ -1,0 +1,145 @@
+id,name,position,start_date,end_date
+03dd24a4-f9e9-4dea-adf8-7bfc3fe891a2,Alasdair McDonnell,Member of Parliament in the United Kingdom,,
+03dd24a4-f9e9-4dea-adf8-7bfc3fe891a2,Alasdair McDonnell,Leader of the Social Democratic and Labour Party,,
+ee0b5d29-df58-43bc-91d0-0a13a18a3b24,Alex Attwood,Minister for Social Development,2010-05-24,2011-05-05
+416ad2eb-10fb-4e0c-9c12-7013af005218,Alex Maskey,Lord Mayor of Belfast,2002-06-06,2003-06-03
+2b0f1aa2-775b-4d01-b61a-65fee63791dc,Arlene Foster,"Minister of Enterprise, Trade and Investment",2008-06-09,2015-05-11
+2b0f1aa2-775b-4d01-b61a-65fee63791dc,Arlene Foster,Minister for the Environment,2007-05-08,2008-06-09
+2b0f1aa2-775b-4d01-b61a-65fee63791dc,Arlene Foster,First Minister of Northern Ireland,2016-01-11,
+2b0f1aa2-775b-4d01-b61a-65fee63791dc,Arlene Foster,Leader of the Democratic Unionist Party,2015-12-17,
+2b0f1aa2-775b-4d01-b61a-65fee63791dc,Arlene Foster,Minister of Finance and Personnel,2015-05-11,2016-01-12
+0f870089-70b2-47fb-8e14-cfc6b21a8976,Bairbre de Brún,"Minister for Health, Social Services and Public Safety",1999-12-02,2000-02-11
+0f870089-70b2-47fb-8e14-cfc6b21a8976,Bairbre de Brún,member of the European Parliament,,
+0f870089-70b2-47fb-8e14-cfc6b21a8976,Bairbre de Brún,"Minister for Health, Social Services and Public Safety",2000-05-30,2002-10-14
+aa015072-86cf-4e99-9084-4427a148d980,Billy Hutchinson,Leader of the Progressive Unionist Party,,
+66cab885-7f56-4af7-b220-fcb1e39ccdda,Brid Rodgers,Minister for Agriculture and Rural Development,1999-12-02,2000-02-11
+66cab885-7f56-4af7-b220-fcb1e39ccdda,Brid Rodgers,senator of Ireland,1983-02,1987-04
+66cab885-7f56-4af7-b220-fcb1e39ccdda,Brid Rodgers,Minister for Agriculture and Rural Development,2000-05-30,2002-10-14
+0a4a500f-ec3f-4be9-b037-b9401d47a6ca,Caitriona Ruane,Minister of Education,2007-05-08,2011-05-05
+d172f066-7fb5-4160-a802-a941e34c5425,Carmel Hanna,Minister for Employment and Learning,,
+9dab0ad2-0d34-4c8e-90f3-cb890d26a2e8,Christopher Hazzard,Minister for Infrastructure,2016-05-25,
+7c464b46-6e5f-4c55-9749-276420c2f5d2,Claire Sugden,Minister of Justice,2016-05-25,
+ab778346-f22f-4f89-af9c-234fd57ded0f,Colum Eastwood,Leader of the Social Democratic and Labour Party,,
+dc6f33f8-c7b9-4c3b-b7c5-e88a76dc2cb4,Conor Murphy,Minister for Regional Development,2007-05-08,2011-05-16
+dc6f33f8-c7b9-4c3b-b7c5-e88a76dc2cb4,Conor Murphy,Member of Parliament in the United Kingdom,,
+ed72674e-94f7-4d8f-a73f-727dd5d9c2d3,Danny Kennedy,Minister for Employment and Learning,2010-10-27,2011-05-05
+ed72674e-94f7-4d8f-a73f-727dd5d9c2d3,Danny Kennedy,Minister for Regional Development,2011-05-16,2015-09-01
+7c15122d-bc3d-43f2-a8c5-9185697c2473,David Burnside,Member of Parliament in the United Kingdom,,
+4b6c4df7-ccbb-4e20-937a-892e61e87c61,David Ervine,Leader of the Progressive Unionist Party,2002,2007
+a061dfbd-2b38-4d23-9d75-7f36fc26fb33,David Ford,Leader of the Alliance Party of Northern Ireland,2001,
+a061dfbd-2b38-4d23-9d75-7f36fc26fb33,David Ford,Minister of Justice,2010-04-12,2016-05-06
+62479dcd-b981-4a57-8a11-b8f8b17249fb,David Simpson,Member of Parliament in the United Kingdom,,
+730ef92a-dc1e-47aa-a13d-29689c2c8cbe,David Trimble,Leader of the Ulster Unionist Party,1995-09-08,2005-06-24
+730ef92a-dc1e-47aa-a13d-29689c2c8cbe,David Trimble,Member of Parliament in the United Kingdom,,
+730ef92a-dc1e-47aa-a13d-29689c2c8cbe,David Trimble,First Minister of Northern Ireland,2001-11-06,2002-10-14
+730ef92a-dc1e-47aa-a13d-29689c2c8cbe,David Trimble,First Minister of Northern Ireland,1998-07-01,2001-07-01
+8a7413f7-31e5-49f6-b5f6-9ec0004e341e,Dawn Purvis,Leader of the Progressive Unionist Party,,
+9d7969ff-df6a-4546-bfc0-032586226175,Dermot Nesbitt,Minister for the Environment,,
+6fc35bf0-2f63-4e8c-bb54-3830f149946a,Diane Dodds,member of the European Parliament,,
+2e2600ae-f727-4bff-b819-dff17cc4451d,Eddie McGrady,Member of Parliament in the United Kingdom,,
+332ec5e4-a28d-4bdb-9a0a-aafc107235fb,Edwin Poots,"Minister for Health, Social Services and Public Safety",2011-05-16,2014-09-23
+5b7e7096-92ea-4e73-9404-af99d421c4ee,Eileen Bell,Speaker of the Northern Ireland Assembly,,
+b2d32b2d-7461-44be-a8d5-127374cfdd14,Francie Molloy,Member of Parliament in the United Kingdom,2013-03-07,
+f3c3081b-9ccc-4875-92ee-c9a603c70b08,Gerry Adams,Deputy to the Dáil,,
+f3c3081b-9ccc-4875-92ee-c9a603c70b08,Gerry Adams,Member of Parliament in the United Kingdom,1997-05-01,2011-01-26
+f3c3081b-9ccc-4875-92ee-c9a603c70b08,Gerry Adams,Leader of Sinn Féin,1983-11-13,
+de99e576-546a-432b-b9c4-57ec40be15b2,Gerry Kelly,Junior Minister,2007-05-08,2011-05-16
+bcb619c2-5d73-4f33-8485-afa6dde4cdc9,Gregory Campbell,Member of Parliament in the United Kingdom,,
+bcb619c2-5d73-4f33-8485-afa6dde4cdc9,Gregory Campbell,Minister for Regional Development,2001-07-27,2001-10-24
+0f9fc03b-1408-47ed-9089-c60606d5aa1c,Ian Paisley,Member of Parliament in the United Kingdom,1970-06-18,2010-05-06
+0f9fc03b-1408-47ed-9089-c60606d5aa1c,Ian Paisley,member of the European Parliament,1979-06-07,2004-06-10
+0f9fc03b-1408-47ed-9089-c60606d5aa1c,Ian Paisley,Member of the House of Lords,2010-06-18,2014-09-12
+0f9fc03b-1408-47ed-9089-c60606d5aa1c,Ian Paisley,First Minister of Northern Ireland,2007-05-08,2008-06-05
+0f9fc03b-1408-47ed-9089-c60606d5aa1c,Ian Paisley,Leader of the Democratic Unionist Party,1971-09-30,2008-05-31
+8fd9ad33-564c-4f27-b89b-64e436c64ae8,Ian Paisley Jnr,Member of Parliament in the United Kingdom,2010-05-06,
+6318edc4-36e6-42aa-95b1-4cefaa2e7baa,Iris Robinson,Member of Parliament in the United Kingdom,1998-06-25,2010-01-13
+e71f70e4-367b-40da-8723-d95c368f5670,Jeffrey M. Donaldson,Member of Parliament in the United Kingdom,1997-05-01,
+50efb41c-8266-44d6-93a4-3f3a77c650da,Jim Allister,member of the European Parliament,2004-06-10,2009-06-04
+ef802218-ad8c-4f84-a8b2-9bc3f1b3a277,Jim Shannon,Member of Parliament in the United Kingdom,,
+a657493a-caef-4aba-95d7-a125287c036c,Jim Wells,"Minister for Health, Social Services and Public Safety",2014-09-23,2015-05-11
+bdd0518b-487c-4e2c-ac56-79f9ecc75ffe,Joe Byrne,Leader of the Social Democratic and Labour Party,,
+29afa184-19c9-42dd-b1f8-81fea2d18b6d,Joe Hendron,Member of Parliament in the United Kingdom,,
+7fdd5506-9918-4d82-ab91-b4ebbedb3f6f,John Hume,Leader of the Social Democratic and Labour Party,1979,2001-11-06
+7fdd5506-9918-4d82-ab91-b4ebbedb3f6f,John Hume,Member of Parliament in the United Kingdom,1983-06-10,2005-04-11
+7fdd5506-9918-4d82-ab91-b4ebbedb3f6f,John Hume,member of the European Parliament,1979-06-10,2004-06-13
+7fdd5506-9918-4d82-ab91-b4ebbedb3f6f,John Hume,Member of the Parliament of Northern Ireland,1969-02-24,1972-03-30
+2d18952d-caea-4751-9497-73f6a53f0fb3,John O'Dowd,deputy First Minister,2011-09-20,2011-10-31
+2d18952d-caea-4751-9497-73f6a53f0fb3,John O'Dowd,Minister of Education,2011-05-16,2016-05-25
+b83a1f37-91bc-42fd-9f0f-7b9caa9915d5,John Taylor,Member of Parliament in the United Kingdom,1983-06-09,2001-06-07
+b83a1f37-91bc-42fd-9f0f-7b9caa9915d5,John Taylor,member of the European Parliament,1979-06-10,1989-06-15
+b83a1f37-91bc-42fd-9f0f-7b9caa9915d5,John Taylor,Member of the House of Lords,,
+b83a1f37-91bc-42fd-9f0f-7b9caa9915d5,John Taylor,Member of the Parliament of Northern Ireland,1965-11-25,1972-03-30
+e1934068-6cf3-404e-956b-2e509489183a,Jonathan Bell,"Minister of Enterprise, Trade and Investment",2015-05-11,2016-05-06
+c5b2241b-bf11-4b65-a2ac-276cb3cec99c,Lord Alderdice,President of Liberal International,2005,2009
+c5b2241b-bf11-4b65-a2ac-276cb3cec99c,Lord Alderdice,Speaker of the Northern Ireland Assembly,1998-07-01,2004-02-29
+c5b2241b-bf11-4b65-a2ac-276cb3cec99c,Lord Alderdice,Member of the House of Lords,,
+c5b2241b-bf11-4b65-a2ac-276cb3cec99c,Lord Alderdice,Leader of the Alliance Party of Northern Ireland,1987,1998
+041322e5-2438-43ce-a060-7cf8ea067063,Lord Browne of Belmont,Member of the House of Lords,,
+8b40120e-84d6-4f12-b7f6-23bdd50be3cc,Margaret Ritchie,Member of Parliament in the United Kingdom,,
+8b40120e-84d6-4f12-b7f6-23bdd50be3cc,Margaret Ritchie,Leader of the Social Democratic and Labour Party,,
+8b40120e-84d6-4f12-b7f6-23bdd50be3cc,Margaret Ritchie,Minister for Social Development,2007-05-08,2010-05-24
+54414391-b30a-4ec5-996d-b9f3896cec6a,Mark Durkan,Leader of the Social Democratic and Labour Party,2001-11-06,2010-02-07
+54414391-b30a-4ec5-996d-b9f3896cec6a,Mark Durkan,Member of Parliament in the United Kingdom,2005-05-05,
+54414391-b30a-4ec5-996d-b9f3896cec6a,Mark Durkan,Minister of Finance and Personnel,2000-05-30,2001-12-14
+54414391-b30a-4ec5-996d-b9f3896cec6a,Mark Durkan,Minister of Finance and Personnel,1999-12-02,2000-02-11
+54414391-b30a-4ec5-996d-b9f3896cec6a,Mark Durkan,deputy First Minister,2001-11-06,2002-10-14
+b81ff022-4ef1-4c86-8289-77e7a102cfd4,Martin McGuinness,Minister of Education,2000-05-30,2002-10-14
+b81ff022-4ef1-4c86-8289-77e7a102cfd4,Martin McGuinness,Member of Parliament in the United Kingdom,1997-05-01,2013-01-02
+b81ff022-4ef1-4c86-8289-77e7a102cfd4,Martin McGuinness,deputy First Minister,2007-05-08,2011-09-20
+b81ff022-4ef1-4c86-8289-77e7a102cfd4,Martin McGuinness,deputy First Minister,2011-10-31,
+b81ff022-4ef1-4c86-8289-77e7a102cfd4,Martin McGuinness,Minister of Education,1999-12-02,2000-02-11
+b661183c-665e-45e7-b8ae-6bd2ae7cbb12,Martina Anderson,member of the European Parliament,,
+cf152a4f-d623-48b4-8d82-82b2188835ca,Maurice Morrow,Minister for Social Development,2016-01-12,2016-05-25
+cf152a4f-d623-48b4-8d82-82b2188835ca,Maurice Morrow,Member of the House of Lords,,
+cf152a4f-d623-48b4-8d82-82b2188835ca,Maurice Morrow,Minister for Social Development,2000-07-27,2001-10-24
+faffb0e4-11c6-4f18-9d12-cb6328c93198,Mervyn Storey,Minister of Finance and Personnel,2016-01-12,
+faffb0e4-11c6-4f18-9d12-cb6328c93198,Mervyn Storey,Minister for Social Development,2014-09-23,2016-01-12
+b25f7720-c856-4459-8aec-de016068a4d3,Michael McGimpsey,"Minister for Health, Social Services and Public Safety",2007-05-08,2011-05-05
+70f90b8a-61cc-4ccb-8f74-af51a81a8739,Michelle Gildernew,Minister for Agriculture and Rural Development,2007-05-08,2011-05-05
+70f90b8a-61cc-4ccb-8f74-af51a81a8739,Michelle Gildernew,Member of Parliament in the United Kingdom,2001-06-07,2015-03-30
+d75da776-9b07-4854-ba8c-a243f7cc4ba0,Michelle McIlveen,Minister for Regional Development,2015-09-21,2016-05-06
+d75da776-9b07-4854-ba8c-a243f7cc4ba0,Michelle McIlveen,"Minister of Agriculture, Environment and Rural Affairs",2016-05-25,
+d55656ff-50ee-47af-a347-f11ae04043ad,Michelle O'Neill,Minister for Agriculture and Rural Development,2011-05-05,2015-05-06
+d55656ff-50ee-47af-a347-f11ae04043ad,Michelle O'Neill,Minister of Health,2016-05-09,
+81a57971-6eaf-4a23-920a-ffb5e9a8337a,Máirtín Ó Muilleoir,Minister of Finance,2016-05-09,
+d0c18645-0b75-47de-96f6-6536e8b1aa60,Naomi Long,Member of Parliament in the United Kingdom,,
+25916233-649d-4681-a2db-9acf93a8deaa,Nelson McCausland,Minister for Social Development,2011-05-16,2014-09-23
+4919f61c-4016-4477-bbfe-c3c46c1e2867,Nigel Dodds,Minister of Finance and Personnel,2008-06-09,2009-07-01
+4919f61c-4016-4477-bbfe-c3c46c1e2867,Nigel Dodds,Member of Parliament in the United Kingdom,2001-06-07,
+4919f61c-4016-4477-bbfe-c3c46c1e2867,Nigel Dodds,"Minister of Enterprise, Trade and Investment",2007-05-08,2008-06-09
+4919f61c-4016-4477-bbfe-c3c46c1e2867,Nigel Dodds,Minister for Social Development,2001-10-24,2002-10-14
+4919f61c-4016-4477-bbfe-c3c46c1e2867,Nigel Dodds,Minister for Social Development,2000-05-30,2000-07-27
+4919f61c-4016-4477-bbfe-c3c46c1e2867,Nigel Dodds,Minister for Social Development,1999-12-02,2000-02-11
+0a2c25ed-bba7-4abe-8a61-309e6f358480,Pat Doherty,Vice-President of Sinn Féin,1988,2009
+0a2c25ed-bba7-4abe-8a61-309e6f358480,Pat Doherty,Member of Parliament in the United Kingdom,2001-06-07,
+11804e13-0836-4df2-afc9-6f69f88c3fc4,Paul Givan,Minister of Communities,2016-05-25,
+525fc807-2ec6-44b8-9f40-d25f0dad4422,Paul Maskey,Member of Parliament in the United Kingdom,,
+d819aab4-d610-4619-a6d6-48061df9fb76,Peter Robinson,Leader of the Democratic Unionist Party,2008-05-31,2015-12-17
+d819aab4-d610-4619-a6d6-48061df9fb76,Peter Robinson,Minister of Finance and Personnel,2007-05-08,2008-06-05
+d819aab4-d610-4619-a6d6-48061df9fb76,Peter Robinson,Member of Parliament in the United Kingdom,1979-05-03,2010-04-12
+d819aab4-d610-4619-a6d6-48061df9fb76,Peter Robinson,First Minister of Northern Ireland,2008-06-05,2016-01-11
+d819aab4-d610-4619-a6d6-48061df9fb76,Peter Robinson,Minister for Regional Development,1999-12-02,2000-02-11
+d819aab4-d610-4619-a6d6-48061df9fb76,Peter Robinson,Minister for Regional Development,2000-05-30,2001-07-27
+d819aab4-d610-4619-a6d6-48061df9fb76,Peter Robinson,Minister for Regional Development,2001-10-24,2002-10-14
+24545e0e-5f36-438b-acf2-d1fc8e0bceb2,Peter Weir,Minister of Education,2016-05-25,
+95c228ae-4850-4392-a73b-048ca6953d33,Reg Empey,Leader of the Ulster Unionist Party,2005-06-25,2010-09-22
+95c228ae-4850-4392-a73b-048ca6953d33,Reg Empey,Minister for Employment and Learning,2007-05-08,2010-10-27
+95c228ae-4850-4392-a73b-048ca6953d33,Reg Empey,First Minister of Northern Ireland,2001-07-01,2001-11-06
+95c228ae-4850-4392-a73b-048ca6953d33,Reg Empey,"Minister of Enterprise, Trade and Investment",2000-05-30,2002-10-14
+95c228ae-4850-4392-a73b-048ca6953d33,Reg Empey,"Minister of Enterprise, Trade and Investment",1999-12-02,2000-02-11
+63bbf4a4-0580-44de-be87-3e794b450d7a,Robert McCartney,Member of Parliament in the United Kingdom,,
+9091a64b-281c-425a-b044-8691dcf18053,Roy Beggs,Deputy Speaker of the Northern Ireland Assembly,2011-05-12,
+4b75917c-54a4-4c7b-a5d9-3f568accb9a7,Sammy Wilson,Minister of Finance and Personnel,2009-07-01,2013-07-29
+4b75917c-54a4-4c7b-a5d9-3f568accb9a7,Sammy Wilson,Member of Parliament in the United Kingdom,,
+4b75917c-54a4-4c7b-a5d9-3f568accb9a7,Sammy Wilson,Minister for the Environment,,
+54f1e598-c4c7-494c-8403-7020612f6ef9,Seamus Mallon,Member of Parliament in the United Kingdom,,
+54f1e598-c4c7-494c-8403-7020612f6ef9,Seamus Mallon,senator of Ireland,,
+54f1e598-c4c7-494c-8403-7020612f6ef9,Seamus Mallon,deputy First Minister,1998-07-01,2001-11-06
+69d1f1b3-f198-4678-b1da-e2e6c018f6d3,Sean Farren,Minister of Finance and Personnel,2001-12-14,2002-10-14
+1a1908a3-091e-4bde-b579-bfb44dba6efc,Simon Hamilton,Minister of Finance and Personnel,2013-07-29,2015-05-11
+1a1908a3-091e-4bde-b579-bfb44dba6efc,Simon Hamilton,"Minister for Health, Social Services and Public Safety",2015-05-11,2016-05-06
+1a1908a3-091e-4bde-b579-bfb44dba6efc,Simon Hamilton,Minister for the Economy,2016-06-25,
+a5efcb08-0421-480f-91ce-cf1e9813d87c,Stephen Farry,Minister for Employment and Learning,2011-05-05,2016-05-06
+fcf7c616-7594-418f-9cb0-6e3588f0189e,Séan Neeson,Leader of the Alliance Party of Northern Ireland,1998,2001
+274fad7a-c0cc-441e-b193-691b5f81bc15,Tom Elliott,Leader of the Ulster Unionist Party,,
+c513dd8f-99c8-4957-a607-cb1af29f680a,William McCrea,Member of Parliament in the United Kingdom,2005-05-05,2015-03-30

--- a/t/fixtures/everypolitician-data/3df153b/data/Austria/Nationalrat/unstable/positions.csv
+++ b/t/fixtures/everypolitician-data/3df153b/data/Austria/Nationalrat/unstable/positions.csv
@@ -1,0 +1,43 @@
+id,name,position,start_date,end_date
+c552adbc-0d09-49b4-8790-8d272a80ccdb,Angela Lueger,member of the Austrian federal council,,
+c552adbc-0d09-49b4-8790-8d272a80ccdb,Angela Lueger,Member of the regional parliament of Vienna,,
+b9a322ff-f617-4887-ba16-77f5449162bc,Barbara Rosenkranz,Member of the Landtag of Lower Austria,,
+08af4160-2fbe-4b3f-9bf6-2a76448e2b56,Bernhard Themessl,Member of state parliament,2003-04-02,2004-10-04
+bfd3a157-1c98-4bc1-a677-b008e124f094,"Christian Hafenecker, MA",Member of the Landtag of Lower Austria,,
+bfd3a157-1c98-4bc1-a677-b008e124f094,"Christian Hafenecker, MA",member of the Austrian federal council,,
+6dd93871-439e-4e39-b4c4-b299b3f86ca2,Christoph Hagen,member of the Austrian federal council,1999-10-20,2004-10-04
+dbcba73c-f62c-435a-9742-4efe9d3f1a7f,Doris Bures,President of the National Council of Austria,,
+bb3f73bb-e7b6-4857-96ac-5bbb21df279a,Dorothea Schittenhelm,Member of the Landtag of Lower Austria,,
+e2304422-6ef0-4839-83ed-17db5fa1f9ce,Dr. Angelika Winzig,member of the Austrian federal council,,
+fcdc3aaa-2d9c-4eaa-bdab-5d2df206649d,Dr. Erwin Rasinger,Member of the regional parliament of Vienna,,
+90cdbfe7-6448-47da-9ff8-93d4baa9f5a8,Dr. Eva Glawischnig-Piesczek,federal spokesperson of the Austrian Green Party,2008,""
+7624014f-6e71-4648-a485-7e94bf4ba197,Dr. Harald Troch,Member of the regional parliament of Vienna,,
+dc43850d-442d-4057-87b4-773473dc314a,Dr. Peter Pilz,Member of the regional parliament of Vienna,,
+1c9b1ac7-bfcb-44c4-8612-9879e4d95236,Dr. Reinhard Eugen Bösch,member of the Austrian federal council,1994-10-19,1999-10-19
+1c9b1ac7-bfcb-44c4-8612-9879e4d95236,Dr. Reinhard Eugen Bösch,Member of state parliament,1989-11-22,1994-10-03
+915eb4ab-1729-43f9-99de-e97efcb1b7ce,Dr. Ruperta Lichtenecker,member of the Austrian federal council,,
+b54c0d59-ed25-4f10-86df-f533143312f9,Elmar Podgorschek,member of the Austrian federal council,2009-10-23,2010-10-20
+e1e52b78-bbc7-4f20-b499-2cfa73a108b8,Erwin Preiner,member of the Austrian federal council,,
+f80e9fb9-4ba2-4e5d-9f68-196cbfd66b02,Fritz Grillitsch,member of the Austrian federal council,,
+6debacb9-8a42-42d3-acf3-c8df77c12e8c,Hannes Weninger,Member of the Landtag of Lower Austria,,
+3fa3bc7c-7f9b-4109-97e0-9e6a4ece455a,Heinz-Christian Strache,Member of the regional parliament of Vienna,1996,2006
+3fa3bc7c-7f9b-4109-97e0-9e6a4ece455a,Heinz-Christian Strache,chairman of the Freedom Party of Austria,2005,""
+af2602d4-b2bb-4669-b234-40c9f5e9c653,Johann Höfinger,member of the Austrian federal council,,
+ba136885-2617-4854-895b-da52e1a268a7,Konrad Antoni,Member of the Landtag of Lower Austria,,
+38088658-0e00-4f1f-b5f9-7ae991f7eaed,Leopold Steinbichler,member of the Austrian federal council,,
+50d6b692-812e-4c36-a888-79cf10355260,Mag. Alev Korun,Member of the regional parliament of Vienna,,
+cc2bf9b3-0bb6-4774-baef-70941a97701d,Mag. Andreas Schieder,Member of the regional parliament of Vienna,,
+ddd3bc16-7a62-483e-959e-178a6768a0cb,"Mag. Beate Meinl-Reisinger, MES",Member of state parliament,2015,
+ddd3bc16-7a62-483e-959e-178a6768a0cb,"Mag. Beate Meinl-Reisinger, MES",Member of the regional parliament of Vienna,,
+660f3681-570a-43db-a065-9b3945146908,Mag. Dr. Beatrix Karl,Federal Minister of Justice,,
+655d287b-d47c-4959-8010-4ffe3c40e439,Mag. Gernot Darmann,Member of state parliament,,
+70f8fed5-0d20-4d68-9846-45d4e6545eab,Mag. Harald Stefan,Member of the regional parliament of Vienna,,
+40ec7e94-6a9a-4c5f-895b-44048aea6850,Mag. Michael Hammer,member of the Austrian federal council,,
+5a1bd841-cab6-4c86-8dc1-74a92b28ac34,Mag. Ruth Becher,Member of the regional parliament of Vienna,,
+4b370b8c-ac7c-4627-a42b-99871acb5312,Mag. Wolfgang Gerstl,Member of the regional parliament of Vienna,,
+8162a184-dd41-4984-958d-a3394c4b7ac0,Martina Diesner-Wais,member of the Austrian federal council,,
+ebb6461b-13cd-4b6e-83bc-ba850e77b010,Nurten Yılmaz,Member of state parliament,2001-04-30,2013-10-28
+ebb6461b-13cd-4b6e-83bc-ba850e77b010,Nurten Yılmaz,Member of the regional parliament of Vienna,,
+9105068b-58ab-4480-917d-b38557b9d7e5,"Petra Bayr, MA",Member of the regional parliament of Vienna,,
+33f07462-d919-42e8-84b9-4c64c99c35f4,Rupert Doppler,Member of the Landtag of Salzburg,,
+790cdbdc-bcf2-49b9-90e6-d5974e06d8ec,Sigrid Maurer,Austrian Students' Association chairperson,2009,2011

--- a/t/fixtures/everypolitician-data/4da60b8/data/Bahamas/House_of_Assembly/unstable/positions.csv
+++ b/t/fixtures/everypolitician-data/4da60b8/data/Bahamas/House_of_Assembly/unstable/positions.csv
@@ -1,0 +1,12 @@
+id,name,position,start_date,end_date
+0bc913f7-434d-4648-a4d6-3ea8837a3b4a,Fred Mitchell,Member of the House of Assembly of the Bahamas,,
+bf4d389a-fd1a-4a8e-8edc-d9c178caf78c,Hubert Ingraham,Prime Minister of the Bahamas,,
+d625fce1-47b0-45e4-a412-0b72bb97ced7,Hubert Minnis,Member of the House of Assembly of the Bahamas,,
+fbc7c142-d11b-499b-8ce3-5b157289fb53,Perry Christie,Prime Minister of the Bahamas,2012-05-08,
+fbc7c142-d11b-499b-8ce3-5b157289fb53,Perry Christie,Prime Minister of the Bahamas,2002-05-03,2005-05-04
+fbc7c142-d11b-499b-8ce3-5b157289fb53,Perry Christie,Prime Minister of the Bahamas,2005-06-06,2007-05-04
+fbca8d53-3f82-445d-8dae-91c70c1753ce,Perry Gomez,Member of the House of Assembly of the Bahamas,,
+dcd1a356-a7e6-409b-8028-27fea2691105,"Philip ""Brave"" Davis",Member of the House of Assembly of the Bahamas,,
+f1850a5c-e5bf-4f43-b5e2-bc39ef0cf753,Renward Wells,Member of the House of Assembly of the Bahamas,,
+ffc68b8c-02e0-4149-9db3-ef498204280a,Ryan Pinder,Member of the House of Assembly of the Bahamas,,
+a0bd764c-7ca1-4f66-8cb6-6ead9d84c5e8,Shane Gibson,Member of the House of Assembly of the Bahamas,,

--- a/t/fixtures/everypolitician-data/6139efe/data/Australia/Representatives/unstable/positions.csv
+++ b/t/fixtures/everypolitician-data/6139efe/data/Australia/Representatives/unstable/positions.csv
@@ -1,0 +1,287 @@
+id,name,position,start_date,end_date
+04ca7bab-ab73-45c8-b153-fbd45553b6f9,Alby Schultz,Member of the New South Wales Legislative Assembly,,
+80790df5-1e09-45f0-af54-a1d47d351bc4,Alex Somlyay,"Minister for Local Government, Territories and Roads",1997,1998
+88f68da4-88de-402e-b5e7-103a8cb7e23d,Alexander Downer,Minister for Foreign Affairs,1996-03-11,2007-12-03
+c8ef8bd6-cf87-478a-99f7-a0a909c7eedf,Allan Holding,member of the Victorian Legislative Assembly,,
+2d32095d-c6bd-461b-851d-06d8d5992fe8,Allan Rocher,member of the Australian Senate,,
+78c29a5c-3db7-4df9-a286-8e2f23781747,Andrew Peacock,Minister for Foreign Affairs,,
+78c29a5c-3db7-4df9-a286-8e2f23781747,Andrew Peacock,Australian Ambassador to the United States of America,1997-02-02,1999-02
+af553f34-8f78-49c4-a075-a3ed14b23675,Andrew Robb,Minister for Trade,,
+3d5b5524-a816-4e83-bf41-15842d822581,Anna Burke,Speaker of the House of Representatives,2012-10-09,2013-11-12
+5e7b542d-5f5e-4502-9ce2-4d0d4eaafc3c,Anthony Albanese,Deputy Prime Minister of Australia,2013-06-27,2013-09-18
+5e7b542d-5f5e-4502-9ce2-4d0d4eaafc3c,Anthony Albanese,Minister for Infrastructure and Transport,2007-12-03,2013-09-18
+5e7b542d-5f5e-4502-9ce2-4d0d4eaafc3c,Anthony Albanese,"Minister for Broadband, Communications and the Digital Economy (Australia)",2013-07-01,2013-09-18
+5e7b542d-5f5e-4502-9ce2-4d0d4eaafc3c,Anthony Albanese,Minister for Infrastructure and Transport,2013-03-25,2013-07-01
+5e7b542d-5f5e-4502-9ce2-4d0d4eaafc3c,Anthony Albanese,Leader of the House,2007-12-03,2013-09-18
+5e7b542d-5f5e-4502-9ce2-4d0d4eaafc3c,Anthony Albanese,Manager of Opposition Business in the House,2006-12-10,2007-12-03
+3ff42d8e-38ab-4ac0-bb07-f7205470544a,Barnaby Joyce,member of the Australian Senate,,
+bfc6b5d0-d8a0-489f-a309-33ebe3107d02,Barry Jones,member of the Victorian Legislative Assembly,,
+ba6fa334-030f-4f71-821c-d8838c24f93a,Belinda Neal,member of the Australian Senate,,
+ef4600b0-ae4f-4492-9967-6577b2154d64,Bill Shorten,"Minister for School Education, Early Childhood and Youth",,
+ef4600b0-ae4f-4492-9967-6577b2154d64,Bill Shorten,Minister for Employment and Workplace Relations,2011-12-14,2013-07-01
+ef4600b0-ae4f-4492-9967-6577b2154d64,Bill Shorten,Leader of the Opposition,,
+68539a70-e7e2-4c79-b2e5-886cbb8c1562,Bob Debus,Member of the New South Wales Legislative Assembly,,
+863a3eed-4c04-4ba1-9c0c-7237d74c8758,Bob Katter,Member of the Queensland Legislative Assembly,,
+cae1b35f-dda6-4ef8-a3cb-e4fdc30c5d78,Bob McMullan,member of the Australian Senate,1988-02-16,1996-02-06
+cae1b35f-dda6-4ef8-a3cb-e4fdc30c5d78,Bob McMullan,Manager of Opposition Business in the House,1998-10-20,2001-11-25
+cae1b35f-dda6-4ef8-a3cb-e4fdc30c5d78,Bob McMullan,Minister for Trade,1994-01-30,1996-03-11
+cae1b35f-dda6-4ef8-a3cb-e4fdc30c5d78,Bob McMullan,Minister for the Arts,1993-03-24,1994-01-30
+99aff1ab-f411-40cb-a6cf-075a36750960,Bob Sercombe,member of the Victorian Legislative Assembly,,
+661427ef-8fbc-41ec-a11a-0e82f4fd8fc8,Bob Woods,member of the Australian Senate,,
+80f25bcb-ae3a-4efa-ab93-03ae61c21328,Brendan Nelson,Minister for Defence,2006-01-27,2007-12-03
+80f25bcb-ae3a-4efa-ab93-03ae61c21328,Brendan Nelson,"Minister for School Education, Early Childhood and Youth",2001-11-26,2006-01-27
+c03a6d98-3ea6-43eb-8666-deea8bd83d8c,Brendan O'Connor,Minister for Employment and Workplace Relations,2013-07-01,2013-09-18
+c03a6d98-3ea6-43eb-8666-deea8bd83d8c,Brendan O'Connor,Minister for Immigration and Border Protection,2013-02-04,2013-06-27
+c03a6d98-3ea6-43eb-8666-deea8bd83d8c,Brendan O'Connor,Minister for Small Business (Australia),2012-03-05,2013-02-04
+c03a6d98-3ea6-43eb-8666-deea8bd83d8c,Brendan O'Connor,Minister for Social Services,2012-03-05,2013-06-27
+c03a6d98-3ea6-43eb-8666-deea8bd83d8c,Brendan O'Connor,Minister for Human Services,2011-12-14,2012-03-05
+c03a6d98-3ea6-43eb-8666-deea8bd83d8c,Brendan O'Connor,Minister for Home Affairs,2009-06-09,2011-12-14
+25eda983-4514-4f75-98e5-4fc5c896192e,Brett Whiteley,Member of the Tasmanian House of Assembly,,
+4601db3b-81d0-4c43-a72c-018a1998838e,Brian Howe,Deputy Prime Minister of Australia,,
+a0cca46d-6808-4c89-b96a-5d064a69d145,Bronwyn Bishop,member of the Australian Senate,1987-07-01,1994-02-24
+a0cca46d-6808-4c89-b96a-5d064a69d145,Bronwyn Bishop,Speaker of the House of Representatives,2013-11-12,2015-08-02
+a0cca46d-6808-4c89-b96a-5d064a69d145,Bronwyn Bishop,Minister for Social Services,1998-10-21,2001-11-26
+a0cca46d-6808-4c89-b96a-5d064a69d145,Bronwyn Bishop,Minister for Defence Science and Personnel,1996-03-11,1998-10-21
+36f0a5b7-6933-4356-bce0-017001b56bc8,Bruce Baird,Member of the New South Wales Legislative Assembly,,
+c21652aa-ee0a-4032-8306-92b0fb2830ba,Bruce Billson,Minister for Small Business (Australia),2013-09-18,
+c21652aa-ee0a-4032-8306-92b0fb2830ba,Bruce Billson,Minister for Veterans' Affairs,2007-03-23,2007-12-03
+0a5abaf3-353f-4d67-a92c-9e28a04b3d89,Bruce Goodluck,Member of the Tasmanian House of Assembly,,
+220d2999-3f3b-4277-8580-89f5e40437e0,Carmen Lawrence,Premier of Western Australia,1990-02-12,1993-02-16
+fb9d872b-f539-42f2-a8a4-c4ec6d443274,Catherine King,Minister for Infrastructure and Transport,2013-07-01,2013-09-18
+c57b1ca8-aa30-4f6f-a47f-5cb9a44c25bc,Cheryl Kernot,member of the Australian Senate,,
+2c1c7f92-58ec-4324-b617-e65d7d35cc86,Chris Bowen,Treasurer of Australia,,
+3c0657ee-c923-4736-9aa6-54f24350418a,Craig Emerson,Minister for Trade,2010-09-14,2013-06-26
+3c0657ee-c923-4736-9aa6-54f24350418a,Craig Emerson,Minister for Industry and Innovation,2013-03-25,2013-06-26
+3c0657ee-c923-4736-9aa6-54f24350418a,Craig Emerson,Treasurer of Australia,2009-06-09,2010-09-14
+b24a9761-6f95-45bf-96a7-f3649986c1fe,Daryl Williams,Attorney-General of Australia,1996,2003
+545ec9bf-2e3c-4926-be5d-919941fb31e9,David Cowan,Minister for Primary Industries,,
+545ec9bf-2e3c-4926-be5d-919941fb31e9,David Cowan,Member of the New South Wales Legislative Assembly,,
+5e2fea8b-0d2f-4971-8551-0691e5c58367,David Fawcett,member of the Australian Senate,,
+398b960c-92c0-4183-92c1-74d35ea4ec38,David Feeney,member of the Australian Senate,,
+bbf892a5-a565-4324-891e-4f2ca8883312,David Hawker,Speaker of the House of Representatives,2004-11-16,2008-02-12
+004e5075-34b7-4ba5-b53b-f992a28ea6dc,De-Anne Kelly,Minister for Veterans' Affairs,2004-10-26,2006-01-27
+af276a32-c269-4323-a66d-4ebe510247ce,Deborah O'Neill,member of the Australian Senate,,
+0ef12804-814c-4a03-ae14-5cb04ff2aab4,Dick Adams,Member of the Tasmanian House of Assembly,,
+172920bb-3edb-4160-9c2a-5df4a2851b0d,Duncan Kerr,Attorney-General of Australia,,
+172920bb-3edb-4160-9c2a-5df4a2851b0d,Duncan Kerr,Minister for Justice,,
+90a7c69e-76e6-4283-9926-85232d454dad,Edward Mack,Member of the New South Wales Legislative Assembly,,
+5fc38a79-04c2-4e8d-bc7a-261badb9c7bc,Fran Bailey,Minister for Employment and Workplace Relations,2004-07-18,2004-10-26
+5fc38a79-04c2-4e8d-bc7a-261badb9c7bc,Fran Bailey,Minister for Small Business (Australia),2004-10-09,2007-11-24
+5fc38a79-04c2-4e8d-bc7a-261badb9c7bc,Fran Bailey,Minister for Foreign Affairs,2004-10-09,2007-11-24
+400c008e-a471-47d3-9a85-5872a2ad1751,Francis Walker,Attorney General of New South Wales,,
+400c008e-a471-47d3-9a85-5872a2ad1751,Francis Walker,Member of the New South Wales Legislative Assembly,,
+07930d8f-209a-495c-832b-ecb1ac595c9c,Frederick Chaney,member of the Australian Senate,,
+3ff31323-ccd5-4c5d-90ec-7c9c8ac3b2cf,Gareth Evans,Attorney-General of Australia,,
+3ff31323-ccd5-4c5d-90ec-7c9c8ac3b2cf,Gareth Evans,Minister for Foreign Affairs,,
+3ff31323-ccd5-4c5d-90ec-7c9c8ac3b2cf,Gareth Evans,member of the Australian Senate,,
+7335bee2-c908-4972-aa3e-8b3c0e981213,Graham Edwards,Member of the Western Australian Legislative Council,1993-02-17,1993-11-30
+7335bee2-c908-4972-aa3e-8b3c0e981213,Graham Edwards,Member of the Western Australian Legislative Council,1983-05-22,1997-05-21
+20f82432-aeea-4a72-8883-dad27cae3476,Greg Combet,"Minister for Sustainability, Environment, Water, Population and Communities (Australia)",,
+20f82432-aeea-4a72-8883-dad27cae3476,Greg Combet,Minister for Industry and Innovation,,
+84408d61-da38-48e6-a66c-dca517711fcc,Greg Hunt,"Minister for Sustainability, Environment, Water, Population and Communities (Australia)",2013-09-18,
+3aa9a44f-1fad-4690-bc3d-0d9c20ed7e08,Harry Jenkins,Speaker of the House of Representatives,2008-02-12,2011-11-24
+36d83a0d-4703-4c96-bed5-04d88791f984,Harry Woods,Member of the New South Wales Legislative Assembly,,
+e95d7765-2620-4040-98d0-2c90a07c788d,Ian Causley,Member of the New South Wales Legislative Assembly,,
+944eda62-d52d-4aed-a646-634d44f01448,Ian Macfarlane,Minister for Industry and Innovation,2013-09-18,
+944eda62-d52d-4aed-a646-634d44f01448,Ian Macfarlane,Minister for Industry and Innovation,2001-11-26,2007-12-03
+944eda62-d52d-4aed-a646-634d44f01448,Ian Macfarlane,Minister for Small Business (Australia),2001-01-30,2001-11-26
+07f7cb7b-70e9-4151-9610-6cbeb9f3807c,Ian Robinson,Member of the New South Wales Legislative Assembly,,
+e456bc4f-60df-492e-ba53-5213fb573083,Ian Sinclair,Speaker of the House of Representatives,1998-03-04,1998-11-10
+e456bc4f-60df-492e-ba53-5213fb573083,Ian Sinclair,Minister for Defence,1982,1983
+e456bc4f-60df-492e-ba53-5213fb573083,Ian Sinclair,"Minister for Broadband, Communications and the Digital Economy (Australia)",1980-11-03,1982-05-07
+e456bc4f-60df-492e-ba53-5213fb573083,Ian Sinclair,Minister for Trade,1980-08-19,1980-11-03
+e456bc4f-60df-492e-ba53-5213fb573083,Ian Sinclair,Minister for Home Affairs,1975-11-11,1975-12-22
+e456bc4f-60df-492e-ba53-5213fb573083,Ian Sinclair,"Minister for Agriculture, Fisheries and Forestry",1975-11-11,1979-09-27
+e456bc4f-60df-492e-ba53-5213fb573083,Ian Sinclair,Manager of Opposition Business in the House,1974-06-14,1975-11-11
+e456bc4f-60df-492e-ba53-5213fb573083,Ian Sinclair,Minister for Infrastructure and Transport,1968-02-28,1971-02-05
+e456bc4f-60df-492e-ba53-5213fb573083,Ian Sinclair,Minister for Human Services,1965-02-22,1968-02-28
+115a6c04-cf5a-49df-b7a5-37ccc225692c,Jackie Kelly,Minister for Sport,1998-10-21,2001-11-26
+115a6c04-cf5a-49df-b7a5-37ccc225692c,Jackie Kelly,Minister for Foreign Affairs,1998-10-21,2001-11-26
+d322608e-7f26-46dc-a20b-327e49c3234d,James Carlton,Minister for Health,1982-05-07,1983-03-11
+11af9c27-adc2-42f0-85ee-e2479c192fbf,Janelle Saffin,Member of the New South Wales Legislative Council,,
+0df71f6b-fcba-4922-943a-f9618c0eb815,Janice Crosio,Member of the New South Wales Legislative Assembly,,
+5aa64c9c-fcfd-4ed3-8880-852db5f3620c,Jenny Macklin,Minister for Social Services,2007-12-03,2013-09-18
+fe2235b1-5fa6-4af1-97d2-94ed094a6c61,Jill Hall,Member of the New South Wales Legislative Assembly,,
+5f86bf2a-28f6-421e-ae7c-e31b67dde4ad,Jim Lloyd,"Minister for Local Government, Territories and Roads",2004-07-18,2007-12-03
+632c45fc-daa4-414b-b1a9-3b0d18ad940b,Joan Child,Speaker of the House of Representatives,,
+68860e72-4069-45f5-a899-e1b717ae41ac,Joe Hockey,Treasurer of Australia,2013-09-18,
+68860e72-4069-45f5-a899-e1b717ae41ac,Joe Hockey,Minister for Employment and Workplace Relations,2007-01-30,2007-12-03
+68860e72-4069-45f5-a899-e1b717ae41ac,Joe Hockey,Manager of Opposition Business in the House,2007-12-02,2009-02-16
+68860e72-4069-45f5-a899-e1b717ae41ac,Joe Hockey,Minister for Human Services,2004-10-26,2007-01-30
+68860e72-4069-45f5-a899-e1b717ae41ac,Joe Hockey,Minister for Small Business (Australia),2001-11-26,2004-10-26
+68860e72-4069-45f5-a899-e1b717ae41ac,Joe Hockey,Australian Ambassador to the United States of America,2016-01-29,""
+2a7adf62-5fc7-4d05-8e3f-71615d79c513,Joel Fitzgibbon,"Minister for Agriculture, Fisheries and Forestry",2013-07-02,2013-09-18
+2a7adf62-5fc7-4d05-8e3f-71615d79c513,Joel Fitzgibbon,Minister for Defence,2007-12-03,2009-06-04
+e6a12e0e-525e-4581-bf90-12e2d0693ae0,John Anderson,Deputy Prime Minister of Australia,1999-07-20,2005-07-06
+e6a12e0e-525e-4581-bf90-12e2d0693ae0,John Anderson,Minister for Infrastructure and Transport,1998-10-21,2005-07-06
+e6a12e0e-525e-4581-bf90-12e2d0693ae0,John Anderson,"Minister for Agriculture, Fisheries and Forestry",1996-03-11,1998-10-21
+ca055ef1-1239-47f5-aa37-1ed0bec31036,John Andrew,Speaker of the House of Representatives,1998-11-10,2004-11-16
+98e9bb15-b93f-47d4-9299-069b51a7c000,John Brumby,member of the Victorian Legislative Assembly,1993-06-01,2011-02-19
+98e9bb15-b93f-47d4-9299-069b51a7c000,John Brumby,Member of the Victorian Legislative Council,,
+98e9bb15-b93f-47d4-9299-069b51a7c000,John Brumby,Premier of Victoria,2007-07-30,2010-12-02
+0da7fd3e-f987-4052-a77e-703258c5e1c3,John Dawkins,Minister for Finance,,
+4df78d42-c788-42c8-a0ec-b168cacdbacd,John Fahey,Premier of New South Wales,,
+4df78d42-c788-42c8-a0ec-b168cacdbacd,John Fahey,Member of the New South Wales Legislative Assembly,,
+d8d13c39-6479-4290-956d-ce043ee8959e,John Howard,Prime Minister of Australia,1996-03-11,2007-12-03
+d8d13c39-6479-4290-956d-ce043ee8959e,John Howard,Treasurer of Australia,1977-11-19,1983-03-11
+d8d13c39-6479-4290-956d-ce043ee8959e,John Howard,Leader of the Opposition,1985-09-05,1989-05-09
+d8d13c39-6479-4290-956d-ce043ee8959e,John Howard,Leader of the Opposition,1995-01-30,1996-03-11
+d8d13c39-6479-4290-956d-ce043ee8959e,John Howard,Minister for Finance,,
+1b41a3c2-aff5-430c-ba3d-de3630928a5f,John Moore,Minister for Defence,1998-10-21,2001-01-30
+1b41a3c2-aff5-430c-ba3d-de3630928a5f,John Moore,Vice-President of the Executive Council,1996-03-11,1998-10-21
+1b41a3c2-aff5-430c-ba3d-de3630928a5f,John Moore,Minister for Industry and Innovation,1996-03-11,1998-10-21
+1b41a3c2-aff5-430c-ba3d-de3630928a5f,John Moore,Treasurer of Australia,1980-11-03,1981-04-20
+ea8539d3-9a85-4b9c-a2a4-203a1e3ac6c8,Jon Sullivan,Member of the Queensland Legislative Assembly,,
+de9e6817-73f5-4afc-aa26-951759bbed59,Julia Gillard,Prime Minister of Australia,2010-06-24,2013-06-27
+de9e6817-73f5-4afc-aa26-951759bbed59,Julia Gillard,Deputy Prime Minister of Australia,2007-12-03,2010-06-24
+de9e6817-73f5-4afc-aa26-951759bbed59,Julia Gillard,"Minister for School Education, Early Childhood and Youth",2007-12-03,2010-06-28
+de9e6817-73f5-4afc-aa26-951759bbed59,Julia Gillard,Minister for Employment and Workplace Relations,2007-12-03,2010-06-28
+de9e6817-73f5-4afc-aa26-951759bbed59,Julia Gillard,Minister for Social Inclusion (Australia),2007-12-03,2010-06-28
+de9e6817-73f5-4afc-aa26-951759bbed59,Julia Gillard,Manager of Opposition Business in the House,2003-12-08,2006-12-10
+de9e6817-73f5-4afc-aa26-951759bbed59,Julia Gillard,Commonwealth Chairperson-in-Office,2011-10-28,2013-06-27
+237da068-da81-4edb-b4cf-4745ddd5a808,Julie Bishop,Minister for Foreign Affairs,2013-09-18,
+237da068-da81-4edb-b4cf-4745ddd5a808,Julie Bishop,"Minister for School Education, Early Childhood and Youth",2006-01-27,2007-12-03
+237da068-da81-4edb-b4cf-4745ddd5a808,Julie Bishop,Minister for the Status of Women,2006-01-27,2007-12-03
+237da068-da81-4edb-b4cf-4745ddd5a808,Julie Bishop,Minister for Social Services,2003-10-07,2006-01-27
+fb80ed6f-bd18-4812-8ef8-ad35abe4832e,Kate Ellis,Minister for Sport,,
+ab6f212e-e038-4ee8-8834-0ab38a1f1a6b,Kathy Sullivan,member of the Australian Senate,,
+aece605a-f632-40d3-ab61-67ae91b943aa,Keith Wright,Member of the Queensland Legislative Assembly,,
+173b018e-63fc-45c2-9f24-27267660e98f,Kevin Andrews,Minister for Immigration and Border Protection,2007-01-30,2007-12-03
+173b018e-63fc-45c2-9f24-27267660e98f,Kevin Andrews,Minister for Employment and Workplace Relations,2003-10-07,2007-01-30
+173b018e-63fc-45c2-9f24-27267660e98f,Kevin Andrews,Minister for Defence,2014-12-23,
+173b018e-63fc-45c2-9f24-27267660e98f,Kevin Andrews,Minister for Social Services,2013-09-18,2014-12-23
+173b018e-63fc-45c2-9f24-27267660e98f,Kevin Andrews,Minister for Social Services,2001-11-26,2003-10-07
+b60d9dc8-1e12-4439-b2c0-b2c70271b1be,Kevin Rudd,Prime Minister of Australia,2013-06-27,2013-09-18
+b60d9dc8-1e12-4439-b2c0-b2c70271b1be,Kevin Rudd,Minister for Foreign Affairs,2010-09-14,2012-02-22
+b60d9dc8-1e12-4439-b2c0-b2c70271b1be,Kevin Rudd,Prime Minister of Australia,2007-12-03,2010-06-24
+b60d9dc8-1e12-4439-b2c0-b2c70271b1be,Kevin Rudd,Commonwealth Chairperson-in-Office,2013-06-27,2013-09-18
+a51e06dc-8b86-4446-a429-44340ce89ef6,Kim Beazley,Leader of the Opposition,2005-01-28,2006-12-04
+a51e06dc-8b86-4446-a429-44340ce89ef6,Kim Beazley,Deputy Prime Minister of Australia,1995-06-20,1996-03-11
+a51e06dc-8b86-4446-a429-44340ce89ef6,Kim Beazley,Minister for Finance,1993-12-23,1996-03-11
+a51e06dc-8b86-4446-a429-44340ce89ef6,Kim Beazley,Australian Ambassador to the United States of America,2010-02-17,2016-01-22
+92e79fd2-dff4-4fec-9f8f-54806f618b6f,Laurence Brereton,Member of the New South Wales Legislative Assembly,,
+2ce06784-37bf-4da0-ace2-32540367ef82,Laurie Ferguson,Member of the New South Wales Legislative Assembly,,
+ebc537f6-e5bc-4ffc-932b-ddf1a3445a93,Leo McLeay,Speaker of the House of Representatives,1989-08-29,1993-02-08
+3d3bce1f-74e0-44fe-bb82-b72071c9f37d,Lindsay Tanner,Minister for Finance,2007-12-03,2010-09-03
+bd1a8e27-d72b-4e12-9cb8-396259658264,Lionel Bowen,Deputy Prime Minister of Australia,1983-03-11,1990-04-04
+bd1a8e27-d72b-4e12-9cb8-396259658264,Lionel Bowen,Member of the New South Wales Legislative Assembly,,
+bd1a8e27-d72b-4e12-9cb8-396259658264,Lionel Bowen,Attorney-General of Australia,1984-12-13,1990-04-04
+bd1a8e27-d72b-4e12-9cb8-396259658264,Lionel Bowen,Vice-President of the Executive Council,1983-07-14,1987-07-24
+bd1a8e27-d72b-4e12-9cb8-396259658264,Lionel Bowen,Minister for Trade,1983-03-11,1984-12-13
+bd1a8e27-d72b-4e12-9cb8-396259658264,Lionel Bowen,Minister for Industry and Innovation,1975-06-06,1975-11-11
+bd1a8e27-d72b-4e12-9cb8-396259658264,Lionel Bowen,"Minister for Broadband, Communications and the Digital Economy (Australia)",1972-12-19,1974-06-12
+db495034-394f-4527-aa6f-a798884139da,Louis Lieberman,member of the Victorian Legislative Assembly,,
+8e5a9eba-fa55-4bfc-b899-74345d3abd20,Luke Hartsuyker,Minister for Employment and Workplace Relations,2013-09-18,
+66b4276a-0477-49b7-ac44-fcef5724f171,Mal Brough,Minister for Social Services,2006-01-27,2007-12-03
+66b4276a-0477-49b7-ac44-fcef5724f171,Mal Brough,Treasurer of Australia,2004-07-18,2006-01-27
+66b4276a-0477-49b7-ac44-fcef5724f171,Mal Brough,Minister for Employment and Workplace Relations,2001-02-14,2004-07-18
+5a5ab335-91bf-46ae-8972-07684b2d7065,Malcolm Turnbull,"Minister for Broadband, Communications and the Digital Economy (Australia)",2013-09-18,2015-09-21
+5a5ab335-91bf-46ae-8972-07684b2d7065,Malcolm Turnbull,Leader of the Opposition,2008-09-16,2009-12-01
+5a5ab335-91bf-46ae-8972-07684b2d7065,Malcolm Turnbull,"Minister for Sustainability, Environment, Water, Population and Communities (Australia)",2007-01-30,2007-12-03
+5a5ab335-91bf-46ae-8972-07684b2d7065,Malcolm Turnbull,Prime Minister of Australia,2015-09-15,
+6e258077-ec34-4510-a9e5-dc88b2a1013f,Mark Dreyfus,Attorney-General of Australia,2013-02-04,2013-09-18
+210671e4-c2ad-47c3-9765-79682f94a61c,Mark Latham,Manager of Opposition Business in the House,2003-06-16,2003-12-08
+951429f2-6028-4e25-bc9f-6eb72e3153b5,Mark Vaile,Deputy Prime Minister of Australia,2005-07-06,2007-12-03
+951429f2-6028-4e25-bc9f-6eb72e3153b5,Mark Vaile,Minister for Infrastructure and Transport,1997-09-25,1998-10-21
+951429f2-6028-4e25-bc9f-6eb72e3153b5,Mark Vaile,"Minister for Agriculture, Fisheries and Forestry",1998-10-21,1999-07-19
+951429f2-6028-4e25-bc9f-6eb72e3153b5,Mark Vaile,Minister for Trade,1999-07-20,2006-09-19
+24916f17-eeee-4b1e-b1de-4c8dee914789,Martin Ferguson,Minister for Foreign Affairs,2007-12-03,2013-03-22
+24916f17-eeee-4b1e-b1de-4c8dee914789,Martin Ferguson,Minister for Industry and Innovation,2007-12-03,2013-03-22
+c661e56b-5774-4b2c-aaf6-2ea5084d798d,Matt Thistlethwaite,member of the Australian Senate,,
+869843cd-7dd0-417d-8325-7fa72bbbbab1,Michael Ferguson,Member of the Tasmanian House of Assembly,,
+764ba518-ae56-49c1-9dea-fbe45772df5a,Michael Keenan,Minister for Justice,,
+012988dd-b93f-4bfe-95b8-27f3e5a56ee7,Michael Ronaldson,Minister for Veterans' Affairs,,
+012988dd-b93f-4bfe-95b8-27f3e5a56ee7,Michael Ronaldson,Special Minister of State,,
+012988dd-b93f-4bfe-95b8-27f3e5a56ee7,Michael Ronaldson,member of the Australian Senate,,
+d6186a2c-cda9-4569-871a-a531ff501642,Michelle O'Byrne,Member of the Tasmanian House of Assembly,,
+37650453-f86f-40b1-8cd1-a577920581c2,Neville Newell,Member of the New South Wales Legislative Assembly,,
+1724df08-91f6-4bb4-bdf1-f7dabb6b646d,Nicholas Reid,Member of the Victorian Legislative Council,,
+2ae6720c-a5c0-49f1-b7e8-3bae8de0a912,Nicola Roxon,Attorney-General of Australia,,
+8053add0-8534-41f5-8795-36fd6b506c7c,Paul Keating,Prime Minister of Australia,1991-12-20,1996-03-11
+8053add0-8534-41f5-8795-36fd6b506c7c,Paul Keating,Deputy Prime Minister of Australia,1990-04-04,1991-06-03
+8053add0-8534-41f5-8795-36fd6b506c7c,Paul Keating,Treasurer of Australia,1983-03-11,1991-06-03
+8053add0-8534-41f5-8795-36fd6b506c7c,Paul Keating,Minister for Home Affairs,1975-10-21,1975-11-11
+b10ac18f-7f76-42c9-b888-4083bb0527f6,Paul Zammit,Member of the New South Wales Legislative Assembly,,
+4cf597a9-53d6-4276-8285-ea93b96ff7de,Peter Baldwin,Member of the New South Wales Legislative Council,,
+070e98b1-f244-4d3d-bbfc-0e7065319dd7,Peter Costello,Treasurer of Australia,1996-03-11,2007-12-03
+c8f6b8fc-89cc-4bd4-8c10-4ca5743b67bc,Peter Duncan,Member of the South Australian House of Assembly,,
+9a1c33f3-0669-4394-bc78-647fa291a7b9,Peter Dutton,Minister for Health,2013-09-18,2014-12-23
+9a1c33f3-0669-4394-bc78-647fa291a7b9,Peter Dutton,Minister for Sport,2013-09-18,2014-12-23
+9a1c33f3-0669-4394-bc78-647fa291a7b9,Peter Dutton,Minister for Employment and Workplace Relations,2004-10-26,2006-01-27
+9a1c33f3-0669-4394-bc78-647fa291a7b9,Peter Dutton,Minister for Immigration and Border Protection,2014-12-23,
+9a1c33f3-0669-4394-bc78-647fa291a7b9,Peter Dutton,Treasurer of Australia,2006-01-27,2007-12-03
+ae157a7a-f03f-4a63-af45-6a67949e925c,Peter Garrett,"Minister for School Education, Early Childhood and Youth",2010-09-14,2013-06-26
+ae157a7a-f03f-4a63-af45-6a67949e925c,Peter Garrett,"Minister for Sustainability, Environment, Water, Population and Communities (Australia)",2010-03-08,2010-09-14
+54e901fd-176b-401f-ae25-727f10c36467,Peter Reith,Minister for Employment and Workplace Relations,1998-10-21,2001-01-30
+e2caf09d-a2e2-4074-8557-ad8eac8e98b2,Peter Slipper,Speaker of the House of Representatives,2011-11-24,2012-10-09
+4c474616-ed09-4b81-a6e8-c8ba237d9910,Peter White,Member of the Queensland Legislative Assembly,,
+f1c9d1e7-2b35-4880-af34-5ef0efbd32c9,Philip Ruddock,Attorney-General of Australia,,
+2e2e2ee2-e26a-4aaf-848a-f69936831fbf,Ralph Willis,Minister for Finance,,
+b57a6967-7138-4ded-99b5-7733f2811957,Raymond Hall,Member of the Parliament of South Australia,,
+b57a6967-7138-4ded-99b5-7733f2811957,Raymond Hall,member of the Australian Senate,,
+3fd4942a-8efc-4277-b8ba-c4eccee2bff7,Richard Marles,Minister for Trade,,
+55afc35c-d6ad-4c91-ba35-529d43a84067,Rob Hulls,Deputy Premier of Victoria,,
+55afc35c-d6ad-4c91-ba35-529d43a84067,Rob Hulls,member of the Victorian Legislative Assembly,,
+a80785a4-a4b0-4695-861c-203eb2eda269,Rob Mitchell,Member of the Victorian Legislative Council,,
+ee32675f-e2e7-489a-91f1-c4b402e18377,Robert Brown,Member of the New South Wales Legislative Assembly,,
+3dc2a9b9-b10a-4b18-96c8-77d86bf17a55,Robert Halverson,Speaker of the House of Representatives,1996-04-30,1998-03-03
+e32069fc-103d-436e-8ad9-4e8408172967,Robert Hawke,Prime Minister of Australia,1983-03-11,1991-12-20
+e32069fc-103d-436e-8ad9-4e8408172967,Robert Hawke,Treasurer of Australia,1991-06-02,1991-06-04
+ec10508f-c56c-4477-bcf6-1ff0cb2c30b8,Robert McClelland,Vice-President of the Executive Council,2010-09-13,2012-03-05
+ec10508f-c56c-4477-bcf6-1ff0cb2c30b8,Robert McClelland,Attorney-General of Australia,2007-12-03,2011-12-14
+2d04937c-3c55-488b-93b9-f14010ffddaa,Robert Oakeshott,Member of the New South Wales Legislative Assembly,,
+a99beff7-e023-4d3c-908f-a0dfd5126b6a,Scott Morrison,Minister for Immigration and Border Protection,2013-09-18,2014-12-23
+a99beff7-e023-4d3c-908f-a0dfd5126b6a,Scott Morrison,Minister for Social Services,2014-12-23,2015-09-21
+a99beff7-e023-4d3c-908f-a0dfd5126b6a,Scott Morrison,Treasurer of Australia,2015-09-21,
+cc4b24f0-609e-4c82-9dc0-ae36450f4819,Sharman Stone,Minister for Employment and Workplace Relations,2006-01-27,2007-12-03
+b88d8ede-6d60-4e77-8376-f83c0f8a9ede,Simon Crean,Minister for Infrastructure and Transport,2010-09-14,2013-03-21
+b88d8ede-6d60-4e77-8376-f83c0f8a9ede,Simon Crean,Minister for the Arts,2010-09-14,2013-03-21
+b88d8ede-6d60-4e77-8376-f83c0f8a9ede,Simon Crean,"Minister for School Education, Early Childhood and Youth",2010-06-28,2010-09-14
+b88d8ede-6d60-4e77-8376-f83c0f8a9ede,Simon Crean,Minister for Employment and Workplace Relations,2010-06-28,2010-09-14
+b88d8ede-6d60-4e77-8376-f83c0f8a9ede,Simon Crean,Minister for Social Inclusion (Australia),2010-06-28,2010-09-14
+b88d8ede-6d60-4e77-8376-f83c0f8a9ede,Simon Crean,Minister for Trade,2007-12-03,2010-06-28
+b88d8ede-6d60-4e77-8376-f83c0f8a9ede,Simon Crean,"Minister for Agriculture, Fisheries and Forestry",1991-06-04,1993-12-23
+b88d8ede-6d60-4e77-8376-f83c0f8a9ede,Simon Crean,Minister for Industry and Innovation,1990-04-04,1991-06-04
+e65961ae-3861-4e51-84f4-dba556be6e41,Stephen Martin,Speaker of the House of Representatives,,
+55ac10c6-26e5-4ae6-a53a-96c09550608a,Stephen Mutch,Member of the New South Wales Legislative Council,,
+45c19310-398d-4845-832a-54a89032eef1,Stephen Smith,Minister for Defence,2010-09-13,2013-09-18
+45c19310-398d-4845-832a-54a89032eef1,Stephen Smith,Minister for Trade,2010-06-28,2010-09-13
+45c19310-398d-4845-832a-54a89032eef1,Stephen Smith,Minister for Foreign Affairs,2007-12-03,2010-09-13
+19bb42b5-6320-4873-96f7-541c49aa8283,Sussan Ley,Minister for Health,2014-12-23,
+19bb42b5-6320-4873-96f7-541c49aa8283,Sussan Ley,Minister for Sport,2014-12-23,
+19bb42b5-6320-4873-96f7-541c49aa8283,Sussan Ley,"Minister for School Education, Early Childhood and Youth",2013-09-18,2014-12-23
+19bb42b5-6320-4873-96f7-541c49aa8283,Sussan Ley,Minister for Aged Care,2015-09-30,
+0616de82-e619-4c65-9e57-239c3cae05a0,Tanya Plibersek,Minister for Health,2011-12-14,2013-09-18
+0616de82-e619-4c65-9e57-239c3cae05a0,Tanya Plibersek,Minister for Human Services,2010-09-14,2011-12-14
+0616de82-e619-4c65-9e57-239c3cae05a0,Tanya Plibersek,Minister for Social Inclusion (Australia),2010-09-14,2011-12-14
+0616de82-e619-4c65-9e57-239c3cae05a0,Tanya Plibersek,Minister for Social Services,2007-12-03,2010-09-14
+1a9410b0-e029-492f-b9d4-0a045c3fa00f,Tim Fischer,Member of the New South Wales Legislative Assembly,,
+1a9410b0-e029-492f-b9d4-0a045c3fa00f,Tim Fischer,Deputy Prime Minister of Australia,1996-03-11,1999-07-20
+1a9410b0-e029-492f-b9d4-0a045c3fa00f,Tim Fischer,Minister for Trade,1996-03-11,1999-07-20
+93e2e4cc-f5ce-4bea-be68-2fc86c38a9bc,Tony Abbott,Prime Minister of Australia,2013-09-18,2015-09-15
+93e2e4cc-f5ce-4bea-be68-2fc86c38a9bc,Tony Abbott,Leader of the Opposition,2009-12-01,2013-09-18
+93e2e4cc-f5ce-4bea-be68-2fc86c38a9bc,Tony Abbott,Leader of the House,2001-11-26,2007-12-03
+93e2e4cc-f5ce-4bea-be68-2fc86c38a9bc,Tony Abbott,Minister for Health,2003-10-07,2007-12-03
+93e2e4cc-f5ce-4bea-be68-2fc86c38a9bc,Tony Abbott,Minister for Employment and Workplace Relations,1998-10-21,2003-10-07
+93e2e4cc-f5ce-4bea-be68-2fc86c38a9bc,Tony Abbott,Commonwealth Chairperson-in-Office,2013-09-18,2013-11-15
+a1d66b71-f8dd-490e-a31d-e1a4bdcc66d6,Tony Burke,Minister for Immigration and Border Protection,,
+a1d66b71-f8dd-490e-a31d-e1a4bdcc66d6,Tony Burke,Member of the New South Wales Legislative Council,,
+eee6e93f-7522-409b-8def-130ae7d972ad,Tony Smith,Speaker of the House of Representatives,2015-08-10,
+af6256ac-35db-4dbf-875a-59d887688c71,Tony Windsor,Member of the New South Wales Legislative Assembly,1991-05-25,2001-10-16
+08ca7ace-5d2c-44a4-9539-b9cadac7bc86,Wallace Fife,Member of the New South Wales Legislative Assembly,,
+e7a0b6bc-6eb4-4ca4-8f7d-49b8662b22f3,Warren Snowdon,Minister for Veterans' Affairs,2010-09-13,2013-09-18
+e7a0b6bc-6eb4-4ca4-8f7d-49b8662b22f3,Warren Snowdon,Minister for Defence Science and Personnel,2010-09-14,2013-09-18
+9ee397bd-f7a6-4e50-b7be-653d1493aeee,Warren Truss,Deputy Prime Minister of Australia,2013-09-18,
+9ee397bd-f7a6-4e50-b7be-653d1493aeee,Warren Truss,Minister for Infrastructure and Transport,2013-09-18,
+9ee397bd-f7a6-4e50-b7be-653d1493aeee,Warren Truss,Minister for Trade,2006-08-10,2007-12-03
+9ee397bd-f7a6-4e50-b7be-653d1493aeee,Warren Truss,Minister for Infrastructure and Transport,2005-07-06,2006-08-10
+9ee397bd-f7a6-4e50-b7be-653d1493aeee,Warren Truss,"Minister for Agriculture, Fisheries and Forestry",1999-07-20,2005-07-06
+36bf7714-2320-4cfd-a8df-8d7080ae9c64,Wayne Swan,Deputy Prime Minister of Australia,2010-06-24,2013-06-27
+36bf7714-2320-4cfd-a8df-8d7080ae9c64,Wayne Swan,Treasurer of Australia,2007-12-03,2013-06-27
+36bf7714-2320-4cfd-a8df-8d7080ae9c64,Wayne Swan,Minister for Finance,2010-09-03,2010-09-14
+36bf7714-2320-4cfd-a8df-8d7080ae9c64,Wayne Swan,Manager of Opposition Business in the House,2001-11-25,2003-06-16
+f19428fd-f51a-4d26-9163-714be54f5c3b,William Hayden,Governor-General of Australia,1989-02-16,1996-02-16
+f19428fd-f51a-4d26-9163-714be54f5c3b,William Hayden,Minister for Foreign Affairs,1983-03-11,1988-08-17
+f19428fd-f51a-4d26-9163-714be54f5c3b,William Hayden,Treasurer of Australia,1975-06-06,1975-11-11
+f19428fd-f51a-4d26-9163-714be54f5c3b,William Hayden,Minister for Human Services,1972-12-19,1975-06-06
+d61fb3e8-77af-4fb2-90fd-dfad16c2afbc,Wilson Tuckey,"Minister for Local Government, Territories and Roads",2001,2003

--- a/t/fixtures/everypolitician-data/75b7651/data/Malaysia/Dewan_Rakyat/unstable/positions.csv
+++ b/t/fixtures/everypolitician-data/75b7651/data/Malaysia/Dewan_Rakyat/unstable/positions.csv
@@ -1,0 +1,39 @@
+id,name,position,start_date,end_date
+478c49bc-68f4-4d11-85ea-75ea9bed389e,Abdul Razak Hussein,Prime Minister of Malaysia,1970-09-22,1976-01-14
+478c49bc-68f4-4d11-85ea-75ea9bed389e,Abdul Razak Hussein,Deputy Prime Minister of Malaysia,1957-08-31,1970-09-22
+478c49bc-68f4-4d11-85ea-75ea9bed389e,Abdul Razak Hussein,Minister of Defence,,
+478c49bc-68f4-4d11-85ea-75ea9bed389e,Abdul Razak Hussein,Minister of Foreign Affairs,,
+dee0e874-677e-4aed-92ab-c6502e35d2ef,Abdullah Ahmad Badawi,Prime Minister of Malaysia,2003-10-31,2009-04-03
+dee0e874-677e-4aed-92ab-c6502e35d2ef,Abdullah Ahmad Badawi,Deputy Prime Minister of Malaysia,1999-01-29,2003-10-31
+dee0e874-677e-4aed-92ab-c6502e35d2ef,Abdullah Ahmad Badawi,Minister of Defence,,
+dee0e874-677e-4aed-92ab-c6502e35d2ef,Abdullah Ahmad Badawi,Minister of Foreign Affairs,,
+4a15de6c-7a19-4a82-9305-094d0a2bd6e6,Abu Hassan Omar,Minister of Foreign Affairs,,
+bc356d91-988a-404c-a1a1-13c8288225e1,Ahmad Zahid Hamidi,Minister of Defence,,
+8208e6e1-e3f3-4c7a-8818-1451cfcfbd7f,Anifah Aman,Minister of Foreign Affairs,,
+49d4fb95-f6b0-4367-8eae-686f818b6926,Ghazali Shafie,Minister of Foreign Affairs,,
+d07ddd90-781b-45f1-a8f3-5867cf4e89b9,Hishammuddin Hussein,Minister of Defence,,
+36c3a6e4-e35b-421b-a184-8080730b64b0,Hussein Onn,Prime Minister of Malaysia,1976-01-15,1981-07-16
+36c3a6e4-e35b-421b-a184-8080730b64b0,Hussein Onn,Deputy Prime Minister of Malaysia,1973-08-13,1976-01-15
+2cad0aa1-f922-4281-8d9e-3ce5df7715fa,Ismail Abdul Rahman,Minister of Foreign Affairs,,
+025e9b75-c8f8-4f7e-a558-dc29afa0b0ff,Koh Tsu Koon,Chief Minister of Penang,,
+344f8a0c-ed23-421e-9c25-fd8c8084336b,Lim Chong Eu,Chief Minister of Penang,,
+3605c889-a8c5-4e2d-b819-048cf76ec0f9,Lim Guan Eng,Chief Minister of Penang,,
+e91f5907-a6ce-4805-9fa6-7e431366e052,Mahathir Mohamad,Prime Minister of Malaysia,1981-07-16,2003-10-31
+e91f5907-a6ce-4805-9fa6-7e431366e052,Mahathir Mohamad,Deputy Prime Minister of Malaysia,1976-03-05,1981-07-16
+e91f5907-a6ce-4805-9fa6-7e431366e052,Mahathir Mohamad,Minister of Defence,,
+1247fb83-3c62-4b75-809a-a55c04b25904,Mohamad Noah Omar,Speaker of the Dewan Rakyat,1959-09-01,1964-02-29
+100ed549-a1bb-4b2e-8a2d-7375f6fc1309,Najib Tun Razak,Prime Minister of Malaysia,2009-04-03,
+100ed549-a1bb-4b2e-8a2d-7375f6fc1309,Najib Tun Razak,Deputy Prime Minister of Malaysia,2004-01-07,2009-04-03
+100ed549-a1bb-4b2e-8a2d-7375f6fc1309,Najib Tun Razak,Minister of Defence,,
+a3fbc33b-2e23-43f4-946f-ff90c015a38a,Nik Ahmad Kamil Nik Mahmud,Speaker of the Dewan Rakyat,1974-11-11,1977-12-20
+76350ad4-3cfb-4b34-84de-f027fdfcf0b7,Omar Abdullah,Minister of External Affairs,,
+76350ad4-3cfb-4b34-84de-f027fdfcf0b7,Omar Abdullah,member of the Lok Sabha,,
+685e6a3b-b6e8-44ee-906b-bdc4ee220e9c,Rais Yatim,Minister of Foreign Affairs,,
+8481f1a6-123c-4b6a-93cd-3b23f3e69a14,Ramli Ngah Talib,Speaker of the Dewan Rakyat,2004-11-22,2008-02-13
+ae7369dc-ad8c-4f3d-81dc-810245d51aa3,Razali Ismail,President of the United Nations General Assembly,,
+dc60bfa6-30ae-44e7-b626-bb549cafab3c,Syed Esa Alwee,Speaker of the Dewan Rakyat,1964-05-18,1964-11-24
+186753e5-25da-4f4b-bdbe-53f95f42c167,Syed Hamid Albar,Minister of Defence,,
+186753e5-25da-4f4b-bdbe-53f95f42c167,Syed Hamid Albar,Minister of Foreign Affairs,,
+2792e299-d125-4c03-8106-05d7b17ad64d,Syed Nasir Ismail,Speaker of the Dewan Rakyat,1978,1982
+f5f1af14-7d25-4c1f-9190-0e5ad3f9371d,Tunku Abdul Rahman Sultan Abdul Hamid Halim Shah,Prime Minister of Malaysia,1957-08-31,1970-09-22
+f5f1af14-7d25-4c1f-9190-0e5ad3f9371d,Tunku Abdul Rahman Sultan Abdul Hamid Halim Shah,Minister of Foreign Affairs,,

--- a/t/fixtures/everypolitician-data/87859a2/data/New_Zealand/House/unstable/positions.csv
+++ b/t/fixtures/everypolitician-data/87859a2/data/New_Zealand/House/unstable/positions.csv
@@ -1,0 +1,55 @@
+id,name,position,start_date,end_date
+ae289677-1951-41d8-bf59-122d34011b27,Amy Adams,Minister of Justice,,
+3fa22c6f-8f2d-4d0b-9234-ae9aa2ac1aeb,Ann Hartley,Mayor of North Shore,,
+4a629361-b148-439f-b874-af88c9ff8c8c,Annette King,Leader of the Opposition,2014-11-24,
+4a629361-b148-439f-b874-af88c9ff8c8c,Annette King,Leader of the Opposition,2008-11-11,2011-12-13
+4a629361-b148-439f-b874-af88c9ff8c8c,Annette King,Minister of Health,1999-12-10,2005-10-19
+4a629361-b148-439f-b874-af88c9ff8c8c,Annette King,Minister of Justice,2007-10-31,2008-11-19
+6a93d08c-85ee-43f0-9226-d516257a348b,Bill English,Deputy Prime Minister of New Zealand,2008-11-19,
+6a93d08c-85ee-43f0-9226-d516257a348b,Bill English,New Zealand finance minister,2008-11-19,
+6a93d08c-85ee-43f0-9226-d516257a348b,Bill English,Leader of the Opposition,2001-10-08,2003-10-28
+6a93d08c-85ee-43f0-9226-d516257a348b,Bill English,Minister of Infrastructure,2008-11-19,2011-12-14
+80c291a2-5395-4f43-9902-7b5047359354,Chris Carter,Minister of Conservation,2002-08-15,2007-11-05
+80c291a2-5395-4f43-9902-7b5047359354,Chris Carter,Minister of Education,2007-11-05,2008-10-19
+f21634fc-9c82-4b99-9c83-a055c7142dba,Clem Simich,Minister of Corrections,,
+c60b57e7-cc3b-48e5-a49e-a7580dacdeb0,Damien O'Connor,Minister of Corrections,,
+7e032f8d-2a06-494d-b3b8-1272afa0f591,Don Brash,Leader of the Opposition,2003-10-28,2006-11-27
+84a6da5d-29ed-4461-9877-570acab059bd,Hekia Parata,Minister of Education,,
+15fc16f7-66da-43e3-81df-78fbd1fcb5ef,Helen Clark,Administrator of the United Nations Development Programme,2009-04-17,
+15fc16f7-66da-43e3-81df-78fbd1fcb5ef,Helen Clark,Prime Minister of New Zealand,1999-12-05,2008-11-19
+15fc16f7-66da-43e3-81df-78fbd1fcb5ef,Helen Clark,Leader of the Opposition,1993-12-01,1999-12-05
+15fc16f7-66da-43e3-81df-78fbd1fcb5ef,Helen Clark,Deputy Prime Minister of New Zealand,1989-08-08,1990-11-02
+15fc16f7-66da-43e3-81df-78fbd1fcb5ef,Helen Clark,Minister of Health,1981-11-28,1990-11-02
+ebd6bf2a-4ea1-4bd5-a1fd-b64692267d85,Hon Anne Tolley,Minister of Education,,
+ebd6bf2a-4ea1-4bd5-a1fd-b64692267d85,Hon Anne Tolley,Minister of Corrections,,
+4c748e72-9334-4541-a126-d100c798b43b,Jim Anderton,Deputy Prime Minister of New Zealand,1999-12-05,2002-08-15
+e30e5818-3151-4202-b4da-ed8d69d97500,Jim Sutton,Minister of Agriculture,1990-02-09,1990-11-02
+c3612695-9e2d-4a53-9b3a-0faae650a920,John Banks,Mayor of Auckland City,2007,2010-10-31
+cf4011ee-2b62-41f7-897d-0b1bf771a89d,John Key,Prime Minister of New Zealand,2008-11-19,
+3da5166a-53e8-438c-8aca-0c507b7cc00f,Judith Collins,Minister of Justice,,
+3da5166a-53e8-438c-8aca-0c507b7cc00f,Judith Collins,Minister of Corrections,,
+e61b4631-5b29-42e7-97b6-dfd1315f3566,Lianne Dalziel,Mayor of Christchurch,2013-10-24,
+9ff932d5-883d-4ed7-b58b-67df054d0221,Lockwood Smith,Minister of Education,,
+e9bcd4ba-f203-467d-ac61-d18a3f2566d8,Mark Burton,Minister of Justice,,
+1422c590-0e1b-4c23-9856-3d60cc1f2c71,Michael Cullen,New Zealand finance minister,1999-12-05,2008-11-19
+1422c590-0e1b-4c23-9856-3d60cc1f2c71,Michael Cullen,Deputy Prime Minister of New Zealand,2002-08-15,2008-11-19
+2fd16480-aa16-4055-bcad-66bfaae6f18b,Nick Smith,Minister of Conservation,2013-01-22,2014-10-08
+2fd16480-aa16-4055-bcad-66bfaae6f18b,Nick Smith,Minister of Education,1999-01-31,1999-12-10
+2fd16480-aa16-4055-bcad-66bfaae6f18b,Nick Smith,Minister of Corrections,,
+3c3df796-31a0-4777-b462-ac013ab39c53,Paul Swain,Minister of Corrections,,
+2358632b-90c5-4887-93dc-eaf4f1b59e50,Peseta Sam Lotu-Iiga,Minister of Corrections,,
+102fedca-153b-457e-8a8b-de68f5521a7c,Phil Goff,Leader of the Opposition,2008-11-11,2011-12-13
+102fedca-153b-457e-8a8b-de68f5521a7c,Phil Goff,Minister of Defence,2005-10-19,2008-11-19
+102fedca-153b-457e-8a8b-de68f5521a7c,Phil Goff,Minister of Foreign Affairs,1999-12-05,2005-10-19
+102fedca-153b-457e-8a8b-de68f5521a7c,Phil Goff,Minister of Justice,1999-12-05,2005-10-19
+102fedca-153b-457e-8a8b-de68f5521a7c,Phil Goff,Minister of Education,,
+102fedca-153b-457e-8a8b-de68f5521a7c,Phil Goff,Minister of Corrections,,
+e1a2ab57-0595-427f-b9f8-12fb2c0da997,Roger Douglas,New Zealand finance minister,1984-07-26,1988-12-14
+2bb3dbad-4fa1-4dda-865f-5c23f0abcb12,Simon Power,Minister of Justice,2008-11-19,2011-12-12
+1c8c74d5-5b29-4074-98f5-0f216a7fe6dc,Steve Maharey,Minister of Education,2005-10,2007-10-31
+e584af29-0b13-44a7-a26f-5bd4838c08b3,Steven Joyce,New Zealand finance minister,,
+f2b11654-027e-4573-a3cf-4ccbff9bffba,Tony Ryall,Minister of Justice,,
+31c94789-10f7-4dc9-b43f-c052f2fa9328,Trevor Mallard,Minister of Education,1999,2005
+995239c2-94c8-40d4-9343-839e60aaebea,Winston Peters,Deputy Prime Minister of New Zealand,1996-12-16,1998-08-14
+995239c2-94c8-40d4-9343-839e60aaebea,Winston Peters,Minister of Foreign Affairs,2005-10-19,2008-08-29
+995239c2-94c8-40d4-9343-839e60aaebea,Winston Peters,Minister of Māori Affairs,1990,1991

--- a/t/fixtures/everypolitician-data/ba4fa22/data/Finland/Eduskunta/unstable/positions.csv
+++ b/t/fixtures/everypolitician-data/ba4fa22/data/Finland/Eduskunta/unstable/positions.csv
@@ -1,0 +1,146 @@
+id,name,position,start_date,end_date
+56c83828-3306-4111-9c21-738821c59dff,Alexander Stubb,Prime Minister of Finland,2014-06-24,2015-05-28
+56c83828-3306-4111-9c21-738821c59dff,Alexander Stubb,Minister for European Affairs and Foreign Trade,2011-06-22,2014-06-23
+56c83828-3306-4111-9c21-738821c59dff,Alexander Stubb,Minister for Foreign Affairs of Finland,2008-04-04,2011-06-22
+56c83828-3306-4111-9c21-738821c59dff,Alexander Stubb,member of the European Parliament,2004-07-20,2008-04-03
+56c83828-3306-4111-9c21-738821c59dff,Alexander Stubb,Minister of Finance,2015-05-29,2016-06-22
+56c83828-3306-4111-9c21-738821c59dff,Alexander Stubb,Chairperson of the National Coalition Party,2014-06-14,2016-06-11
+92f7ac1d-dfe7-4ce8-907d-6a98ab80fe48,Anna-Maja Henriksson,Minister of Justice,2011-06-22,
+c763afe6-eb22-4d99-9a0c-1e7ab07b4a4b,Anne Berner,Minister of Transport and Communications,2015-05-29,
+7767f71a-d9f6-4f0e-9602-bcce0c450049,Anne Holmlund,Minister of the Interior,,
+1ec1193d-3a91-4b79-9f40-9eef915cb7db,Anneli Jäätteenmäki,Prime Minister of Finland,2003-04-17,2003-06-24
+1ec1193d-3a91-4b79-9f40-9eef915cb7db,Anneli Jäätteenmäki,member of the European Parliament,2004-07-20,
+1ec1193d-3a91-4b79-9f40-9eef915cb7db,Anneli Jäätteenmäki,Leader of the Centre Party,,
+1ec1193d-3a91-4b79-9f40-9eef915cb7db,Anneli Jäätteenmäki,Minister of Justice,,
+ae338943-c336-409c-9cf8-fb6ed13c74f6,Anni Sinnemäki,Minister of Labour,2009-06-26,2011-06-22
+fb98e4b0-6dfd-408f-96c6-6e793782a947,Antti Kalliomäki,Minister of Finance,,
+dbac1ee3-23d0-470f-936b-a46518826e99,Antti Rinne,Minister of Finance,2014-06-06,
+dbac1ee3-23d0-470f-936b-a46518826e99,Antti Rinne,Deputy Prime Minister of Finland,2014-06-06,
+bbabb2ce-15b3-41f3-871c-088ee3eb8a1d,Arja Alho,Minister of Finance,,
+b49169c8-2910-43cf-9f7e-ebc1b4a8c265,Astrid Thors,High Commissioner on National Minorities,,
+b49169c8-2910-43cf-9f7e-ebc1b4a8c265,Astrid Thors,member of the European Parliament,,
+6621513b-4109-4dbb-a0fb-18735f26114a,Carl Haglund,member of the European Parliament,2009-07-14,2012-07-04
+6621513b-4109-4dbb-a0fb-18735f26114a,Carl Haglund,Minister of Defence,2012-07-05,
+2e9650cb-3ae1-4f81-b62b-189bfb9b63ec,Claes Andersson,Minister of Culture,,
+b09ab486-043f-4457-b36f-be474b2382ec,Eero Heinäluoma,Speaker of the Parliament of Finland,,
+b09ab486-043f-4457-b36f-be474b2382ec,Eero Heinäluoma,Minister of Finance,,
+0398fbde-2da4-4458-8386-1a7ec0096953,Erkki Tuomioja,Minister for Foreign Affairs of Finland,2011-06-22,2015-05-28
+0398fbde-2da4-4458-8386-1a7ec0096953,Erkki Tuomioja,Minister for Foreign Affairs of Finland,2000-02-25,2007-04-19
+0398fbde-2da4-4458-8386-1a7ec0096953,Erkki Tuomioja,President of the Nordic Council,2008-01-01,2008-12-31
+38b0abf1-ef26-474e-9134-7bdff1ac7b10,Esko Aho,Prime Minister of Finland,1991-04-26,1995-04-13
+38b0abf1-ef26-474e-9134-7bdff1ac7b10,Esko Aho,Leader of the Centre Party,,
+577b8c51-9a9f-4c66-8e17-8d1adc1b2d0c,Hannu Takkula,member of the European Parliament,,
+8d870697-e565-401f-a1fc-6289b0e4f9c5,Heidi Hautala,member of the European Parliament,1995-01-01,2003-03-25
+8d870697-e565-401f-a1fc-6289b0e4f9c5,Heidi Hautala,Minister for International Development,2011-06-22,2013-10-16
+8d870697-e565-401f-a1fc-6289b0e4f9c5,Heidi Hautala,member of the European Parliament,2009-07-14,2011-06-21
+8d870697-e565-401f-a1fc-6289b0e4f9c5,Heidi Hautala,member of the European Parliament,2014-07-01,
+fc4e6ff9-2317-44b6-9aec-70763ff56fbd,Henna Virkkunen,member of the European Parliament,,
+78e3b770-8ff1-405e-b954-600ea8572ad0,Henrik Lax,member of the European Parliament,,
+02a828f8-6813-4b62-8ab5-a1c30f846f03,Ilkka Kanerva,Minister for Foreign Affairs of Finland,,
+b9e4b017-627a-4914-9083-ddba88283e6c,Jan-Erik Enestam,Secretary General of the Nordic Council,2007,2013
+3372e4a8-d920-4d96-81aa-5ef127def40e,Jari Koskinen,member of the European Parliament,,
+3372e4a8-d920-4d96-81aa-5ef127def40e,Jari Koskinen,Minister of Agriculture and Forestry,,
+0cf2038f-5518-4ddc-9d8f-2376be385479,Jari Lindström,Minister of Justice,2015-05-29,
+0cf2038f-5518-4ddc-9d8f-2376be385479,Jari Lindström,Minister of Labour,2015-05-29,
+fcf7a3b7-c75a-43f5-8c71-4c767bc2d460,Johannes Koskinen,Minister of Justice,,
+8beff688-bd43-4db7-ab8b-4458fb32bc89,Jouko Skinnari,Minister of Finance,1997-10-09,1999-04-14
+89f662b7-796d-4387-8d54-07ddd4161c5d,Juha Korkeaoja,Minister of Agriculture and Forestry,,
+98402739-bd5d-4d57-9881-39cedffd2f69,Juha Sipilä,Leader of the Centre Party,2012-05-09,
+98402739-bd5d-4d57-9881-39cedffd2f69,Juha Sipilä,Speaker of the Parliament of Finland,2015-04-28,2015-05-28
+98402739-bd5d-4d57-9881-39cedffd2f69,Juha Sipilä,Prime Minister of Finland,2015-05-29,
+d82070f2-3566-44c2-af8b-2483cd574459,Jukka Gustafsson,Minister of Education and Culture of Finland,,
+676752ce-443f-4a9a-8d6b-b0476dccc240,Jussi Halla-aho,member of the European Parliament,,
+3153f5d8-53c8-4770-b1b5-3646e4aac1cb,Jutta Urpilainen,Minister of Finance,2011-06-22,2014-06-06
+19af20ef-1069-4145-a178-7bcc2f140d31,Jyrki Katainen,Prime Minister of Finland,2011-06-22,2014-06-23
+19af20ef-1069-4145-a178-7bcc2f140d31,Jyrki Katainen,Deputy Prime Minister of Finland,2007-04-19,2011-06-22
+19af20ef-1069-4145-a178-7bcc2f140d31,Jyrki Katainen,Minister of Finance,2007-04-19,2011-06-22
+19af20ef-1069-4145-a178-7bcc2f140d31,Jyrki Katainen,member of the European Parliament,,
+19af20ef-1069-4145-a178-7bcc2f140d31,Jyrki Katainen,European Commissioner for Industry and Entrepreneurship,2014-11-01,
+19af20ef-1069-4145-a178-7bcc2f140d31,Jyrki Katainen,European Commissioner for Economic and Monetary Affairs and the Euro,2014-07-18,2014-11-01
+6af311be-417a-4671-825d-2ec1e5c5ccf2,Jörn Donner,member of the European Parliament,,
+d9d8d91b-a13c-4642-aac5-56a39f80abcf,Kari Rajamäki,Minister of the Interior,2003-04-17,2007-04-19
+522448d9-64ef-4f07-b81a-38ecaee3dcbc,Kimmo Sasi,President of the Nordic Council,2012-01-01,2012-12-31
+a0899714-8870-46d4-b437-d7caa20ead10,Kimmo Tiilikainen,Minister of Agriculture and Forestry,,
+9f30db8d-4536-4f28-9a23-ed552ae9391c,Kirsi Piha,member of the European Parliament,,
+4e3fb493-62d4-4f45-a0ab-74333e248778,Lauri Ihalainen,Minister of Labour,2011-06-22,2015-05-29
+3eee3275-bc92-4a67-9542-5f15bc07221f,Leena Luhtanen,Minister of Justice,,
+f36344e6-39b4-4344-b1e7-6e719c1f69fc,Lenita Toivakka,Minister for European Affairs and Foreign Trade,2014-06-24,
+4c6f6183-5a40-41ff-b5b9-66bae283bb08,Liisa Jaakonsaari,member of the European Parliament,,
+e8756e98-870a-475b-919b-d37892c4828a,Maija Rask,Minister of Education and Culture of Finland,,
+ee098f19-e905-4520-8b25-4bef5b62b9af,Mari Kiviniemi,Leader of the Centre Party,2010,2012-05-09
+ee098f19-e905-4520-8b25-4bef5b62b9af,Mari Kiviniemi,Prime Minister of Finland,2010-06-22,2011-06-22
+ee098f19-e905-4520-8b25-4bef5b62b9af,Mari Kiviniemi,Minister for European Affairs and Foreign Trade,2005-09-02,2006-03-03
+86a3be36-c854-4f39-9276-6b5ddf3ac663,Maria Guzenina,Minister of Health and Social Services,,
+daa5215d-f9c8-4892-8302-2cce652420f4,Maria Lohela,Speaker of the Parliament of Finland,2015-05-29,
+59a386a6-52a5-49d5-ba51-7a7381c8fca5,Marjatta Stenius-Kaukonen,member of the European Parliament,,
+bab532eb-9a5f-4610-9229-48bd015a15f6,Marjo Matikainen-Kallström,member of the European Parliament,1996,2004-07
+5276efaf-c4e5-424b-ac69-571b74d80f8c,Matti Vanhanen,Minister of Defence,2003-04-17,2003-06-24
+5276efaf-c4e5-424b-ac69-571b74d80f8c,Matti Vanhanen,Prime Minister of Finland,2003-06-23,2010-06-22
+5276efaf-c4e5-424b-ac69-571b74d80f8c,Matti Vanhanen,Leader of the Centre Party,,
+56a76ead-b1b2-4bee-bc07-8924ca351e9a,Merja Kyllönen,member of the European Parliament,,
+1438bccb-d02e-4ac1-8d8d-7baad7c3412e,Miapetra Kumpula-Natri,member of the European Parliament,,
+b8d6462b-8eca-4166-9407-b5644b040115,Mirja Ryynänen,member of the European Parliament,,
+a6cfddb1-fb4a-419f-b5a7-585c9742543d,Olli Rehn,European Commissioner for Economic and Monetary Affairs and the Euro,,
+a6cfddb1-fb4a-419f-b5a7-585c9742543d,Olli Rehn,European Commissioner for Enlargement and European Neighbourhood Policy,,
+a6cfddb1-fb4a-419f-b5a7-585c9742543d,Olli Rehn,member of the European Parliament,1995-01-01,1996-11-10
+a6cfddb1-fb4a-419f-b5a7-585c9742543d,Olli Rehn,Vice President of the European Parliament,2014-07-01,2015-04-26
+dfb2eeb0-e963-47a7-946d-e026bc5d687c,Outi Ojala,member of the European Parliament,,
+dfb2eeb0-e963-47a7-946d-e026bc5d687c,Outi Ojala,President of the Nordic Council,2002-01-01,2002-12-31
+51422f66-b2bf-433d-9f21-fe836fd97285,Paavo Lipponen,Prime Minister of Finland,1995-04-13,2003-04-17
+51422f66-b2bf-433d-9f21-fe836fd97285,Paavo Lipponen,Speaker of the Parliament of Finland,2003-04-22,2007-03-20
+436f3f0b-41d4-47f8-958c-77236bae29d1,Paavo Väyrynen,Deputy Prime Minister of Finland,1983-05-06,1987-04-29
+436f3f0b-41d4-47f8-958c-77236bae29d1,Paavo Väyrynen,Minister for Foreign Affairs of Finland,,
+436f3f0b-41d4-47f8-958c-77236bae29d1,Paavo Väyrynen,member of the European Parliament,1995-01-01,2007-04-18
+436f3f0b-41d4-47f8-958c-77236bae29d1,Paavo Väyrynen,Leader of the Centre Party,1980,1990
+436f3f0b-41d4-47f8-958c-77236bae29d1,Paavo Väyrynen,member of the European Parliament,2014-07-01,
+8c78ba81-cbc7-43e1-98da-109d2860dc6d,Paula Risikko,Minister of the Interior,2016-06-22,
+f26d760a-eb0b-42db-a1fa-5b318369b0a9,Pekka Haavisto,Minister for International Development,2013-10-17,
+7c47fc1c-7dfa-474b-afbf-ba0d32b82f2e,Pertti Salolainen,Chairperson of the National Coalition Party,,
+f41bbcac-12b6-495f-868f-cb41163ce3f6,Petteri Orpo,Minister of Agriculture and Forestry,2014-06-24,2015-05-28
+f41bbcac-12b6-495f-868f-cb41163ce3f6,Petteri Orpo,Minister of the Interior,2015-05-29,2016-06-22
+f41bbcac-12b6-495f-868f-cb41163ce3f6,Petteri Orpo,Chairperson of the National Coalition Party,2016-06-11,
+f41bbcac-12b6-495f-868f-cb41163ce3f6,Petteri Orpo,Minister of Finance,2016-06-22,
+7d762ef2-ba91-48af-ab18-cce29a024cd3,Päivi Räsänen,Minister of the Interior,2011-06-22,2014-06-23
+7d762ef2-ba91-48af-ab18-cce29a024cd3,Päivi Räsänen,Minister of the Interior,2014-06-24,2015-05-28
+38968a1f-8db5-49a2-b1b6-8bac63b323ab,Riitta Myller,member of the European Parliament,,
+5d1255ea-92ce-46de-969a-d75c3bb0f358,Riitta Uosukainen,Speaker of the Parliament of Finland,1994-02-07,1995-03-23
+5d1255ea-92ce-46de-969a-d75c3bb0f358,Riitta Uosukainen,Speaker of the Parliament of Finland,1995-04-21,1999-03-23
+5d1255ea-92ce-46de-969a-d75c3bb0f358,Riitta Uosukainen,Speaker of the Parliament of Finland,1999-04-20,2003-03-18
+5d1255ea-92ce-46de-969a-d75c3bb0f358,Riitta Uosukainen,Minister of Education and Culture of Finland,1991-04-26,1994-02-10
+e49efde9-f261-4ca2-b00b-a4c76ece5832,Roger Jansson,Premier of the Åland Islands,,
+fd2c8ba5-9edf-4347-b873-50b22d358966,Sampo Terho,member of the European Parliament,,
+b302e829-8c61-49bc-8df8-d6126f9fe1d0,Sari Essayah,member of the European Parliament,2009-07-14,2014-06-30
+71eecb7b-ceea-405c-b4ff-837db3f33be4,Sari Sarkomaa,Minister of Education and Culture of Finland,,
+55410e5c-b2cf-4916-bfea-67fc38d82af6,Satu Hassi,member of the European Parliament,2004,2014
+1add8f0a-3723-4d72-9c6a-7633f20dbd6e,Sauli Niinistö,President of Finland,2012-03-01,
+1add8f0a-3723-4d72-9c6a-7633f20dbd6e,Sauli Niinistö,Speaker of the Parliament of Finland,2007-04-24,2011-04-27
+1add8f0a-3723-4d72-9c6a-7633f20dbd6e,Sauli Niinistö,Minister of Finance,1996-02-02,1999-04-15
+1add8f0a-3723-4d72-9c6a-7633f20dbd6e,Sauli Niinistö,Deputy Prime Minister of Finland,1995-04-13,2001-08-30
+1add8f0a-3723-4d72-9c6a-7633f20dbd6e,Sauli Niinistö,Minister of Justice,1995-04-13,1996-02-01
+1add8f0a-3723-4d72-9c6a-7633f20dbd6e,Sauli Niinistö,Minister of Finance,1999-04-15,2003-04-16
+1add8f0a-3723-4d72-9c6a-7633f20dbd6e,Sauli Niinistö,Chairperson of the National Coalition Party,1994,2001
+cbd6a50b-7352-48cf-9a7a-1cad44320c5e,Sinikka Laisaari,Minister of Labour,1999-04-15,2000-02-24
+cbd6a50b-7352-48cf-9a7a-1cad44320c5e,Sinikka Laisaari,Minister of Health and Social Services,2003-04-17,2007-04-19
+cbd6a50b-7352-48cf-9a7a-1cad44320c5e,Sinikka Laisaari,Minister of Trade and Industry,2000-02-25,2003-04-16
+cbd6a50b-7352-48cf-9a7a-1cad44320c5e,Sinikka Laisaari,Minister of Health and Social Services,1995-04-13,1999-04-14
+0f73f289-bd06-4517-9e4b-abf8ade45f22,Sirkka-Liisa Anttila,member of the European Parliament,,
+0f73f289-bd06-4517-9e4b-abf8ade45f22,Sirkka-Liisa Anttila,Minister of Agriculture and Forestry,,
+72a9f113-36ca-403a-835c-76b6341fe453,Sirpa Pietikäinen,member of the European Parliament,,
+80058037-9390-4399-9578-943c126e297a,Susanna Huovinen,Minister of Transport and Communications,2005-09-23,2007-04-19
+80058037-9390-4399-9578-943c126e297a,Susanna Huovinen,Minister of Health and Social Services,2013-05-24,2014-06-24
+80058037-9390-4399-9578-943c126e297a,Susanna Huovinen,Minister of Health and Social Services,2014-06-24,2015-05-29
+ddf04a07-6213-41b5-b282-07f254e31722,Suvi Lindén,Minister of Culture,,
+761d0e9b-0cb6-4e6b-bafa-3a1527e0f5f1,Suvi-Anne Siimes,Minister of Culture,1998-09-04,1999-04-14
+5bc23739-8590-41d0-b892-122e749bc22c,Tarja Cronberg,member of the European Parliament,2011,2014
+5bc23739-8590-41d0-b892-122e749bc22c,Tarja Cronberg,Minister of Labour,2007-04-19,2009-06-25
+f3666d8c-a87e-48d9-9233-0cfa77937482,Tarja Filatov,Minister of Labour,2000-02-25,2007-04-19
+4f4c57fe-3058-4eca-8321-235a82a49c09,Tarja Halonen,President of Finland,2000-03-01,2012-03-01
+4f4c57fe-3058-4eca-8321-235a82a49c09,Tarja Halonen,Minister for Foreign Affairs of Finland,1995-04-13,2000-02-25
+4f4c57fe-3058-4eca-8321-235a82a49c09,Tarja Halonen,Minister of Justice,1990-02-28,1991-04-26
+a9dd88f4-76dc-45c6-8b74-7772af506e25,Timo Soini,member of the European Parliament,,
+a9dd88f4-76dc-45c6-8b74-7772af506e25,Timo Soini,Minister for Foreign Affairs of Finland,,
+ecd7fb03-dfbf-49a2-a98e-6d357c61309b,Tuija Brax,Minister of Justice,,
+208ceb92-0a4a-4fa8-83bc-80cf718cd865,Ulla-Maj Wideroos,Minister of Finance,,
+78ccd7e6-4fe4-450c-a60c-9f77f539c20e,Ville Itälä,member of the European Parliament,,
+78ccd7e6-4fe4-450c-a60c-9f77f539c20e,Ville Itälä,Chairperson of the National Coalition Party,,
+26bdc2b9-0de0-4b31-86d2-695502f630c9,Ville Niinistö,Minister of the Environment,2011-06-22,2014-09-25

--- a/t/fixtures/everypolitician-data/bd08b5e/data/North_Korea/National_Assembly/unstable/positions.csv
+++ b/t/fixtures/everypolitician-data/bd08b5e/data/North_Korea/National_Assembly/unstable/positions.csv
@@ -1,0 +1,6 @@
+id,name,position,start_date,end_date
+ebbf5070-ae94-4ae9-9c7a-5645c6ce7bb0,Kim Jong-un[14],First Secretary of the Workers' Party of Korea,2012-04-11,
+ebbf5070-ae94-4ae9-9c7a-5645c6ce7bb0,Kim Jong-un[14],Chairman of the National Defence Commission,2012-04-13,
+ebbf5070-ae94-4ae9-9c7a-5645c6ce7bb0,Kim Jong-un[14],Supreme Commander of the Korean People's Army,2011-12-17,
+3c6651fb-00b9-45be-bdff-f2b4e18013cd,Kim Yong-il,Premier of North Korea,2007-04-11,2010-06-07
+fde201c2-61f8-4d9a-80be-c487f1222272,Pak Pong-ju,Premier of North Korea,2013-04-01,

--- a/t/fixtures/everypolitician-data/f88ce37/data/Estonia/Riigikogu/unstable/positions.csv
+++ b/t/fixtures/everypolitician-data/f88ce37/data/Estonia/Riigikogu/unstable/positions.csv
@@ -1,0 +1,111 @@
+id,name,position,start_date,end_date
+480df40f-359a-4238-b179-332d47dd1611,Aivar Sõerd,Minister of Finance,2005-04-13,2007-04-05
+e28a42b5-395d-4993-9025-f5b417edd583,Andres Anvelt,Minister of Justice,2014-03-26,2015-04-09
+062854b4-591c-4c47-83e4-bf0c20c64ef3,Andrus Ansip,Mayor of Tartu,1998-09-10,2004-09-23
+062854b4-591c-4c47-83e4-bf0c20c64ef3,Andrus Ansip,member of the European Parliament,2014-07-01,2014-10-31
+062854b4-591c-4c47-83e4-bf0c20c64ef3,Andrus Ansip,Prime Minister of Estonia,2005-04-12,2014-03-26
+062854b4-591c-4c47-83e4-bf0c20c64ef3,Andrus Ansip,European Commissioner for Digital Agenda,2014-11-01,
+062854b4-591c-4c47-83e4-bf0c20c64ef3,Andrus Ansip,Minister of Economic Affairs and Communications,2004-09-13,2005-04-13
+ca220e41-2833-436b-b94c-91273c29b73a,Anne Sulling,Minister of Foreign Trade and Entrepreneurship,2014-03-26,2015-04-09
+4ab03025-d72c-4b06-94b9-e23ec9d32e3a,Arto Aas,Minister of Public Administration,2015-04-09,
+bfbf9f5e-8ccc-44f8-ac89-700922daa181,Edgar Savisaar,Prime Minister of Estonia,1991-08-20,1992-01-29
+bfbf9f5e-8ccc-44f8-ac89-700922daa181,Edgar Savisaar,Mayor of Tallinn,2001-12,2004-10
+bfbf9f5e-8ccc-44f8-ac89-700922daa181,Edgar Savisaar,Mayor of Tallinn,2007-04-09,
+bfbf9f5e-8ccc-44f8-ac89-700922daa181,Edgar Savisaar,Minister of the Interior,2005-04-12,2005-10-10
+bfbf9f5e-8ccc-44f8-ac89-700922daa181,Edgar Savisaar,Minister of Economic Affairs and Communications,2005-04-13,2007-04-05
+32f14e80-cf5b-407c-a6a6-95fbd7f2851c,Eiki Nestor,Minister of Social Affairs,1999-03-25,2002-01-28
+6274ade3-5a81-4510-a353-bd701af44228,Eldar Efendijev,Minister of Population and Ethnic Affairs,2002-01-28,2003-04-10
+e4d2b6ca-4dbc-41d6-92cf-431d405ac4ab,Ester Tuiksoo,Minister of Agriculture,2004-04-05,2007-04-05
+03d7b8ee-b3b7-4548-a696-fd243ef706d3,Hannes Hanso,Minister of Defence,2015-09-14,
+3783663b-a6e2-4da0-abdb-ad5d5fc2d6e5,Hanno Pevkur,Minister of Justice,2012-12-10,2014-03-26
+3783663b-a6e2-4da0-abdb-ad5d5fc2d6e5,Hanno Pevkur,Minister of the Interior,2014-03-26,
+3783663b-a6e2-4da0-abdb-ad5d5fc2d6e5,Hanno Pevkur,Minister of Social Affairs,2009-02-23,2012-12-10
+134ff404-8a56-436f-8f6b-c287dc8892ce,Helir-Valdor Seeder,Minister of Agriculture,2007-04-06,2014-03-26
+134ff404-8a56-436f-8f6b-c287dc8892ce,Helir-Valdor Seeder,Minister of Finance,2009,2009
+f9e8ab84-eba2-493c-a246-e3ba6665578a,Helmen Kütt,Minister of Social Protection,2014-03-26,2015-03-30
+10ddfe8e-def5-46e9-a15f-5a76a6eb6d1b,Indrek Saar,Minister of Culture,2015-04-09,
+72e3aa88-8434-4da2-9760-0177ab88f56b,Ivari Padar,member of the European Parliament,,
+72e3aa88-8434-4da2-9760-0177ab88f56b,Ivari Padar,Minister of Agriculture,2014-04-07,
+72e3aa88-8434-4da2-9760-0177ab88f56b,Ivari Padar,Minister of Finance,2007-04-05,2009-05-21
+72e3aa88-8434-4da2-9760-0177ab88f56b,Ivari Padar,Minister of Agriculture,1999-03-25,2002-01-28
+dcab809b-7a75-4fe3-a4cf-488e510d07b9,Jaak Aaviksoo,Minister of Culture and Education,1995-11-06,1995-12-31
+dcab809b-7a75-4fe3-a4cf-488e510d07b9,Jaak Aaviksoo,Minister of Education and Research,2011-04-06,2014-03-26
+dcab809b-7a75-4fe3-a4cf-488e510d07b9,Jaak Aaviksoo,Minister of Defence,2007-04-05,2011-04-06
+dcab809b-7a75-4fe3-a4cf-488e510d07b9,Jaak Aaviksoo,Minister of Education and Research,1996-01-01,1996-11-30
+0f616bd9-0e2d-4993-bee3-c7b3a6a82708,Jaak Allik,Minister of Culture,1996-01-01,1999-03-25
+0f616bd9-0e2d-4993-bee3-c7b3a6a82708,Jaak Allik,minister without portfolio,1995-11-06,1996-01-01
+93c9f00c-5a92-45a1-bbc4-2c7899a33557,Jaan Õunapuu,Minister of Regional Affairs,2003-04-10,2007-04-05
+3fad94a9-bdd1-4fd4-bcf8-30cdf745516c,Jaanus Marrandi,Minister of Agriculture,2002-01-28,2003-04-10
+89da6035-2917-4ebe-9fcf-c927aa576942,Jaanus Tamkivi,Minister of the Environment,2007-04-05,2011-04-05
+fb7fe98f-f304-44d4-b055-24a94ba7b0c0,Jevgeni Ossinovski,Minister of Education and Research,2014-03-26,2015-04-09
+fb7fe98f-f304-44d4-b055-24a94ba7b0c0,Jevgeni Ossinovski,Minister of Health and Labour,2015-09-14,
+8288a3ee-f554-42a8-b98d-8f0f1e11bd86,Juhan Parts,Prime Minister of Estonia,2003-04-10,2005-04-12
+8288a3ee-f554-42a8-b98d-8f0f1e11bd86,Juhan Parts,Minister of Economic Affairs and Communications,2007-04-06,2014-03-26
+508adc11-672e-401d-bf60-7912e9ebf6fc,Jürgen Ligi,Minister of Finance,2009-06-04,2014-11-03
+508adc11-672e-401d-bf60-7912e9ebf6fc,Jürgen Ligi,Minister of Education and Research,2015-04-09,
+508adc11-672e-401d-bf60-7912e9ebf6fc,Jürgen Ligi,Minister of Defence,2005-10-10,2007-04-05
+3fd0711e-db41-48c3-a04c-d3128ab80066,Jüri Adams,Minister of Justice,1994-11-08,1995-04-17
+228ba218-43db-4b81-9a34-44ec36b98b24,Kaja Kallas,member of the European Parliament,2014-07-01,
+c4a5d205-2d51-495f-9c8a-36afdbf2549c,Kalle Laanet,Minister of the Interior,2005-04-13,2007-04-05
+ed651195-2f16-4074-86d0-ba81c2581f36,Keit Pentus-Rosimannus,Minister of Foreign Affairs,2014-11-17,2015-07-01
+ed651195-2f16-4074-86d0-ba81c2581f36,Keit Pentus-Rosimannus,Minister of the Environment,2011-04-06,2014-11-17
+dd71454a-fb2f-4ec4-9c51-ef0956e0d39f,Ken-Marti Vaher,Minister of Justice,2003-04-10,2005-04-13
+dd71454a-fb2f-4ec4-9c51-ef0956e0d39f,Ken-Marti Vaher,Minister of the Interior,2011-04-06,2014-03-26
+e6279173-c122-46a0-a4e1-0155c8df817c,Kristen Michal,Minister of Justice,2011-04-05,2012-12-10
+e6279173-c122-46a0-a4e1-0155c8df817c,Kristen Michal,Minister of Economic Affairs and Infrastructure,2015-04-09,
+6c6e3b63-d1ac-4744-affe-e8545737a830,Kristiina Ojuland,member of the European Parliament,,
+6c6e3b63-d1ac-4744-affe-e8545737a830,Kristiina Ojuland,Minister of Foreign Affairs,2002-01-28,2005-02-10
+f04fbe53-d4e9-4fc2-b210-d181afcac9b7,Laine Randjärv,Minister of Culture,2007-04-05,2011-04-06
+f04fbe53-d4e9-4fc2-b210-d181afcac9b7,Laine Randjärv,Mayor of Tartu,2004-09-23,2007-04-05
+12bfe340-4e98-4e45-afa2-75b4a87c373f,Mailis Reps,Minister of Education and Research,2005-04-13,2007-04-05
+12bfe340-4e98-4e45-afa2-75b4a87c373f,Mailis Reps,Minister of Education and Research,2002-01-28,2003-04-10
+8b23cd8f-fe08-4f63-a321-3aa53ae9940e,Maret Maripuu,Minister of Social Affairs,2007-04-05,2009-02-23
+a7cf5ead-b4dd-4113-bc14-62dc4990b416,Margus Hanson,Minister of Defence,2003-04-10,2004-11-22
+ac4cc87b-1de2-418e-b92d-799fce699e48,Margus Tsahkna,Minister of Social Protection,2015-04-09,
+d88222df-a90a-4cbe-ad0a-317c4556c07b,Marianne Mikko,member of the European Parliament,,
+e8cd9094-5cf9-4b4e-89bb-b1b60119cef3,Maris Lauri,Minister of Finance,2014-11-03,2015-03-30
+0259486a-0410-49f3-aef9-8b79c15741a7,Marko Pomerants,Minister of the Interior,2009-07-03,2011-04-05
+0259486a-0410-49f3-aef9-8b79c15741a7,Marko Pomerants,Minister of Social Affairs,2003-04-10,2005-04-13
+0259486a-0410-49f3-aef9-8b79c15741a7,Marko Pomerants,Minister of the Environment,2015-04-09,
+fb57a6ab-7353-4608-a7e8-6c7e8adf9997,Mart Laar,Minister of Defence,2011-04-06,2012-05-11
+fb57a6ab-7353-4608-a7e8-6c7e8adf9997,Mart Laar,member of the European Parliament,2003-04-24,2004-07-19
+fb57a6ab-7353-4608-a7e8-6c7e8adf9997,Mart Laar,Prime Minister of Estonia,1992-10-21,1994-11-08
+fb57a6ab-7353-4608-a7e8-6c7e8adf9997,Mart Laar,Prime Minister of Estonia,1999-03-25,2002-01-28
+24727280-679e-4ca3-ae34-15051aa40bcf,Mati Raidma,Minister of the Environment,2014-11-17,2015-04-09
+4abfac12-b57f-40f8-831c-15f0786e0e03,Paul-Eerik Rummo,Minister of Culture and Education,1992,1994
+4abfac12-b57f-40f8-831c-15f0786e0e03,Paul-Eerik Rummo,Minister of Education and Research,1992-10-21,1994-06-21
+4abfac12-b57f-40f8-831c-15f0786e0e03,Paul-Eerik Rummo,Minister of Population and Ethnic Affairs,2003-04-10,2007-04-05
+37157edd-5b83-4193-ba8b-7636a9b92788,Peep Aru,Minister of Regional Affairs,1997,1999
+37157edd-5b83-4193-ba8b-7636a9b92788,Peep Aru,minister without portfolio,1997-04-07,1999-03-25
+5db703d7-bdb8-4d14-b2dd-1100aa9c1671,Peeter Kreitzberg,Minister of Culture and Education,1995-04-18,1995-11-05
+fde979c9-f1b8-48c6-85e5-7448e1815ad3,Rannar Vassiljev,Minister of Health and Labour,2015-04-09,2015-09-14
+4b060a08-805e-45c3-8477-f770d4e52c1a,Rein Lang,Minister of Culture,2011-04-06,2013-12-04
+4b060a08-805e-45c3-8477-f770d4e52c1a,Rein Lang,Minister of Justice,2005-04-12,2011-04-06
+4b060a08-805e-45c3-8477-f770d4e52c1a,Rein Lang,Minister of Foreign Affairs,2005-02-21,2005-04-13
+acdfe7cf-1b7c-49c6-b3f2-46cacc8d1d24,Rein Randver,Minister of the Environment,2006-10-11,2007-04-05
+51ff72fb-c6e8-4200-984e-471441cdcc6b,Siim Valmar Kiisler,Minister of Regional Affairs,2008-01-23,2014-03-26
+fa8a4384-62a5-4d09-9b6e-1a93c6cc8ef0,Sven Mikser,Minister of Defence,2014-03-26,2015-09-14
+fa8a4384-62a5-4d09-9b6e-1a93c6cc8ef0,Sven Mikser,Minister of Defence,2002-01-28,2003-04-10
+fadf4b85-2782-4159-8a94-457448957956,Sven Sester,Minister of Finance,2015-04-09,
+6b71eefc-413d-4db6-88f0-d7ff845ebaf1,Taavi Rõivas,Prime Minister of Estonia,2014-03-26,
+6b71eefc-413d-4db6-88f0-d7ff845ebaf1,Taavi Rõivas,Minister of Social Affairs,2012-12-11,2014-03-26
+660009df-70d6-41db-9c62-a2f4b3954649,Tiit Tammsaar,Minister of Agriculture,2003-04-10,2004-04-02
+3d3d1918-5637-49e1-ae01-14a1358ad702,Tõnis Lukas,Minister of Education and Research,1999-03-25,2002-01-28
+3d3d1918-5637-49e1-ae01-14a1358ad702,Tõnis Lukas,Minister of Education and Research,2007-04-05,2011-04-05
+3d3d1918-5637-49e1-ae01-14a1358ad702,Tõnis Lukas,Mayor of Tartu,1996-10-31,1997-04-03
+06c667e1-ad6e-4d82-8881-baeeb6311493,Tõnis Palts,Minister of Finance,2003-04-10,2003-10-06
+1a8c0540-64fd-4d50-b33b-a4c37ef596a3,Urmas Klaas,Mayor of Tartu,2014-04-08,
+173df2d0-3584-4a91-bd88-abd1799f83d6,Urmas Kruuse,Minister of Health and Labour,2014-03-26,2015-03-30
+173df2d0-3584-4a91-bd88-abd1799f83d6,Urmas Kruuse,Mayor of Tartu,2007-04-26,2014-03-26
+173df2d0-3584-4a91-bd88-abd1799f83d6,Urmas Kruuse,Minister of Rural Affairs,2015-04-09,
+22d0ca41-c8a6-4475-9cad-6b932a909a48,Urmas Paet,member of the European Parliament,2014-11-03,
+22d0ca41-c8a6-4475-9cad-6b932a909a48,Urmas Paet,Minister of Culture,2003-04-10,2005-04-12
+22d0ca41-c8a6-4475-9cad-6b932a909a48,Urmas Paet,Minister of Foreign Affairs,2005-04-13,2014-11-03
+75a1da0b-ed40-418a-b412-0595bb0f617e,Urmas Reinsalu,Minister of Justice,2015-04-09,
+75a1da0b-ed40-418a-b412-0595bb0f617e,Urmas Reinsalu,Minister of Defence,2012-05-11,2014-03-26
+cdb00a6d-65c7-4f22-a8d5-57dd296b30a3,Urve Palo,Minister of Economic Affairs and Infrastructure,2014-03-26,2015-04-09
+cdb00a6d-65c7-4f22-a8d5-57dd296b30a3,Urve Palo,Minister of Entrepreneurship,2015-04-09,2015-08-30
+cdb00a6d-65c7-4f22-a8d5-57dd296b30a3,Urve Palo,Minister of Population and Ethnic Affairs,2007-04-05,2009-05-21
+13d18bf2-db98-4bda-b8b5-cf2f09c00ae9,Urve Tiidus,Minister of Culture,2013-12-04,2015-04-09
+2cced9a3-4f1c-4266-af00-a73dd22a47f9,Vilja Savisaar-Toomast,member of the European Parliament,,
+77605932-0f05-461e-8a0d-a5618f0fe6b8,Yana Toom,member of the European Parliament,2014,

--- a/t/fixtures/everypolitician-data/f8dcbd9/data/Australia/Senate/unstable/positions.csv
+++ b/t/fixtures/everypolitician-data/f8dcbd9/data/Australia/Senate/unstable/positions.csv
@@ -1,0 +1,99 @@
+id,name,position,start_date,end_date
+9dd3a970-1895-4d6f-b486-fc9ec1a71e3b,Alan Ferguson,President of the Australian Senate,,
+b824bea9-284a-48b1-969f-0e1b37310919,Amanda Vanstone,Minister for Employment and Workplace Relations,,
+b824bea9-284a-48b1-969f-0e1b37310919,Amanda Vanstone,Minister for Immigration and Border Protection,,
+b7aa3154-8a36-48a2-b600-1d170b41bca0,Barnaby Joyce,Member of the Australian House of Representatives,,
+6369dcf7-1429-443d-84b2-4ff2621e4365,Belinda Neal,Member of the Australian House of Representatives,,
+dc2d214f-1eb7-4201-8ea8-01e22d42fac5,Bob Brown,Member of the Tasmanian House of Assembly,,
+a84574bb-4f51-4c4d-98d7-5ba05b502278,Bob Carr,Premier of New South Wales,1995-04-04,2005-08-03
+a84574bb-4f51-4c4d-98d7-5ba05b502278,Bob Carr,Minister for Foreign Affairs,2012-03-13,2013-09-18
+a84574bb-4f51-4c4d-98d7-5ba05b502278,Bob Carr,Member of the New South Wales Legislative Assembly,,
+30dbb752-cd6d-4274-9139-6d64184b71f0,Bob McMullan,Member of the Australian House of Representatives,,
+30dbb752-cd6d-4274-9139-6d64184b71f0,Bob McMullan,Manager of Opposition Business in the House,1998-10-20,2001-11-25
+30dbb752-cd6d-4274-9139-6d64184b71f0,Bob McMullan,Minister for Trade,1994-01-30,1996-03-11
+30dbb752-cd6d-4274-9139-6d64184b71f0,Bob McMullan,Minister for the Arts,1993-03-24,1994-01-30
+a12db1cc-bb5c-498f-bc87-b539147fe0d2,Bob Woods,Member of the Australian House of Representatives,,
+384ac513-247d-4105-9692-15b6bec3d639,Bronwyn Bishop,Member of the Australian House of Representatives,1994-03-26,
+384ac513-247d-4105-9692-15b6bec3d639,Bronwyn Bishop,Speaker of the House of Representatives,2013-11-12,2015-08-02
+384ac513-247d-4105-9692-15b6bec3d639,Bronwyn Bishop,Minister for Social Services,1998-10-21,2001-11-26
+384ac513-247d-4105-9692-15b6bec3d639,Bronwyn Bishop,Minister for Defence Science and Personnel,1996-03-11,1998-10-21
+51d08543-73e6-406b-9df1-acaf5758eda5,Cheryl Kernot,Member of the Australian House of Representatives,,
+04b83926-3eb9-4620-ada4-391542de8356,Chris Evans,Minister for Employment and Workplace Relations,2010-09-14,2011-12-14
+044c2835-1a7b-4652-9df4-189d26a458e1,Christine Milne,Member of the Tasmanian House of Assembly,,
+bb533f2a-e62d-4fae-acf7-cfe317d08cd6,David Fawcett,Member of the Australian House of Representatives,,
+e69a7709-cfe4-4b78-9433-4324eed6622e,David Feeney,Member of the Australian House of Representatives,,
+edbd5bf4-a9da-4d33-b081-38cb61a5d5f8,David Hamer,Member of the Australian House of Representatives,,
+fa6d6ed9-90d9-4225-a8c6-95cbe7528c39,David Johnston,Minister for Defence,,
+d78e6905-f642-405e-991c-b81a8f8449ad,Deborah O'Neill,Member of the Australian House of Representatives,,
+d4053204-d523-40fd-a661-b19e362ceccc,Eric Abetz,Minister for Employment and Workplace Relations,2013-09-18,2015-09-21
+d4053204-d523-40fd-a661-b19e362ceccc,Eric Abetz,Special Minister of State,2001-01-30,2006-01-27
+d4053204-d523-40fd-a661-b19e362ceccc,Eric Abetz,Leader of the Government in the Senate,2013-09-18,
+d4053204-d523-40fd-a661-b19e362ceccc,Eric Abetz,Leader of the Opposition in the Senate,2010-05-03,2013-09-18
+d4053204-d523-40fd-a661-b19e362ceccc,Eric Abetz,"Minister for Agriculture, Fisheries and Forestry",2006-01-27,2007-12-03
+7aa7d043-819e-4902-ace5-458638718989,Frederick Chaney,Member of the Australian House of Representatives,,
+41c92a2b-a4b4-4f75-9240-2abe0c450626,Gareth Evans,Attorney-General of Australia,,
+41c92a2b-a4b4-4f75-9240-2abe0c450626,Gareth Evans,Minister for Foreign Affairs,,
+41c92a2b-a4b4-4f75-9240-2abe0c450626,Gareth Evans,Member of the Australian House of Representatives,,
+448b3399-2de4-4078-83f8-7141d763ff2d,Gary Humphries,Chief Minister of the Australian Capital Territory,2000-10-18,2001-11-05
+011f00b2-70b7-49c4-a55e-8cbda1ab3a38,George Brandis,Attorney-General of Australia,,
+011f00b2-70b7-49c4-a55e-8cbda1ab3a38,George Brandis,Minister for the Arts,,
+1eb553b2-b5a7-45ed-b309-aa243e16ede1,Graham Richardson,Minister for Health,1993-03-24,1994-03-25
+1eb553b2-b5a7-45ed-b309-aa243e16ede1,Graham Richardson,"Minister for Sustainability, Environment, Water, Population and Communities (Australia)",1994-03-01,1994-03-25
+1eb553b2-b5a7-45ed-b309-aa243e16ede1,Graham Richardson,Vice-President of the Executive Council,1991-02-01,1992-05-18
+1eb553b2-b5a7-45ed-b309-aa243e16ede1,Graham Richardson,Minister for Infrastructure and Transport,1991-12-27,1992-05-18
+1eb553b2-b5a7-45ed-b309-aa243e16ede1,Graham Richardson,Minister for Human Services,1990-04-04,1991-12-27
+1eb553b2-b5a7-45ed-b309-aa243e16ede1,Graham Richardson,Minister for the Arts,1988-01-19,1990-04-04
+1eb553b2-b5a7-45ed-b309-aa243e16ede1,Graham Richardson,"Minister for Sustainability, Environment, Water, Population and Communities (Australia)",1987-07-24,1988-01-19
+b203cfe8-badd-401b-bad9-106489e0b2d7,Grant Chapman,Member of the Australian House of Representatives,,
+d2f76458-d23d-4247-bb15-27657baa0808,Grant Tambling,Member of the Australian House of Representatives,,
+b424105b-4341-40f8-840e-b419f5aee1a7,Guy Barnett,Member of the Tasmanian House of Assembly,2014,
+c85f9d82-4b30-45ef-ac06-58b8fc37cff6,Helen Coonan,"Minister for Broadband, Communications and the Digital Economy (Australia)",,
+c85f9d82-4b30-45ef-ac06-58b8fc37cff6,Helen Coonan,Shadow Foreign Secretary,,
+798bb3bc-e9a4-4faa-9694-3a2ed4ce0bed,Jacinta Collins,Minister for Social Services,,
+798bb3bc-e9a4-4faa-9694-3a2ed4ce0bed,Jacinta Collins,Manager of Government Business in the Senate,,
+422159d5-4e66-446e-9b8f-1ae992e984d0,Jim Short,Member of the Australian House of Representatives,,
+91ad205d-3d70-491f-93bd-42e678c6097e,Jocelyn Newman,Minister for Human Services,,
+91ad205d-3d70-491f-93bd-42e678c6097e,Jocelyn Newman,Minister for Social Services,,
+4af0b549-dc5c-462d-b5b0-64aad7620afb,John Button,Minister for Industry and Innovation,,
+0aa33f7a-e177-40b9-a6c0-cb81800d5f62,John Coates,Member of the Australian House of Representatives,,
+91ed0aba-03e0-40df-a1bf-95b1c3128f48,John Faulkner,Minister for Defence,,
+91ed0aba-03e0-40df-a1bf-95b1c3128f48,John Faulkner,Vice-President of the Executive Council,,
+91ed0aba-03e0-40df-a1bf-95b1c3128f48,John Faulkner,Special Minister of State,,
+2c5522b8-ec16-4248-9480-6e3a56047091,John Morris,Member of the New South Wales Legislative Council,1976-04-23,1984-03-05
+6bc11145-4ad4-4a86-b490-1a1c7738e633,John Olsen,Member of the Parliament of South Australia,,
+6bc11145-4ad4-4a86-b490-1a1c7738e633,John Olsen,Premier of South Australia,,
+a00901e6-0ecd-474a-bd0b-25e476fb6676,Kate Lundy,Minister for Sport,2012-03-05,2013-07-01
+a00901e6-0ecd-474a-bd0b-25e476fb6676,Kate Lundy,Minister for Immigration and Border Protection,2012-03-05,2013-09-18
+92c436dd-812d-4b8d-8e75-e810236027a8,Katy Gallagher,Chief Minister of the Australian Capital Territory,2011-05-16,2014-12-11
+92c436dd-812d-4b8d-8e75-e810236027a8,Katy Gallagher,member of the Australian Capital Territory Legislative Assembly,2001-10-20,2014-12-23
+18098c6f-6b97-4a77-bb3e-6d7979892039,Kay Patterson,Minister for Social Services,2003-10-07,2006-01-27
+18098c6f-6b97-4a77-bb3e-6d7979892039,Kay Patterson,Minister for Health,2001-11-26,2003-10-07
+e5965652-0ceb-4f21-a435-5883c8207885,Kim Carr,Minister for Human Services,,
+e5965652-0ceb-4f21-a435-5883c8207885,Kim Carr,Minister for Defence Materiel,,
+e5965652-0ceb-4f21-a435-5883c8207885,Kim Carr,Minister for Industry and Innovation,,
+4d6a8209-95b4-481e-ac94-2d60743a59f4,Lee Rhiannon,Member of the New South Wales Legislative Council,1999-03-27,2010-07-19
+cdbd90ad-9f19-4c7a-bf47-dc9bbda4367e,Lin Thorp,Member of the Tasmanian Legislative Council,1999-08-28,2011-05-07
+fe076b5f-04a7-44c4-931f-de8aa2635f46,Lisa Singh,Member of the Tasmanian House of Assembly,2006-03-18,2010-04-13
+db1362ca-7fe8-4039-a388-4ab5e7c8c76d,Margaret Reid,President of the Australian Senate,1996-08-20,2002-08-19
+88876a8a-2909-4fc9-8211-047df1bc43ef,Mathias Cormann,Minister for Finance,2013-09-18,
+0df2b935-09c4-4ca9-a4e6-5f55dce57423,Matt Thistlethwaite,Member of the Australian House of Representatives,,
+7b3d609b-beb1-4e36-99fc-55787f818f56,Michael Baume,Member of the Australian House of Representatives,,
+a263008a-ea71-4dd7-b348-8e73a6289b54,Michael Ronaldson,Minister for Veterans' Affairs,,
+a263008a-ea71-4dd7-b348-8e73a6289b54,Michael Ronaldson,Special Minister of State,,
+a263008a-ea71-4dd7-b348-8e73a6289b54,Michael Ronaldson,Member of the Australian House of Representatives,,
+24f5ba80-73a8-45de-a8a1-6fb657be10bb,Michael Tate,Minister for Justice and Consumer Affairs,1990-04-04,1992-05-27
+24f5ba80-73a8-45de-a8a1-6fb657be10bb,Michael Tate,Minister for Justice,1987-09-18,1993-03-24
+24f5ba80-73a8-45de-a8a1-6fb657be10bb,Michael Tate,Special Minister of State,1987-02-16,1987-07-24
+26c73bfa-9bd8-43e0-99d7-9183da991280,Michaelia Cash,Minister for Employment and Workplace Relations,2015-09-21,
+e930bdf9-1e7b-472b-adb2-9816c9f1cef8,Mitch Fifield,"Minister for Broadband, Communications and the Digital Economy (Australia)",2015-09-21,""
+3f2957c5-fe0a-45d5-b1ce-872b2bdc6d44,Nick McKim,Member of the Tasmanian House of Assembly,,
+e73ba683-a92a-4e37-bc7d-6ffd69a6c235,Nick Minchin,Minister for Finance,2001-11-26,2007-12-03
+d954072d-7cc3-4b81-81f7-124cf02695a1,Nick Xenophon,Member of the South Australian Legislative Council,,
+aa4699f5-7e99-4b4e-9a86-aabeaa3af028,Nigel Scullion,Minister for Social Services,,
+34fe4405-d658-4300-9390-2a64287b39e5,Norman Sanders,Member of the Tasmanian House of Assembly,,
+824ec8ce-676f-45fa-ace6-73503dd0ff20,Penny Wong,Minister for Finance,2010-09-14,2013-09-18
+824ec8ce-676f-45fa-ace6-73503dd0ff20,Penny Wong,"Minister for Sustainability, Environment, Water, Population and Communities (Australia)",,
+f1860237-418b-44db-bae6-640210259992,Peter Walsh,Minister for Finance,,
+2d808c63-98c4-46b3-8146-5b63ae322048,Santo Santoro,Member of the Queensland Legislative Assembly,,
+9a016d4d-f26b-4b85-a026-f2eba23de3b8,Stephen Conroy,"Minister for Broadband, Communications and the Digital Economy (Australia)",,
+c9889cbd-3a44-42e5-9c9f-cec16037cb0e,Terrence Aulich,Member of the Tasmanian House of Assembly,,

--- a/t/page/term_table.rb
+++ b/t/page/term_table.rb
@@ -5,7 +5,7 @@ require_relative '../../lib/page/term_table'
 describe 'TermTable' do
   describe 'Austria' do
     subject do
-      stub_popolo('3df153b', 'Austria/Nationalrat')
+      stub_term_table('3df153b', 'Austria/Nationalrat')
       Page::TermTable.new(
         term: index_at_known_sha.country('austria').legislature('nationalrat').term('25')
       )
@@ -59,7 +59,7 @@ describe 'TermTable' do
       end
 
       it 'returns an empty array when there is only a single group' do
-        stub_popolo('bd08b5e', 'North_Korea/National_Assembly')
+        stub_term_table('bd08b5e', 'North_Korea/National_Assembly')
         north_korea = Page::TermTable.new(
           term: index_at_known_sha.country('north-korea').legislature('national-assembly').term('13')
         )

--- a/t/test_helper.rb
+++ b/t/test_helper.rb
@@ -58,6 +58,7 @@ module Minitest
 
     def stub_term_table(sha, legislature)
       stub_everypolitician_data_request("#{sha}/data/#{legislature}/ep-popolo-v1.0.json")
+      stub_everypolitician_data_request("#{sha}/data/#{legislature}/unstable/positions.csv")
     end
 
     def last_response_must_be_valid

--- a/t/test_helper.rb
+++ b/t/test_helper.rb
@@ -56,6 +56,10 @@ module Minitest
       stub_json('https://api.github.com/repos/everypolitician/everypolitician-data/issues?labels=New%20Country,3%20-%20WIP&per_page=100')
     end
 
+    def stub_term_table(sha, legislature)
+      stub_everypolitician_data_request("#{sha}/data/#{legislature}/ep-popolo-v1.0.json")
+    end
+
     def last_response_must_be_valid
       skip unless supported_html_tidy_version?
       validation = PageValidations::HTMLValidation.new.validation(last_response.body, last_request.url)

--- a/t/web/person_cards_test.rb
+++ b/t/web/person_cards_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+describe 'PersonCard' do
+  describe 'cabinet memberships' do
+    before { stub_term_table('f88ce37', 'Estonia/Riigikogu') }
+    let(:legislature) { index_at_known_sha.country('Estonia').legislature('Riigikogu') }
+    let(:term) { legislature.term('13') }
+    let(:cabinet_membership) { term.cabinet_memberships.first }
+    let(:person) { legislature.popolo.persons.find_by(id: cabinet_membership.person_id) }
+    subject { PersonCard.new(person: person, term: term) }
+
+    it 'returns a list of cabinet memberships for a person' do
+      subject.cabinet_memberships.must_include cabinet_membership
+    end
+  end
+end

--- a/t/web/term_table/australia.rb
+++ b/t/web/term_table/australia.rb
@@ -21,7 +21,7 @@ describe 'Per Country Tests: Australia' do
 
   describe 'Representatives' do
     before do
-      stub_everypolitician_data_request('6139efe/data/Australia/Representatives/ep-popolo-v1.0.json')
+      stub_term_table('6139efe', 'Australia/Representatives')
       get '/australia/representatives/term-table/44.html'
     end
 
@@ -51,7 +51,7 @@ describe 'Per Country Tests: Australia' do
 
   describe 'Senate' do
     before do
-      stub_everypolitician_data_request('f8dcbd9/data/Australia/Senate/ep-popolo-v1.0.json')
+      stub_term_table('f8dcbd9', 'Australia/Senate')
       get '/australia/senate/term-table/44.html'
     end
 

--- a/t/web/term_table/bahamas.rb
+++ b/t/web/term_table/bahamas.rb
@@ -6,7 +6,7 @@ describe 'Bahamas' do
   subject { Nokogiri::HTML(last_response.body) }
 
   before do
-    stub_popolo('4da60b8', 'Bahamas/House_of_Assembly')
+    stub_term_table('4da60b8', 'Bahamas/House_of_Assembly')
     get '/bahamas/house-of-assembly/term-table/2012.html'
   end
 

--- a/t/web/term_table/finland.rb
+++ b/t/web/term_table/finland.rb
@@ -12,7 +12,7 @@ describe 'Per Country Tests' do
 
   describe 'Finland' do
     before do
-      stub_everypolitician_data_request('ba4fa22/data/Finland/Eduskunta/ep-popolo-v1.0.json')
+      stub_term_table('ba4fa22', 'Finland/Eduskunta')
       get '/finland/eduskunta/term-table/35.html'
     end
 

--- a/t/web/term_table/malaysia.rb
+++ b/t/web/term_table/malaysia.rb
@@ -4,7 +4,7 @@ require_relative '../../../app'
 
 describe 'Per Country Tests' do
   before do
-    stub_everypolitician_data_request('75b7651/data/Malaysia/Dewan_Rakyat/ep-popolo-v1.0.json')
+    stub_term_table('75b7651', 'Malaysia/Dewan_Rakyat')
   end
 
   subject { Nokogiri::HTML(last_response.body) }

--- a/t/web/term_table/ni.rb
+++ b/t/web/term_table/ni.rb
@@ -12,7 +12,7 @@ describe 'Northern Ireland' do
 
   describe 'membership dates' do
     before do
-      stub_everypolitician_data_request('1a17862/data/Northern_Ireland/Assembly/ep-popolo-v1.0.json')
+      stub_term_table('1a17862', 'Northern_Ireland/Assembly')
       get '/northern-ireland/assembly/term-table/3.html'
     end
 

--- a/t/web/term_table/nz.rb
+++ b/t/web/term_table/nz.rb
@@ -4,7 +4,7 @@ require_relative '../../../app'
 
 describe 'Per Country Tests' do
   before do
-    stub_everypolitician_data_request('87859a2/data/New_Zealand/House/ep-popolo-v1.0.json')
+    stub_term_table('87859a2', 'New_Zealand/House')
   end
 
   subject { Nokogiri::HTML(last_response.body) }

--- a/t/web/term_table/party_groupings.rb
+++ b/t/web/term_table/party_groupings.rb
@@ -8,7 +8,7 @@ describe 'Party Groupings section' do
 
   describe 'only Independent' do
     before do
-      stub_everypolitician_data_request('beb21e5/data/Alderney/States/ep-popolo-v1.0.json')
+      stub_term_table('beb21e5', 'Alderney/States')
       get '/alderney/states/term-table/2014.html'
     end
 
@@ -19,7 +19,7 @@ describe 'Party Groupings section' do
 
   describe 'only Unknown' do
     before do
-      stub_everypolitician_data_request('75b7651/data/Transnistria/Supreme_Council/ep-popolo-v1.0.json')
+      stub_term_table('75b7651', 'Transnistria/Supreme_Council')
       get '/transnistria/supreme-council/term-table/6.html'
     end
 
@@ -30,7 +30,7 @@ describe 'Party Groupings section' do
 
   describe 'regular section' do
     before do
-      stub_everypolitician_data_request('f88ce37/data/Estonia/Riigikogu/ep-popolo-v1.0.json')
+      stub_term_table('f88ce37', 'Estonia/Riigikogu')
       get '/estonia/riigikogu/term-table/13.html'
     end
     it 'should have party groupings' do

--- a/t/web/term_table/seat_count.rb
+++ b/t/web/term_table/seat_count.rb
@@ -9,7 +9,7 @@ describe 'Seat Count' do
 
   describe 'Estonia' do
     before do
-      stub_everypolitician_data_request('f88ce37/data/Estonia/Riigikogu/ep-popolo-v1.0.json')
+      stub_term_table('f88ce37', 'Estonia/Riigikogu')
       get '/estonia/riigikogu/term-table/13.html'
     end
 
@@ -29,7 +29,7 @@ describe 'Seat Count' do
 
   describe 'Historic Finland' do
     before do
-      stub_everypolitician_data_request('ba4fa22/data/Finland/Eduskunta/ep-popolo-v1.0.json')
+      stub_term_table('ba4fa22', 'Finland/Eduskunta')
       get '/finland/eduskunta/term-table/35.html'
     end
 

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -178,6 +178,22 @@
                                   <% end %>
                                 </p>
                               <% end %>
+
+                              <% person.cabinet_memberships.each do |mem| %>
+                                <p class="person-card__politics">
+
+                                <%= mem.label %>
+
+                                <% if !mem.start_date.to_s.empty? and !mem.end_date.to_s.empty? %>
+                                  <span class="person-card__politics__date">(<%= mem.start_date.to_s %> to <%= mem.end_date.to_s %>)</span>
+                                <% elsif !mem.start_date.to_s.empty? %>
+                                  <span class="person-card__politics__date">(from <%= mem.start_date.to_s %>)</span>
+                                <% elsif !mem.end_date.to_s.empty? %>
+                                  <span class="person-card__politics__date">(until <%= mem.end_date.to_s %>)</span>
+                                <% end %>
+
+                                </p>
+                              <% end %>
                             </div>
 
                             <% %i(bio social contacts identifiers).select { |s| person.send(s).any? }.each do |section| %>


### PR DESCRIPTION
# What does this do?

Outputs cabinet memberships on term table page.

# Why was this needed?

We want to output cabinet memberships a member has held in order to finish #24.

# Relevant Issue(s)

Fixes #24 

# Implementation notes

This adds some methods to the `lib/everypolitician_extensions.rb` file which augments the everypolitician-ruby and everypolitician-popolo gems. Currently the logic for connecting a person to a cabinet membership is in the `PersonCard` class, as it doesn't really make sense trying to shoehorn it into the Popolo classes.

# Screenshots

![cabinet-memberships](https://cloud.githubusercontent.com/assets/22996/23314100/c004d080-fac0-11e6-9bdb-6692599ffeea.png)

# Notes to Reviewer

- I'm not very happy with the tests in this pull request. I'm open to suggestions on how these can be improved.
- The tests are still using quite an old version of `countries.json`, so it's testing against an older format of CSV
- This only filters out positions with no `start_date`, it doesn't do anything about the `type` column. I don't _think_ this is  an issue because `positions.csv` now only holds cabinet data (as per https://github.com/everypolitician/viewer-sinatra/pull/15609#pullrequestreview-22923927).
- It's quite possible I'm trying to change too much at once in this pull request. Happy to try splitting it up if needed.