### PR TITLE
[WIP] Wikidata countries list page

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -99,6 +99,11 @@ get '/needed.html' do
   erb :needed
 end
 
+get '/wikidata/countries.html' do
+  @page = Page::WikidataCountries.new
+  erb :"wikidata/countries"
+end
+
 get '/*.css' do |filename|
   scss :"sass/#{filename}"
 end

--- a/lib/page/wikidata_countries.rb
+++ b/lib/page/wikidata_countries.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Page
+  class WikidataCountries
+    def title
+      'EveryPolitician'
+    end
+  end
+end

--- a/public/javascript/vendor/Sparql.js
+++ b/public/javascript/vendor/Sparql.js
@@ -1,0 +1,488 @@
+var wikibase = wikibase || {};
+wikibase.queryService = wikibase.queryService || {};
+wikibase.queryService.api = wikibase.queryService.api || {};
+
+wikibase.queryService.api.Sparql = ( function( $ ) {
+	'use strict';
+
+	var SPARQL_SERVICE_URI = 'https://query.wikidata.org/bigdata/namespace/wdq/sparql',
+		ERROR_CODES = {
+			TIMEOUT: 10,
+			MALFORMED: 20,
+			SERVER: 30,
+			UNKNOWN: 100
+		},
+		ERROR_MAP = {
+			'QueryTimeoutException: Query deadline is expired': ERROR_CODES.TIMEOUT,
+			'java.util.concurrent.TimeoutException': ERROR_CODES.TIMEOUT,
+			'MalformedQueryException: ': ERROR_CODES.MALFORMED
+		},
+		DEFAULT_LANGUAGE = 'en';
+
+	/**
+	 * SPARQL API for the Wikibase query service
+	 *
+	 * @class wikibase.queryService.api.Sparql
+	 * @license GNU GPL v2+
+	 *
+	 * @author Stanislav Malyshev
+	 * @author Jonas Kress
+	 * @constructor
+	 *
+	 * @param {string} [serviceUri] Optional URI to the SPARQL service endpoint
+	 * @param {string} [language]
+	 */
+	function SELF( serviceUri, language ) {
+		this._serviceUri = serviceUri || SPARQL_SERVICE_URI;
+		this._language = language || DEFAULT_LANGUAGE;
+	}
+
+	/**
+	 * @property {Object}
+	 */
+	SELF.prototype.ERROR_CODES = ERROR_CODES;
+
+	/**
+	 * @property {string}
+	 * @private
+	 */
+	SELF.prototype._serviceUri = null;
+
+	/**
+	 * @property {number}
+	 * @private
+	 */
+	SELF.prototype._executionTime = null;
+
+	/**
+	 * @property {Object}
+	 * @private
+	 */
+	SELF.prototype._error = null;
+
+	/**
+	 * @property {number}
+	 * @private
+	 */
+	SELF.prototype._resultLength = null;
+
+	/**
+	 * @property {Object}
+	 * @private
+	 */
+	SELF.prototype._rawData = null;
+
+	/**
+	 * @property {string}
+	 * @private
+	 */
+	SELF.prototype._queryUri = null;
+
+	/**
+	 * @property {string}
+	 * @private
+	 */
+	SELF.prototype._language = null;
+
+	/**
+	 * Submit a query to the API
+	 *
+	 * @return {jQuery.Promise}
+	 */
+	SELF.prototype.queryDataUpdatedTime = function() {
+		// Cache the update time only for a minute
+		var deferred = $.Deferred(),
+			query = encodeURI( 'prefix schema: <http://schema.org/> '
+				+ 'SELECT * WHERE {<http://www.wikidata.org> schema:dateModified ?y}' ),
+			url = this._serviceUri + '?query=' + query + '&nocache='
+				+ Math.floor( Date.now() / 60000 ),
+			settings = {
+				headers: {
+					Accept: 'application/sparql-results+json'
+				}
+			};
+
+		$.ajax( url, settings ).done( function( data, textStatus, jqXHR ) {
+			if ( !data.results.bindings[0] ) {
+				deferred.reject();
+				return;
+			}
+
+			var updateDate = new Date( data.results.bindings[0][data.head.vars[0]].value ),
+				dateText = updateDate.toLocaleTimeString( navigator.language, {
+						timeZoneName: 'short'
+					} ) + ', ' + updateDate.toLocaleDateString( navigator.language, {
+						month: 'short',
+						day: 'numeric',
+						year: 'numeric'
+					} ),
+				differenceInSeconds = Math.round( ( new Date() - updateDate ) / 1000 );
+
+			deferred.resolve( dateText, differenceInSeconds );
+		} ).fail( function() {
+			deferred.reject();
+		} );
+
+		return deferred;
+	};
+
+	/**
+	 * Submit a query to the API
+	 *
+	 * @param {string[]} query
+	 * @param {number} [timeout] in millis
+	 * @return {jQuery.Promise} query
+	 */
+	SELF.prototype.query = function( query, timeout ) {
+		query = this._replaceAutoLanguage( query );
+
+		var data = 'query=' + encodeURIComponent( query );
+		if ( timeout ) {
+			data += '&maxQueryTimeMillis=' + timeout;
+		}
+
+		var self = this,
+			deferred = $.Deferred(),
+			settings = {
+				headers: { Accept: 'application/sparql-results+json' },
+				data: data
+			};
+		function done( data, textStatus, request ) {
+			self._executionTime = Date.now() - self._executionTime;
+
+			if ( typeof data.boolean === 'boolean' ) {
+				self._resultLength = 1;
+			} else {
+				self._resultLength = data.results.bindings.length || 0;
+			}
+			self._rawData = data;
+
+			deferred.resolve( data );
+		}
+		function fail( request, options, exception ) {
+			self._executionTime = null;
+			self._rawData = null;
+			self._resultLength = null;
+			self._generateErrorMessage( request, options, exception );
+
+			deferred.reject();
+		}
+
+		this._queryUri = this._serviceUri + '?' + settings.data;
+
+		this._executionTime = Date.now();
+		$.ajax( this._serviceUri, settings ).done( done ).fail( function( request, options, exception ) {
+			if ( request.getAllResponseHeaders() === '' ) {
+				// query might have been too long for GET, retry with POST
+				settings.method = 'POST';
+				$.ajax( self._serviceUri, settings ).done( done ).fail( fail );
+			} else {
+				fail.apply( this, arguments );
+			}
+		} );
+
+		return deferred;
+	};
+
+	/**
+	 * Get execution time in ms of the submitted query
+	 */
+	SELF.prototype._generateErrorMessage = function( request, options, exception ) {
+		var error = {
+			code: ERROR_CODES.UNKNOWN,
+			message: null,
+			debug: request.responseText
+		};
+
+		if ( request.status === 0 || exception ) {
+			error.code = ERROR_CODES.SERVER;
+			error.message = exception.message;
+		}
+
+		try {//extract error from server response
+			var errorToMatch = error.debug.substring(
+				error.debug.indexOf( 'java.util.concurrent.ExecutionException:' )
+			);
+
+			for ( var errorKey in ERROR_MAP ) {
+				if ( errorToMatch.indexOf( errorKey ) !== -1 ) {
+					error.code = ERROR_MAP[ errorKey ];
+					error.message = null;
+				}
+			}
+
+			if ( error.code === ERROR_CODES.UNKNOWN || error.code === ERROR_CODES.MALFORMED ) {
+				error.message = error.debug
+						.match(
+								/(java\.util\.concurrent\.ExecutionException\:)+(.*)(Exception\:)+(.*)/ )
+						.pop().trim();
+			}
+		} catch ( e ) {
+		}
+
+		this._error = error;
+	};
+
+	/**
+	 * Get execution time in seconds of the submitted query
+	 *
+	 * @return {number}
+	 */
+	SELF.prototype.getExecutionTime = function() {
+		return this._executionTime;
+	};
+
+	/**
+	 * Get error of the submitted query if it has failed
+	 *
+	 * @return {object}
+	 */
+	SELF.prototype.getError = function() {
+		return this._error;
+	};
+
+	/**
+	 * Get result length of the submitted query if it has failed
+	 *
+	 * @return {number}
+	 */
+	SELF.prototype.getResultLength = function() {
+		return this._resultLength;
+	};
+
+	/**
+	 * Get query URI
+	 *
+	 * @return {string}
+	 */
+	SELF.prototype.getQueryUri = function() {
+		return this._queryUri;
+	};
+
+	/**
+	 * Process SPARQL query result.
+	 *
+	 * @param {Object} data
+	 * @param {Function} rowHandler
+	 * @param {*} context
+	 * @private
+	 * @return {*} The provided context, modified by the rowHandler.
+	 */
+	SELF.prototype._processData = function( data, rowHandler, context ) {
+		var results = data.results.bindings.length;
+		for ( var i = 0; i < results; i++ ) {
+			var rowBindings = {};
+			for ( var j = 0; j < data.head.vars.length; j++ ) {
+				if ( data.head.vars[j] in data.results.bindings[i] ) {
+					rowBindings[data.head.vars[j]] = data.results.bindings[i][data.head.vars[j]];
+				} else {
+					rowBindings[data.head.vars[j]] = undefined;
+				}
+			}
+			context = rowHandler( rowBindings, context );
+		}
+		return context;
+	};
+
+	/**
+	 * Encode string as CSV.
+	 *
+	 * @param {string} string
+	 * @return {string}
+	 */
+	SELF.prototype._encodeCsv = function( string ) {
+		var result = string.replace( /"/g, '""' );
+		if ( /[",\n]/.test( result ) ) {
+			result = '"' + result + '"';
+		}
+		return result;
+	};
+
+	/**
+	 * Get the raw result
+	 *
+	 * @return {Object} result
+	 */
+	SELF.prototype.getResultRawData = function() {
+		return this._rawData;
+	};
+
+	/**
+	 * Get the result of the submitted query as CSV
+	 *
+	 * @return {string} csv
+	 */
+	SELF.prototype.getResultAsCsv = function() {
+		var self = this,
+			data = self._rawData,
+			output = data.head.vars.map( this._encodeCsv ).join( ',' ) + '\n';
+
+		output = this._processData( data, function( row, out ) {
+			var rowOut = '';
+			var first = true;
+			var rowCSV;
+			for ( var rowVar in row ) {
+				if ( row[rowVar] === undefined ) {
+					rowCSV = '';
+				} else {
+					rowCSV = self._encodeCsv( row[rowVar].value );
+				}
+				if ( !first ) {
+					rowOut += ',';
+				} else {
+					first = false;
+				}
+				rowOut += rowCSV;
+			}
+			rowOut += '\n';
+			return out + rowOut;
+		}, output );
+		return output;
+	};
+
+	/**
+	 * Get the result of the submitted query as JSON
+	 *
+	 * @return {string}
+	 */
+	SELF.prototype.getResultAsJson = function() {
+		var output = [],
+			data = this._rawData;
+
+		output = this._processData( data, function( row, out ) {
+			var extractRow = {};
+			for ( var rowVar in row ) {
+				extractRow[rowVar] = ( row[rowVar] || {} ).value;
+			}
+			out.push( extractRow );
+			return out;
+		}, output );
+		return JSON.stringify( output );
+	};
+
+	/**
+	 * Get the result of the submitted query as raw JSON
+	 *
+	 * @return {string}
+	 */
+	SELF.prototype.getResultAsAllJson = function() {
+		return JSON.stringify( this._rawData );
+	};
+
+	/**
+	 * Render value as per http://www.w3.org/TR/sparql11-results-csv-tsv/#tsv
+	 *
+	 * @param {Object} binding
+	 * @return {string}
+	 */
+	SELF.prototype._renderValueTSV = function( binding ) {
+		var value = binding.value.replace( /\t/g, '' );
+		switch ( binding.type ) {
+		case 'uri':
+			return '<' + value + '>';
+		case 'bnode':
+			return '_:' + value;
+		case 'literal':
+			var lvalue = JSON.stringify( value );
+			if ( binding['xml:lang'] ) {
+				return lvalue + '@' + binding['xml:lang'];
+			}
+			if ( binding.datatype ) {
+				if ( binding.datatype === 'http://www.w3.org/2001/XMLSchema#integer' ||
+						binding.datatype === 'http://www.w3.org/2001/XMLSchema#decimal' ||
+						binding.datatype === 'http://www.w3.org/2001/XMLSchema#double' ) {
+					return value;
+				}
+				return lvalue + '^^<' + binding.datatype + '>';
+			}
+			return lvalue;
+		}
+		return value;
+	};
+
+	/**
+	 * Get the result of the submitted query as SPARQL TSV
+	 *
+	 * @return {string}
+	 */
+	SELF.prototype.getSparqlTsv = function() {
+		var self = this,
+			data = this._rawData,
+			output = data.head.vars.map( function( vname ) {
+			return '?' + vname;
+		} ).join( '\t' ) + '\n';
+
+		output = this._processData( data, function( row, out ) {
+			var rowOut = '';
+			var first = true;
+			var rowTSV;
+			for ( var rowVar in row ) {
+				if ( row[rowVar] === undefined ) {
+					rowTSV = '';
+				} else {
+					rowTSV = self._renderValueTSV( row[rowVar] );
+				}
+				if ( !first ) {
+					rowOut += '\t';
+				} else {
+					first = false;
+				}
+				rowOut += rowTSV;
+			}
+			rowOut += '\n';
+			return out + rowOut;
+		}, output );
+		return output;
+	};
+
+	/**
+	 * Get the result of the submitted query as simplified TSV
+	 *
+	 * @return {string}
+	 */
+	SELF.prototype.getSimpleTsv = function() {
+		var data = this._rawData,
+			output = data.head.vars.join( '\t' ) + '\n';
+
+		output = this._processData( data, function( row, out ) {
+			var rowOut = '';
+			var first = true;
+			var rowTSV;
+			for ( var rowVar in row ) {
+				if ( row[rowVar] === undefined ) {
+					rowTSV = '';
+				} else {
+					rowTSV = row[rowVar].value.replace( /\t/g, '' );
+				}
+				if ( !first ) {
+					rowOut += '\t';
+				} else {
+					first = false;
+				}
+				rowOut += rowTSV;
+			}
+			rowOut += '\n';
+			return out + rowOut;
+		}, output );
+		return output;
+	};
+
+	/**
+	 * @private
+	 */
+	SELF.prototype._replaceAutoLanguage = function( query ) {
+		return query.replace( /\[AUTO_LANGUAGE\]/g, this._language );
+	};
+
+	/**
+	 * Set the default language
+	 *
+	 * @param {string} language of search string default:en
+	 */
+	SELF.prototype.setLanguage = function( language ) {
+		this._language = language;
+	};
+
+	return SELF;
+
+}( jQuery ) );

--- a/views/wikidata/countries.erb
+++ b/views/wikidata/countries.erb
@@ -29,9 +29,30 @@
       $('#countries h2').html('Data from ' + numberOfCountries + ' countries');
     };
 
+    function entityID(entityURI) {
+      return entityURI.split('/').pop();
+    };
+
+    function populateCountries(countries) {
+      var countriesUL = $('#countries ul')
+      countriesUL.empty();
+
+      $.each(countries, function(_, country) {
+        countriesUL.append(
+          '<li>' +
+          '  <a class="avatar-unit" href="country/' + entityID(country.item) + '">' +
+          '    <span class="avatar"><i class="fa fa-users"></i></span>' +
+          '    <h3>' + country.itemLabel + '</h3>' +
+          '  </a>' +
+          '</li>'
+        );
+      });
+    };
+
     api.query(query).done(function() {
       var countries = JSON.parse(api.getResultAsJson());
       updateTitles(countries.length);
+      populateCountries(countries);
     });
   });
 </script>

