### PR TITLE
Cabinet memberships documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,39 +110,6 @@ bundle exec rake test:all
 bundle exec rake
 ```
 
-## Internal documentation
-
-### Interacting with unstable data
-
-We use data from the `unstable/positions.csv` file in a legislature's
-directory to display cabinet memberships on the website. Because this data
-is unstable there currently aren't methods in [the `everypolitician`
-gem](https://github.com/everypolitician/everypolitician-ruby) for
-interacting with it, so viewer-sinatra has some of its own classes for
-dealing with it. These classes live in the
-`lib/everypolitician_extensions.rb` file and are documented below.
-
-#### Get all cabinet memberships for a person
-
-To print all of the known cabinet memberships for a person, you can do the
-following:
-
-```ruby
-house_of_commons = Everypolitician::Index.new.country('UK').legislature('Commons')
-person = house_of_commons.popolo.persons.find_by(name: 'Gordon Brown')
-
-person.cabinet_memberships.each do |membership|
-  puts "#{person.name} was #{membership.label} #{membership.start_date} - #{membership.end_date}"
-end
-```
-
-Which will output something like this:
-
-```
-Gordon Brown was Prime Minister of the United Kingdom 2007-06-27 - 2010-05-11
-Gordon Brown was Chancellor of the Exchequer 1997-05-02 - 2007-06-27
-```
-
 ## Sinatra, SASS, styling
 
 The project uses [Sinatra](http://www.sinatrarb.com), an ultra-minimal Ruby MVC web app framework.

--- a/lib/person_cards.rb
+++ b/lib/person_cards.rb
@@ -64,6 +64,18 @@ class PersonCard
     person.memberships.where(legislative_period_id: term.id)
   end
 
+  # List of cabinet memberships this person held in this term
+  #
+  # @example Iterating through cabinet memberships for a {PersonCard} instance.
+  #   person_card.cabinet_memberships.each do |membership|
+  #     puts "#{person_card.name} was #{membership.label} #{membership.start_date} - #{membership.end_date}"
+  #   end
+  #
+  # @return [Array<Everypolitician::LegislatureExtension::CabinetMembership>]
+  def cabinet_memberships
+    []
+  end
+
   private
 
   attr_reader :person, :term

--- a/t/page/term_table.rb
+++ b/t/page/term_table.rb
@@ -95,6 +95,10 @@ describe 'TermTable' do
         af.legislative_memberships.first.area.name.must_equal 'Wahlkreis: 3B – Waldviertel'
       end
 
+      it 'has a stub implementation of cabinet memberships' do
+        af.cabinet_memberships.must_equal []
+      end
+
       it 'has two entries on bio card' do
         af.bio.count.must_equal 2
       end


### PR DESCRIPTION
# What does this do?

Updates the documentation for the cabinet memberships methods that was added in https://github.com/everypolitician/viewer-sinatra/pull/15609 and moves it out of the README and into `lib/person_cards.rb`.

# Why was this needed?

Originally we thought this code might be useful to outside people, as it was augmenting the everypolitician-ruby gem. Now though, we've decided that it's best for the functionality to live in some viewer-sinatra specific classes for now, until we have a better idea of how it all fits together at least. So this moves the docs to a more logical place.

# Relevant Issue(s)

Extracted from https://github.com/everypolitician/viewer-sinatra/pull/15615

Follows on from https://github.com/everypolitician/viewer-sinatra/pull/15609

Replaces https://github.com/everypolitician/viewer-sinatra/pull/15612

Part of #24 

# Implementation notes

This uses the YARD `@example` documentation tag, which render the example code out in the docs, see screenshot below.

# Screenshots

![yard-person-card](https://cloud.githubusercontent.com/assets/22996/23396266/4c8ab70c-fd93-11e6-8546-06da001ea12c.png)

# Notes to Reviewer

This is just the documentation for now, the implementation will come as a separate pull request.