### PR TITLE
Change term table stubbing in the tests

### DIFF
--- a/t/page/term_table.rb
+++ b/t/page/term_table.rb
@@ -5,7 +5,7 @@ require_relative '../../lib/page/term_table'
 describe 'TermTable' do
   describe 'Austria' do
     subject do
-      stub_popolo('3df153b', 'Austria/Nationalrat')
+      stub_term_table('3df153b', 'Austria/Nationalrat')
       Page::TermTable.new(
         term: index_at_known_sha.country('austria').legislature('nationalrat').term('25')
       )
@@ -59,7 +59,7 @@ describe 'TermTable' do
       end
 
       it 'returns an empty array when there is only a single group' do
-        stub_popolo('bd08b5e', 'North_Korea/National_Assembly')
+        stub_term_table('bd08b5e', 'North_Korea/National_Assembly')
         north_korea = Page::TermTable.new(
           term: index_at_known_sha.country('north-korea').legislature('national-assembly').term('13')
         )

--- a/t/test_helper.rb
+++ b/t/test_helper.rb
@@ -56,6 +56,10 @@ module Minitest
       stub_json('https://api.github.com/repos/everypolitician/everypolitician-data/issues?labels=New%20Country,3%20-%20WIP&per_page=100')
     end
 
+    def stub_term_table(sha, legislature)
+      stub_everypolitician_data_request("#{sha}/data/#{legislature}/ep-popolo-v1.0.json")
+    end
+
     def last_response_must_be_valid
       skip unless supported_html_tidy_version?
       validation = PageValidations::HTMLValidation.new.validation(last_response.body, last_request.url)

--- a/t/web/term_table/australia.rb
+++ b/t/web/term_table/australia.rb
@@ -21,7 +21,7 @@ describe 'Per Country Tests: Australia' do
 
   describe 'Representatives' do
     before do
-      stub_everypolitician_data_request('6139efe/data/Australia/Representatives/ep-popolo-v1.0.json')
+      stub_term_table('6139efe', 'Australia/Representatives')
       get '/australia/representatives/term-table/44.html'
     end
 
@@ -51,7 +51,7 @@ describe 'Per Country Tests: Australia' do
 
   describe 'Senate' do
     before do
-      stub_everypolitician_data_request('f8dcbd9/data/Australia/Senate/ep-popolo-v1.0.json')
+      stub_term_table('f8dcbd9', 'Australia/Senate')
       get '/australia/senate/term-table/44.html'
     end
 

--- a/t/web/term_table/bahamas.rb
+++ b/t/web/term_table/bahamas.rb
@@ -6,7 +6,7 @@ describe 'Bahamas' do
   subject { Nokogiri::HTML(last_response.body) }
 
   before do
-    stub_popolo('4da60b8', 'Bahamas/House_of_Assembly')
+    stub_term_table('4da60b8', 'Bahamas/House_of_Assembly')
     get '/bahamas/house-of-assembly/term-table/2012.html'
   end
 

--- a/t/web/term_table/finland.rb
+++ b/t/web/term_table/finland.rb
@@ -12,7 +12,7 @@ describe 'Per Country Tests' do
 
   describe 'Finland' do
     before do
-      stub_everypolitician_data_request('ba4fa22/data/Finland/Eduskunta/ep-popolo-v1.0.json')
+      stub_term_table('ba4fa22', 'Finland/Eduskunta')
       get '/finland/eduskunta/term-table/35.html'
     end
 

--- a/t/web/term_table/malaysia.rb
+++ b/t/web/term_table/malaysia.rb
@@ -4,7 +4,7 @@ require_relative '../../../app'
 
 describe 'Per Country Tests' do
   before do
-    stub_everypolitician_data_request('75b7651/data/Malaysia/Dewan_Rakyat/ep-popolo-v1.0.json')
+    stub_term_table('75b7651', 'Malaysia/Dewan_Rakyat')
   end
 
   subject { Nokogiri::HTML(last_response.body) }