--- a/views/wikidata/countries.erb
+++ b/views/wikidata/countries.erb
@@ -24,9 +24,14 @@
                 '}\n' +
                 'ORDER BY ?itemLabel';
 
+    function updateTitles(numberOfCountries) {
+      $('html head title').html('EveryPolitician: Political data for ' + numberOfCountries + ' countries');
+      $('#countries h2').html('Data from ' + numberOfCountries + ' countries');
+    };
+
     api.query(query).done(function() {
       var countries = JSON.parse(api.getResultAsJson());
-      console.log(countries);
+      updateTitles(countries.length);
     });
   });
 </script>

--- a/views/wikidata/countries.erb
+++ b/views/wikidata/countries.erb
@@ -1,0 +1,12 @@
+<div class="page-section" id="countries">
+    <div class="container">
+
+      <div class="text-center">
+          <h2><!-- TODO: Populate with JS --></h2>
+      </div>
+
+      <ul class="grid-list grid-list--vertically-center">
+        <!-- TODO: Populate with JS -->
+      </ul>
+  </div>
+</div>

--- a/views/wikidata/countries.erb
+++ b/views/wikidata/countries.erb
@@ -10,3 +10,23 @@
       </ul>
   </div>
 </div>
+
+<script src="/javascript/vendor/Sparql.js"></script>
+<script type="text/javascript">
+  $(document).ready(function() {
+    var api = new wikibase.queryService.api.Sparql();
+    var query = 'SELECT ?item ?itemLabel WHERE {\n' +
+                '   ?item p:P31 ?statement .\n' +
+                '   ?statement ps:P31 wd:Q160016 .\n' +
+                '   MINUS { ?statement pq:P582 ?end }      # no longer a country\n' +
+                '   MINUS { ?item wdt:P1552 wd:Q47185282 } # not free\n' +
+                '   SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }\n' +
+                '}\n' +
+                'ORDER BY ?itemLabel';
+
+    api.query(query).done(function() {
+      var countries = JSON.parse(api.getResultAsJson());
+      console.log(countries);
+    });
+  });
+</script>


