### PR TITLE
Update to Ruby 2.3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script:
   - scripts/check-fail.sh
 sudo: false
 rvm:
-  - 2.3.1
+  - 2.3.3
 notifications:
   slack:
     secure: GVD9d+kwR5hzab5ZnWugbCkp9QSYyheSrABWkD+LmpMcWcx7jijajSn4LLvDi/zHYn1MdOBcPe08hSygmpm7ViUApp0EJcSzE4BLU/5oAs+ANV0Qq6jsssMlyo3v8eRAqHNiLxAiAsz+lc0EZWfQnSW8kHzzbO3NeYq1NRL5CgQ=

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 source 'https://rubygems.org'
 
-ruby '2.3.1'
+ruby '2.3.3'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,7 +145,7 @@ DEPENDENCIES
   yard
 
 RUBY VERSION
-   ruby 2.3.1p112
+   ruby 2.3.3p222
 
 BUNDLED WITH
-   1.13.4
+   1.13.7


### PR DESCRIPTION
# What does this do?

Updates the Ruby version to 2.3.3.

# Why was this needed?

Most of our other apps and scrapers are running on Ruby 2.3.3, so this makes viewer-sinatra consistent with those. It also means we benefit from any fixes that are in the latest patch version.