### PR TITLE
update nokogiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,15 +50,13 @@ GEM
     mini_portile2 (2.1.0)
     minitest (5.9.0)
     multipart-post (2.0.0)
-    nokogiri (1.6.8)
+    nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
-      pkg-config (~> 1.1.7)
     octokit (3.8.0)
       sawyer (~> 0.6.0, >= 0.5.3)
     parser (2.3.3.1)
       ast (~> 2.2)
     path_expander (1.0.0)
-    pkg-config (1.1.7)
     powerpack (0.1.1)
     pry (0.10.1)
       coderay (~> 1.1.0)
@@ -148,4 +146,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.13.7
+   1.14.6


### PR DESCRIPTION
Nokogiri 1.6.8 has security issues (https://github.com/sparklemotion/nokogiri/issues/1615)

Update to 1.7.1