### PR TITLE
Vagrant ruby capybara updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
   - bash <(curl -fsSL https://github.com/everypolitician/ensure-regression-tests/raw/master/ensure-regression-tests)
 sudo: false
 rvm:
-  - 2.3.3
+  - 2.3.6
 notifications:
   slack:
     secure: GVD9d+kwR5hzab5ZnWugbCkp9QSYyheSrABWkD+LmpMcWcx7jijajSn4LLvDi/zHYn1MdOBcPe08hSygmpm7ViUApp0EJcSzE4BLU/5oAs+ANV0Qq6jsssMlyo3v8eRAqHNiLxAiAsz+lc0EZWfQnSW8kHzzbO3NeYq1NRL5CgQ=

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-ruby '2.3.3'
+ruby '2.3.6'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,7 +181,7 @@ DEPENDENCIES
   yard
 
 RUBY VERSION
-   ruby 2.3.3p222
+   ruby 2.3.6p384
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/README.md
+++ b/README.md
@@ -50,7 +50,11 @@ Finally, follow the instructions displayed by the virtual machine.
 
 ### Run without Vagrant
 
-You can also run this project locally without using Vagrant. First [install Foreman globally](https://github.com/ddollar/foreman#installation):
+You can also run this project locally without using Vagrant, but you will need
+to make sure the "required packages" from `script/provision.sh` are available
+locally, before you begin.
+
+Then [install Foreman globally](https://github.com/ddollar/foreman#installation):
 
 ```bash
 gem install foreman

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -10,7 +10,9 @@ sudo apt-get update
 
 # Install required packages
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
-  ruby2.3 ruby2.3-dev git build-essential libxslt1-dev zlib1g-dev
+  ruby2.3 ruby2.3-dev git build-essential libxslt1-dev zlib1g-dev \
+  qt5-default libqt5webkit5-dev \
+  gstreamer1.0-plugins-base gstreamer1.0-tools gstreamer1.0-x
 
 # Add cd /vagrant to ~/.bashrc
 grep -qG "cd /vagrant" "$HOME/.bashrc" || echo "cd /vagrant" >> "$HOME/.bashrc"


### PR DESCRIPTION
# What does this do?

Enables you to run `vagrant up` in the project directory, and be given a working vagrant VM, so you can `vagrant ssh` in and run `foreman start` to work on the EveryPolitician front-end locally.

# Why was this needed?

The Vagrant provisioner was out of date from #15649  – it requested a version of Ruby that caused an error from Bundler, and it lacked a bunch of native packages that `capybara-webkit` requires.

# Relevant Issue(s)

# Implementation notes

Tested with Vagrant 2.0.2 and Virtualbox 5.2.8r121009 on macOS 10.13.3.

# Screenshots

# Notes to Reviewer

# Notes to Merger

