### PR TITLE
Rename rake test:all to test

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,7 @@ require 'rubocop/rake_task'
 require 'reek/rake/task'
 
 Rake::TestTask.new do |t|
+  t.name = 'test:page'
   t.warning = true
   t.description = 'Run "Page" tests'
   t.test_files = FileList['t/page/*.rb', 't/helpers/*.rb']
@@ -29,7 +30,6 @@ Rake::TestTask.new do |t|
 end
 
 Rake::TestTask.new do |t|
-  t.name = 'test:all'
   t.verbose = true
   t.description = 'Run all tests (slow)'
   t.test_files = FileList['t/**/*.rb']
@@ -55,4 +55,4 @@ end
 require 'bundler/audit/task'
 Bundler::Audit::Task.new
 
-task default: ['test:all', 'rubocop', 'bundle:audit']
+task default: ['test', 'rubocop', 'bundle:audit']


### PR DESCRIPTION
# What does this do?

Renames the `test:all` rake task to be called `test`.

# Why was this needed?

The `ensure-regression-tests` script that gets run on Travis assumes that all of your tests will run when `rake test` is executed. This wasn't the case for this repo, which means that the script was failing on Travis, even thought there were regression tests.

# Relevant Issue(s)

Fixes https://github.com/everypolitician/viewer-sinatra/issues/15625
