### PR TITLE
Show Ruby code example on every term-table page

### DIFF
--- a/t/web/term_table/australia.rb
+++ b/t/web/term_table/australia.rb
@@ -47,6 +47,12 @@ describe 'Per Country Tests: Australia' do
       tony = 'mem-93e2e4cc-f5ce-4bea-be68-2fc86c38a9bc'
       subject.css("div.person-card[id=#{tony}]").text.must_include 'Honourable'
     end
+
+    it 'should contain a correct code example' do
+      subject.css('.page-section--code pre').text.must_include "Index.new.country('Australia')"
+      subject.css('.page-section--code pre').text.must_include "legislature('Representatives')"
+      subject.css('.page-section--code pre').text.must_include "terms.find_by(id: 'term/44')"
+    end
   end
 
   describe 'Senate' do

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -221,8 +221,8 @@
 require 'everypolitician'
 country = Everypolitician::Index.new.country('<%= @page.country.slug %>')
 house = country.legislature('<%= @page.house.slug %>')
-house.popolo.terms.find_by(id: '<%= @page.current_term.id %>').memberships.each do |m|
-  puts "#{m.person.name} (#{m.party.name}): #{m.person.gender}"
+house.popolo.terms.find_by(id: '<%= @page.current_term.id %>').memberships.each do |membership|
+  puts "#{membership.person.name} (#{membership.party.name}): #{membership.person.gender}"
 end
           </pre>
           <p>

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -223,8 +223,7 @@ country = Everypolitician::Index.new.country('<%= @page.country.slug %>')
 house = country.legislature('<%= @page.house.slug %>')
 house.popolo.terms.find_by(id: '<%= @page.current_term.id %>').memberships.each do |membership|
   puts "#{membership.person.name} (#{membership.party.name}): #{membership.person.gender}"
-end
-          </pre>
+end</pre>
           <p>
             Libraries also available in
             <a href="https://github.com/everypolitician/everypolitician-python">Python</a> and 

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -222,7 +222,7 @@ require 'everypolitician'
 country = Everypolitician::Index.new.country('<%= @page.country.slug %>')
 house = country.legislature('<%= @page.house.slug %>')
 house.popolo.terms.find_by(id: '<%= @page.current_term.id %>').memberships.each do |m|
-  puts "#{m.person.name} (#{m.party.name}): @#{m.person.twitter || '?'}"
+  puts "#{m.person.name} (#{m.party.name}): #{m.person.gender}"
 end
           </pre>
           <p>

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -209,6 +209,29 @@
 
         </div>
     </div>
+      <div class="page-section page-section--code">
+        <div class="container">
+          <p>
+            Ruby programmer? It’s easy to use this data in your own app! Use the
+            <a href="https://medium.com/@everypolitician/introducing-the-everypolitician-gem-ab39db5b7e49">gem</a>
+            <!-- https://github.com/everypolitician/everypolitician-ruby -->
+            like this:
+          </p>
+          <pre>
+require 'everypolitician'
+country = Everypolitician::Index.new.country('<%= @page.country.slug %>')
+house = country.legislature('<%= @page.house.slug %>')
+house.popolo.terms.find_by(id: '<%= @page.current_term.id %>').memberships.each do |m|
+  puts "#{m.person.name} (#{m.party.name}): @#{m.person.twitter || '?'}"
+end
+          </pre>
+          <p>
+            Libraries also available in
+            <a href="https://github.com/everypolitician/everypolitician-python">Python</a> and 
+            <a href="https://github.com/andylolz/everypolitician-php">PHP</a>.
+          </p>
+        </div>
+      </div>
 
       <div class="page-section page-section--grey source-credits">
         <div class="container">


### PR DESCRIPTION
# What does this do?

Adds an example snippet of Ruby (using the everypolitician gem) for accessing the data that's displayed on a term-table page.

# Why was this needed?

Enhancement: if a potential developer is looking at that page on the EveryPolitician website, on the basis that a simple example is a dev's favourite favourite way of learning, then this communicates how easy it is to use the data in their own project.

# Relevant Issue(s)

#15611 

# Implementation notes

None: no design effort made here (e.g. syntax colouring, any dynamic hide/show etc)... this just uses an existing section style, with a new class (`page-section--code`) that has no explicit CSS associated with it — in fact this class is only used in order to isolate the code example the tests.

# Screenshots

![screen shot 2017-03-02 at 16 08 52](https://cloud.githubusercontent.com/assets/111320/23518424/5213601e-ff6b-11e6-9fe9-5de9b2004439.png)

# Notes to Reviewer

The output from running the snippet of code is non-specific: just `name (party): gender` which is enough to convey that the program has access to the data, iterating over the memberships. It's _almost_ the same as the one we used on the EveryPolitician leaflet—the difference is _this_ code uses the specific term ID, and prints the gender (not the twitter handle) simply because without needing further checks gender is more likely to be populated with data.

Also: it's not obvious what the right targets should be for the links to the libraries: check that they are what you expect

* Ruby https://github.com/everypolitician/viewer-sinatra/blob/7bf8de9df72ae271a2dbd80fb27e1f96bd8571fd/views/term_table.erb#L216-L217
* Python https://github.com/everypolitician/viewer-sinatra/blob/7bf8de9df72ae271a2dbd80fb27e1f96bd8571fd/views/term_table.erb#L230
* PHP https://github.com/everypolitician/viewer-sinatra/blob/7bf8de9df72ae271a2dbd80fb27e1f96bd8571fd/views/term_table.erb#L231

Finally here's the example cut-and-pasted from a local run. _This_ code (that is, the example being created in the HTML) is not tested automatically in Viewer-Sinatra's tests; this snippet works for me locally in my `everypolitician-data` bundled environment.

```Ruby
require 'everypolitician'
country = Everypolitician::Index.new.country('Japan')
house = country.legislature('House-of-Representatives')
house.popolo.terms.find_by(id: 'term/46').memberships.each do |m|
  puts "#{m.person.name} (#{m.party.name}): #{m.person.gender}"
end
```

sample output (truncated):

```
KAWAMURA Takeo (LDP): male
MORIYAMA Masahito (LDP): male
NAKAGAWA Yuko (LDP): female
NAGAOKA Keiko (LDP): female
HASHIMOTO Hidenori (LDP): male
...
```

# Notes to Merger

Only consequence is an extra div containing the example code at the bottom of every term-table page.


