### PR TITLE
Fix Travis build

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,11 +47,11 @@ GEM
     iso_country_codes (0.7.1)
     json (1.8.2)
     method_source (0.8.2)
-    mini_portile2 (2.2.0)
+    mini_portile2 (2.3.0)
     minitest (5.9.0)
     multipart-post (2.0.0)
-    nokogiri (1.8.0)
-      mini_portile2 (~> 2.2.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     octokit (3.8.0)
       sawyer (~> 0.6.0, >= 0.5.3)
     parser (2.3.3.1)
@@ -146,4 +146,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.14.6
+   1.16.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,7 +109,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    yajl-ruby (1.2.1)
+    yajl-ruby (1.3.1)
     yard (0.9.5)
 
 PLATFORMS

--- a/scripts/install_tidy.sh
+++ b/scripts/install_tidy.sh
@@ -8,5 +8,5 @@ unzip 5.2.0.zip
 cd tidy-html5-5.2.0/build/cmake
 cmake ../..
 make
-mkdir ~/bin
+mkdir -p ~/bin
 mv tidy ~/bin/tidy


### PR DESCRIPTION
# What does this do?

Gets Travis building `master` successfully again.

# Why was this needed?

`master` cannot currently be built on Travis. We need successful builds to be able to continue to make changes.

# Relevant Issue(s)

N/A

# Implementation notes

Two problems were preventing the build from working.

Travis seems to now create a `~/bin` folder so the [`scripts/install_tidy.sh` script was failing](https://travis-ci.org/everypolitician/viewer-sinatra/builds/316179211#L796). 1500da4 fixes this by not failing if the directory already exists.

Two gems had new security advisories so [`rake bundle:audit` was failing](https://travis-ci.org/everypolitician/viewer-sinatra/builds/316180819#L960-L976). 87884b8 and 069ff9a fix this by updating the two gems.

# Screenshots

N/A

# Notes to Reviewer

N/A

# Notes to Merger

N/A