--- a/t/web/term_table/ni.rb
+++ b/t/web/term_table/ni.rb
@@ -12,7 +12,7 @@ describe 'Northern Ireland' do
 
   describe 'membership dates' do
     before do
-      stub_everypolitician_data_request('1a17862/data/Northern_Ireland/Assembly/ep-popolo-v1.0.json')
+      stub_term_table('1a17862', 'Northern_Ireland/Assembly')
       get '/northern-ireland/assembly/term-table/3.html'
     end
 

--- a/t/web/term_table/nz.rb
+++ b/t/web/term_table/nz.rb
@@ -4,7 +4,7 @@ require_relative '../../../app'
 
 describe 'Per Country Tests' do
   before do
-    stub_everypolitician_data_request('87859a2/data/New_Zealand/House/ep-popolo-v1.0.json')
+    stub_term_table('87859a2', 'New_Zealand/House')
   end
 
   subject { Nokogiri::HTML(last_response.body) }

--- a/t/web/term_table/party_groupings.rb
+++ b/t/web/term_table/party_groupings.rb
@@ -8,7 +8,7 @@ describe 'Party Groupings section' do
 
   describe 'only Independent' do
     before do
-      stub_everypolitician_data_request('beb21e5/data/Alderney/States/ep-popolo-v1.0.json')
+      stub_term_table('beb21e5', 'Alderney/States')
       get '/alderney/states/term-table/2014.html'
     end
 
@@ -19,7 +19,7 @@ describe 'Party Groupings section' do
 
   describe 'only Unknown' do
     before do
-      stub_everypolitician_data_request('75b7651/data/Transnistria/Supreme_Council/ep-popolo-v1.0.json')
+      stub_term_table('75b7651', 'Transnistria/Supreme_Council')
       get '/transnistria/supreme-council/term-table/6.html'
     end
 
@@ -30,7 +30,7 @@ describe 'Party Groupings section' do
 
   describe 'regular section' do
     before do
-      stub_everypolitician_data_request('f88ce37/data/Estonia/Riigikogu/ep-popolo-v1.0.json')
+      stub_term_table('f88ce37', 'Estonia/Riigikogu')
       get '/estonia/riigikogu/term-table/13.html'
     end
     it 'should have party groupings' do

--- a/t/web/term_table/seat_count.rb
+++ b/t/web/term_table/seat_count.rb
@@ -9,7 +9,7 @@ describe 'Seat Count' do
 
   describe 'Estonia' do
     before do
-      stub_everypolitician_data_request('f88ce37/data/Estonia/Riigikogu/ep-popolo-v1.0.json')
+      stub_term_table('f88ce37', 'Estonia/Riigikogu')
       get '/estonia/riigikogu/term-table/13.html'
     end
 
@@ -29,7 +29,7 @@ describe 'Seat Count' do
 
   describe 'Historic Finland' do
     before do
-      stub_everypolitician_data_request('ba4fa22/data/Finland/Eduskunta/ep-popolo-v1.0.json')
+      stub_term_table('ba4fa22', 'Finland/Eduskunta')
       get '/finland/eduskunta/term-table/35.html'
     end
 


### PR DESCRIPTION
# What does this do?

This adds an additional helper method to `test_helper.rb` called `stub_term_table`. As the name suggests it stubs out the requests that are made on the term table page.

# Why was this needed?

As part of #24 we want to start making requests to `unstable/positions.csv` in the legislature directory of everypolitician-data. This means we'll be adding an additional HTTP requests to the term table page that need to be stubbed out. Having a single method where we can change what's stubbed for this page makes this much easier.

# Relevant Issue(s)

Extracted from https://github.com/everypolitician/viewer-sinatra/pull/15615

Related to https://github.com/everypolitician/viewer-sinatra/issues/15607

Part of #24 