### PR TITLE
Add check-fail.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
 script:
   - bundle exec rake
   - travis_wait 30 scripts/release.sh
+  - scripts/check-fail.sh
 sudo: false
 rvm:
   - 2.3.1

--- a/scripts/check-fail.sh
+++ b/scripts/check-fail.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Checks tests introduced in pull requests fail on master.
+
+set -eo pipefail
+
+if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
+  echo "Skipping $0 for non-PR build"
+  exit 0
+fi
+
+if echo "${TRAVIS_PULL_REQUEST_BRANCH}" | grep -qi refactor; then
+  echo "The title of the PR indicates this is a refactoring; skipping this check"
+  exit 0
+fi
+
+target_branch="${TRAVIS_BRANCH}"
+
+if [ -z "${target_branch}" ]; then
+  echo "No target branch found" >&2
+  exit 1
+fi
+
+# Checkout the branch that the pull request is targeting...
+git checkout "${target_branch}"
+
+# ...but revert the test code back to the pull request version
+for dir in t tests test spec; do
+  git checkout "HEAD@{1}" -- "${dir}" 2> /dev/null || true
+done
+
+if bundle exec rake test; then
+  echo "Your newly introduced tests should have failed on ${target_branch}" >&2
+  echo "If you expected them to pass then include 'refactor' in the branch name" >&2
+  exit 1
+else
+  echo "Your new tests failed on ${target_branch}, which is a good thing!"
+fi


### PR DESCRIPTION
# What does this do?

This adds the `check-fail.sh` which runs tests added in pull requests and checks that they fail when run against the code on the `master` branch.

# Why was this needed?

Having this script in place makes it much harder to add production code that doesn't have regression tests.

# Relevant Issue(s)

Part of https://github.com/everypolitician/everypolitician/issues/588

# Implementation notes

I've added the script last in `.travis.yml`, which means it will have to wait for the full viewer-static build to complete first. The reason for this is that `check-fail.sh` in its current form will alter the branch that the repo is on and won't put it back, so the `release.sh` script would have unexpected results if it ran after `check-fail.sh`.