### PR DESCRIPTION
# What does this do?

Creates a new page at `/wikidata/countries.html` which displays the same thing as the wikidata-legislature-browser. The page is populated using JavaScript on the client instead of the Ruby/Sinatra backend.

# Why was this needed?

We're recreating the pages that the wikidata-legislature-browser prototype has but implementing them in JavaScript on the client so our static pages can have more up to date data from the Wikidata API. This is the first of those pages.

# Relevant Issue(s)

#15643

# Implementation notes

This uses a [JavaScript SPARQL API client](https://github.com/wikimedia/wikidata-query-gui/blob/cfb3a0d36f12cf72ceb7d8c4887ad49ef0a8f5b1/wikibase/queryService/api/Sparql.js) from the wikidata-query-gui project. It makes doing SPARQL Wikidata queries from JavaScript easier. It's GPLv2 licensed so I think we're fine to use it in this project.

# Screenshots

Ruby prototype left, this PR right:

![screenshot_from_2018-01-23_16-47-28](https://user-images.githubusercontent.com/48945/35550188-73a3ae36-05dd-11e8-8761-967171afab6a.png)

# Notes to Reviewer

This PR doesn't currently have any tests. Are integration-level tests from minitest fine or do we want to set up some JavaScript testing?

# Notes to Merger

Because this page isn't currently set up to be scraped onto the static site this won't be visible on the deployed site.