### PR TITLE
Revert "Install `tidy` from package on Travis"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,11 @@ language: ruby
 cache: bundler
 before_install:
   - echo -e "machine github.com\n  login $GITHUB_ACCESS_TOKEN" >> ~/.netrc
+  - scripts/install_tidy.sh
 addons:
   apt:
-    sources:
-      - debian-sid
     packages:
-      - tidy
+    - cmake
 script:
   - xvfb-run bundle exec rake
   - travis_wait 30 scripts/release.sh

--- a/scripts/install_tidy.sh
+++ b/scripts/install_tidy.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+cd /tmp
+wget https://github.com/htacg/tidy-html5/archive/5.2.0.zip
+unzip 5.2.0.zip
+cd tidy-html5-5.2.0/build/cmake
+cmake ../..
+make
+mkdir -p ~/bin
+mv tidy ~/bin/tidy


### PR DESCRIPTION
Reverts everypolitician/viewer-sinatra#15647

Installing `tidy` from debian-sid has stopped working, so return to building our own known version.