### PR TITLE
[Refactor] Rename rake test:all to test

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ To run the tests you have some options:
 ### Run just the page tests
 
 ```bash
-bundle exec rake test
+bundle exec rake test:page
 ```
 
 ### Run just the web tests (slow)
@@ -101,7 +101,7 @@ bundle exec rake test:extensions
 ### Run absolutely all the tests (slow, as you guessed)
 
 ```bash
-bundle exec rake test:all
+bundle exec rake test
 ```
 
 ### Run absolutely all the tests plus rubocop and bundle audit

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,7 @@ require 'rubocop/rake_task'
 require 'reek/rake/task'
 
 Rake::TestTask.new do |t|
+  t.name = 'test:page'
   t.warning = true
   t.description = 'Run "Page" tests'
   t.test_files = FileList['t/page/*.rb', 't/helpers/*.rb']
@@ -29,7 +30,6 @@ Rake::TestTask.new do |t|
 end
 
 Rake::TestTask.new do |t|
-  t.name = 'test:all'
   t.verbose = true
   t.description = 'Run all tests (slow)'
   t.test_files = FileList['t/**/*.rb']
@@ -55,4 +55,4 @@ end
 require 'bundler/audit/task'
 Bundler::Audit::Task.new
 
-task default: ['test:all', 'rubocop', 'bundle:audit']
+task default: ['test', 'rubocop', 'bundle:audit']


### PR DESCRIPTION
# What does this do?

Renames the `test:all` rake task to be called `test`.

# Why was this needed?

The `ensure-regression-tests` script that gets run on Travis assumes that all of your tests will run when `rake test` is executed. This wasn't the case for this repo, which means that the script was failing on Travis, even thought there were regression tests.

# Relevant Issue(s)

Fixes https://github.com/everypolitician/viewer-sinatra/issues/15625
