### PR TITLE
Suppress warnings when running the full test suite

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -31,6 +31,7 @@ Rake::TestTask.new do |t|
 end
 
 Rake::TestTask.new do |t|
+  t.warning = false
   t.verbose = true
   t.description = 'Run all tests (slow)'
   t.test_files = FileList['t/**/*.rb']


### PR DESCRIPTION
# What does this do?

Explicitly suppresses warnings when running the full test suite.

# Why was this needed?

Prior to Rake 11.0 Rake::TestTask warnings were disabled by default but
now they're enabled.

https://github.com/ruby/rake/blob/master/History.rdoc#1100--2016-03-09
>Use ruby warnings by default. Pull request # 97 by Harold Giménez

We upgraded to Rake > 11.0 in:
https://github.com/everypolitician/viewer-sinatra/pull/15633/files#diff-e79a60dc6b85309ae70a6ea8261eaf95R77

Now that they're enabled we need to explicitly disable them on our test
task that runs the full test suite. This is because we don't yet have
the test suite running cleanly without warnings, though we do want to
(see https://github.com/everypolitician/viewer-sinatra/issues/15572).

Test output before PR: https://travis-ci.org/everypolitician/viewer-sinatra/builds/316216105#L864-L1196
Test output after PR: https://travis-ci.org/everypolitician/viewer-sinatra/builds/330668008#L1041-L1056

# Relevant Issue(s)

# Implementation notes

# Screenshots

# Notes to Reviewer

# Notes to Merger

