### PR TITLE
Rename PersonCard#memberships to #legislative_memberships

### DIFF
--- a/lib/person_cards.rb
+++ b/lib/person_cards.rb
@@ -58,11 +58,14 @@ class PersonCard
     Section::Identifiers.new(person, top_identifiers: top_identifiers).data
   end
 
-  # List of memberships this person held in this term
+  # List of legislative memberships this person held in this term
   # @return [Array<EveryPolitician::Popolo::Membership>]
-  def memberships
+  def legislative_memberships
     person.memberships.where(legislative_period_id: term.id)
   end
+
+  # TODO: Remove this alias and the associated tests.
+  alias memberships legislative_memberships
 
   private
 

--- a/t/page/term_table.rb
+++ b/t/page/term_table.rb
@@ -95,6 +95,14 @@ describe 'TermTable' do
         af.memberships.first.area.name.must_equal 'Wahlkreis: 3B – Waldviertel'
       end
 
+      it 'has a single legislative membership' do
+        af.legislative_memberships.count.must_equal 1
+        af.legislative_memberships.first.start_date.must_equal '2013-10-29'
+        af.legislative_memberships.first.end_date.must_equal nil
+        af.legislative_memberships.first.group.name.must_equal 'ÖVP'
+        af.legislative_memberships.first.area.name.must_equal 'Wahlkreis: 3B – Waldviertel'
+      end
+
       it 'has two entries on bio card' do
         af.bio.count.must_equal 2
       end

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -164,7 +164,7 @@
 
                                 <h3 class="person-card__name"><%= person.name %></h3>
 
-                              <% person.memberships.each do |mem| %>
+                              <% person.legislative_memberships.each do |mem| %>
                                 <p class="person-card__politics">
 
                                   <%= [mem.group, mem.area].reject(&:nil?).map(&:name).join(" — ") %>


### PR DESCRIPTION
# What does this do?

This renames the `PersonCard#memberships` to `PersonCard#legislative_memberships`.

# Why was this needed?

We want to add another method to the `PersonCard` class which returns cabinet memberships as part of #24. Therefore it makes sense to rename this method to legislative_memberships to make it clear that it's only returning a subset of the memberships.

# Relevant Issue(s)

Extracted from https://github.com/everypolitician/viewer-sinatra/pull/15616

Part of #24 

# Implementation notes

~~Since this is an internal class I've decided to just rename the method, rather than bother keeping an alias to the old method as I originally did in https://github.com/everypolitician/viewer-sinatra/pull/15616.~~ 

I realised that just renaming the method would mean changing code and tests in one pull request, which is a Bad Thing. Instead, I've left the original `memberships` method in place as an alias to the new `legislative_memberships` method. The `memberships` method should be removed in a future pull request.