### PR TITLE
remove 'sudo: false' from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ script:
   - xvfb-run bundle exec rake
   - travis_wait 30 scripts/release.sh
   - bash <(curl -fsSL https://github.com/everypolitician/ensure-regression-tests/raw/master/ensure-regression-tests)
-sudo: false
 rvm:
   - 2.3.6
 notifications:


### PR DESCRIPTION
This is an old deprecated configuration option:
  https://docs.travis-ci.com/user/reference/overview/#deprecated-virtualization-environments